### PR TITLE
Keywords in multiple extensions notebook

### DIFF
--- a/notebooks/keywords_in_multiple_headers.ipynb
+++ b/notebooks/keywords_in_multiple_headers.ipynb
@@ -1,0 +1,244 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### This notebook identifies keywords that are in the purposely skipped list and also exist in multiple headers (e.g. PRIMARY and SCI, SCI and DQ, etc.)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import glob\n",
+    "import os\n",
+    "\n",
+    "from astropy.io import fits\n",
+    "\n",
+    "from jwql.utils.utils import get_config"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "filesystem = get_config()['filesystem']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "filenames = glob.glob(os.path.join(filesystem, '*/*.fits'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "non_unique_keys = []\n",
+    "for filename in filenames:\n",
+    "    \n",
+    "    header_keys = []\n",
+    "    hdulist = fits.open(filename, mode='readonly')\n",
+    "    for hdu in hdulist:\n",
+    "        keys = list(set(hdu.header))\n",
+    "        for key in keys:\n",
+    "            if key in header_keys:\n",
+    "                non_unique_keys.append(key)\n",
+    "            header_keys.append(key)\n",
+    "            \n",
+    "non_unique_keys = set(non_unique_keys)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'',\n",
+       " 'BITPIX',\n",
+       " 'BSCALE',\n",
+       " 'BUNIT',\n",
+       " 'BZERO',\n",
+       " 'CDELT1',\n",
+       " 'CDELT2',\n",
+       " 'CDELT3',\n",
+       " 'CRPIX1',\n",
+       " 'CRPIX2',\n",
+       " 'CRPIX3',\n",
+       " 'CRVAL1',\n",
+       " 'CRVAL2',\n",
+       " 'CRVAL3',\n",
+       " 'CTYPE1',\n",
+       " 'CTYPE2',\n",
+       " 'CTYPE3',\n",
+       " 'CUNIT1',\n",
+       " 'CUNIT2',\n",
+       " 'CUNIT3',\n",
+       " 'DEC_REF',\n",
+       " 'DEC_V1',\n",
+       " 'EXTNAME',\n",
+       " 'EXTVER',\n",
+       " 'GCOUNT',\n",
+       " 'NAXIS',\n",
+       " 'NAXIS1',\n",
+       " 'NAXIS2',\n",
+       " 'NAXIS3',\n",
+       " 'NAXIS4',\n",
+       " 'PA_APER',\n",
+       " 'PA_V3',\n",
+       " 'PC1_1',\n",
+       " 'PC1_2',\n",
+       " 'PC1_3',\n",
+       " 'PC2_1',\n",
+       " 'PC2_2',\n",
+       " 'PC2_3',\n",
+       " 'PC3_3',\n",
+       " 'PCOUNT',\n",
+       " 'PHOTMJSR',\n",
+       " 'PHOTUJA2',\n",
+       " 'RADESYS',\n",
+       " 'RA_REF',\n",
+       " 'RA_V1',\n",
+       " 'ROLL_REF',\n",
+       " 'SHUTSTA',\n",
+       " 'SLITID',\n",
+       " 'SLIT_DEC',\n",
+       " 'SLIT_RA',\n",
+       " 'SLTNAME',\n",
+       " 'SLTSIZE1',\n",
+       " 'SLTSIZE2',\n",
+       " 'SLTSTRT1',\n",
+       " 'SLTSTRT2',\n",
+       " 'SOURCEID',\n",
+       " 'SPORDER',\n",
+       " 'SRCXPOS',\n",
+       " 'SRCYPOS',\n",
+       " 'S_REGION',\n",
+       " 'TFIELDS',\n",
+       " 'TFORM1',\n",
+       " 'TFORM10',\n",
+       " 'TFORM11',\n",
+       " 'TFORM12',\n",
+       " 'TFORM13',\n",
+       " 'TFORM2',\n",
+       " 'TFORM3',\n",
+       " 'TFORM4',\n",
+       " 'TFORM5',\n",
+       " 'TFORM6',\n",
+       " 'TFORM7',\n",
+       " 'TFORM8',\n",
+       " 'TFORM9',\n",
+       " 'TTYPE1',\n",
+       " 'TTYPE10',\n",
+       " 'TTYPE11',\n",
+       " 'TTYPE12',\n",
+       " 'TTYPE13',\n",
+       " 'TTYPE2',\n",
+       " 'TTYPE3',\n",
+       " 'TTYPE4',\n",
+       " 'TTYPE5',\n",
+       " 'TTYPE6',\n",
+       " 'TTYPE7',\n",
+       " 'TTYPE8',\n",
+       " 'TTYPE9',\n",
+       " 'TUNIT1',\n",
+       " 'TUNIT2',\n",
+       " 'TUNIT3',\n",
+       " 'TUNIT5',\n",
+       " 'TUNIT6',\n",
+       " 'TUNIT7',\n",
+       " 'TUNIT8',\n",
+       " 'V2_REF',\n",
+       " 'V3I_YANG',\n",
+       " 'V3_REF',\n",
+       " 'VA_SCALE',\n",
+       " 'VPARITY',\n",
+       " 'WAVEND',\n",
+       " 'WAVSTART',\n",
+       " 'WCSAXES',\n",
+       " 'XTENSION'}"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "non_unique_keys"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### These are the keywords that exist in multiple headers and are skipped:\n",
+    "- NAXIS\n",
+    "- NAXIS1\n",
+    "- NAXIS2\n",
+    "- NAXIS3\n",
+    "- NAXIS4\n",
+    "- EXTNAME\n",
+    "- BUNIT\n",
+    "- BSCALE\n",
+    "- BZERO\n",
+    "- XTENSION"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernelspec": {
+   "display_name": "Python [conda env:astroconda3]",
+   "language": "python",
+   "name": "conda-env-astroconda3-py"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This PR introduces a new jupyter notebook that identifies keywords that exist in multiple header extensions and are also part of the purposefully-skipped keyword list.  This helps in identifying which keywords the `jwql` team would like MAST to store instead of skip. 