### PR TITLE
Ignoring E505 (line too long) in pep8speaks

### DIFF
--- a/.pep8speaks.yml
+++ b/.pep8speaks.yml
@@ -17,6 +17,7 @@ scanner:
 pycodestyle:
     max-line-length: 100  # Default is 79 in PEP8
     ignore:  # Errors and warnings to ignore
+        - E505
 
 only_mention_files_with_errors: True  # If False, a separate status comment for each file is made.
 descending_issues_order: False # If True, PEP8 issues in message will be displayed in descending order of line numbers in the file


### PR DESCRIPTION
This PR adds a line to ignore `E505` (line too long) in `.pep8speaks.yml`. 