### PR TITLE
Remove "Quicklook" reference from outward-facing content

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="https://i.imgur.com/MwnjFVM.png" width="400"/>
 </p>
 
-# The James Webb Quicklook Application (`JWQL`)
+# The JWST Quicklook Application (`JWQL`)
 
 [![PyPI - License](https://img.shields.io/pypi/l/Django.svg)](https://github.com/spacetelescope/jwql/blob/master/LICENSE)
 [![Python](https://img.shields.io/badge/Python-3.6-blue.svg)](https://www.python.org/)
@@ -11,11 +11,11 @@
 [![STScI](https://img.shields.io/badge/powered%20by-STScI-blue.svg?colorA=707170&colorB=3e8ddd&style=flat)](http://www.stsci.edu)
 
 
-The James Webb Quicklook Application (`JWQL`) is a database-driven web application and automation framework for use by the JWST instrument teams to monitor the health and stability of the JWST instruments.  The system is comprised of the following:
+The JWST Quicklook Application (`JWQL`) is a database-driven web application and automation framework for use by the JWST instrument teams to monitor and trend the health, stability, and performance of the JWST instruments.  The system is comprised of the following:
 1. A network file system that stores all uncalibrated and calibrated data products on disk in a centrally-located area, accessible to instrument team members (MAST data cache)
 2. A relational database that stores observational metadata allowing for data discovery via relational queries (MAST database API).
-3. A software library that provides tools to support an automation framework in which to build automated instrument monitoring tasks.
-4. A web application that allows users to visually inspect new and archival JWST data as well as instrument-specific monitoring and calibration results.
+3. A software library that provides tools to support an automation framework in which to build automated instrument monitoring routines.
+4. A web application that allows users to visually inspect new and archival JWST data as well as instrument-specific monitoring and performance results.
 
 The `jwql` application is currently under heavy development.  The `1.0` release is expected in 2019.
 

--- a/jwql/website/apps/jwql/templates/about.html
+++ b/jwql/website/apps/jwql/templates/about.html
@@ -2,7 +2,7 @@
 
 {% block preamble %}
 
-    <title>About - JWST Quicklook</title>
+    <title>About - JWQL</title>
 
 {% endblock %}
 
@@ -14,7 +14,7 @@
 
         <h4>About the project</h4>
 
-        The James Webb Quicklook Application (JWQL) is a database-driven web application and automation framework for use by the JWST instrument teams to monitor the health and stability of the JWST instruments. Developed in Python, it exists within a private <a href="https://github.com/spacetelescope/jwql" target="_blank">GitHub repository</a>. The team actively strives to adhere to software engineering best practices, strictly following defined workflows and Python style guides.<br><br>
+        The JWST Quicklook Application (JWQL) is a database-driven web application and automation framework for use by the JWST instrument teams to monitor the health and stability of the JWST instruments. Developed in Python, it exists within a private <a href="https://github.com/spacetelescope/jwql" target="_blank">GitHub repository</a>. The team actively strives to adhere to software engineering best practices, strictly following defined workflows and Python style guides.<br><br>
 
         The project consists of the following components:<br><br>
 
@@ -43,7 +43,7 @@
 
         <br>
         <h4>Contact</h4>
-        If you have discovered an issue with the functionality of the JWST Quicklook project, we ask that you please <a href="https://github.com/spacetelescope/jwql/issues" target="_blank">submit an issue</a> on our GitHub repository. Any other questions, comments, or concerns can be directed to <a href='jwql@stsci.edu'>jwql@stsci.edu</a>.<br><br>
+        If you have discovered an issue with the functionality of the JWQL application, we ask that you please <a href="https://github.com/spacetelescope/jwql/issues" target="_blank">submit an issue</a> on our GitHub repository. Any other questions, comments, or concerns can be directed to <a href='jwql@stsci.edu'>jwql@stsci.edu</a>.<br><br>
 
         <h4>Acknowledgements</h4>
 

--- a/jwql/website/apps/jwql/templates/archive.html
+++ b/jwql/website/apps/jwql/templates/archive.html
@@ -2,7 +2,7 @@
 
 {% block preamble %}
 
-	<title>Archived {{ inst }} Images - JWST Quicklook</title>
+	<title>Archived {{ inst }} Images - JWQL</title>
 
 	<!-- Custom styles and scripts for this template -->
 	<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.0.13/css/all.css" integrity="sha384-DNOHZ68U8hZfKXOrtjWvjxusGo9WQnrNx2sqG0tfsghAvtVlRW3tvkXWZh58N9jp" crossorigin="anonymous">

--- a/jwql/website/apps/jwql/templates/base.html
+++ b/jwql/website/apps/jwql/templates/base.html
@@ -33,7 +33,7 @@
 		<!-- Navigation Bar -->
 		<nav class="navbar navbar-expand-md fixed-top">
 		    <a class="navbar-left" href={{ url('jwql:home') }}><img src={{ static('img/JWQLlogo_small.png') }} height=35 width=35></a>
-	        <a class="navbar-brand" href={{ url('jwql:home') }}>JWST Quicklook</a>
+	        <a class="navbar-brand" href={{ url('jwql:home') }}>JWQL</a>
 	        <a class="navbar-brand" href="#"><font color='#f2ce3a'>{{ inst }}</font></a>
 	        <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarsExampleDefault" aria-controls="navbarsExampleDefault" aria-expanded="false" aria-label="Toggle navigation">
 	          <span class="navbar-toggler-icon"></span>

--- a/jwql/website/apps/jwql/templates/dashboard.html
+++ b/jwql/website/apps/jwql/templates/dashboard.html
@@ -2,7 +2,7 @@
 
 {% block preamble %}
 
-	<title>Dashboard - JWST Quicklook</title>
+	<title>Dashboard - JWQL</title>
 
     <!-- Add bokeh files -->
     <link href="https://cdn.pydata.org/bokeh/release/bokeh-0.12.5.min.css" rel="stylesheet" type="text/css">

--- a/jwql/website/apps/jwql/templates/home.html
+++ b/jwql/website/apps/jwql/templates/home.html
@@ -2,14 +2,14 @@
 
 {% block preamble %}
 
-	<title>Home - JWST Quicklook</title>
+	<title>Home - JWQL</title>
 
 {% endblock %}
 
 {% block content %}
 
     <main role="main" class="container">
-    	<h2>Welcome to the JWST Quicklook page.</h2>
+    	<h2>Welcome to the JWQL application.</h2>
         <hr>
 
     	<div class="instrument_select">
@@ -38,7 +38,7 @@
         </div>
 
         <br>
-        The James Webb Quicklook Application (JWQL) is a database-driven web application and automation framework for use by the JWST instrument teams to monitor the health and stability of the JWST instruments.
+        The JWST Quicklook Application (JWQL) is a database-driven web application and automation framework for use by the JWST instrument teams to monitor the health and stability of the JWST instruments.
         Visit our <a href={{ url('jwql:about') }}>about page</a> to learn more about our project, goals, and developers.<br><br>
 
         The JWQL application is currently under heavy development. The 1.0 release is expected in 2019.

--- a/jwql/website/apps/jwql/templates/instrument.html
+++ b/jwql/website/apps/jwql/templates/instrument.html
@@ -2,7 +2,7 @@
 
 {% block preamble %}
 
-	<title>{{ inst }} - JWST Quicklook</title>
+	<title>{{ inst }} - JWQL</title>
 
 {% endblock %}
 

--- a/jwql/website/apps/jwql/templates/thumbnails.html
+++ b/jwql/website/apps/jwql/templates/thumbnails.html
@@ -2,7 +2,7 @@
 
 {% block preamble %}
 
-	<title>Unlooked {{ inst }} Images - JWST Quicklook</title>
+	<title>Unlooked {{ inst }} Images - JWQL</title>
 
 {% endblock %}
 

--- a/jwql/website/apps/jwql/templates/view_header.html
+++ b/jwql/website/apps/jwql/templates/view_header.html
@@ -2,7 +2,7 @@
 
 {% block preamble %}
 
-	<title>View {{ inst }} Image - JWST Quicklook</title>
+	<title>View {{ inst }} Image - JWQL</title>
 
 {% endblock %}
 

--- a/jwql/website/apps/jwql/templates/view_image.html
+++ b/jwql/website/apps/jwql/templates/view_image.html
@@ -2,7 +2,7 @@
 
 {% block preamble %}
 
-	<title>View {{ inst }} Image - JWST Quicklook</title>
+	<title>View {{ inst }} Image - JWQL</title>
 
 {% endblock %}
 

--- a/jwql/website/apps/jwql/views.py
+++ b/jwql/website/apps/jwql/views.py
@@ -3,7 +3,7 @@
 In Django, "a view function, or view for short, is simply a Python
 function that takes a Web request and returns a Web response" (from
 Django documentation). This module defines all of the views that are
-used to generate the various webpages used for the Quicklook project.
+used to generate the various webpages used for the JWQL application.
 For example, these views can list the tools available to users, query
 the ``jwql`` database, and display images and headers.
 

--- a/jwql/website/jwql_proj/urls.py
+++ b/jwql/website/jwql_proj/urls.py
@@ -1,7 +1,7 @@
 """Maps URL paths to views in the ``jwql`` project.
 
 This module connects requested URL paths to the corresponding view in
-``views.py`` for each webpage in the Quicklook project. When Django is
+``views.py`` for each webpage in the JWQL application. When Django is
 provided a path, it searches through the urlpatterns list provided
 here until it finds one that matches. It then calls the assigned view
 to load the appropriate webpage, passing an HttpRequest object.


### PR DESCRIPTION
This PR removes references to the term "Quicklook" from the application, as we are trying to stray away from that term and promote our acronym `JWQL`. 