### PR TITLE
WIP: Add documentation button to top of base.html

### DIFF
--- a/jwql/website/apps/jwql/templates/about.html
+++ b/jwql/website/apps/jwql/templates/about.html
@@ -22,6 +22,8 @@
 
         The JWQL application is currently under heavy development. The 1.0 release is expected in 2019.<br><br>
 
+        Documentation can be found on <a href="https://jwql.readthedocs.io/en/latest/" target="_blank">readthedocs</a>.<br><br>
+
         The list of automated monitors that the JWQL team is currently planning to develop, in collaboration with each instrument team, can be found on <a href="https://innerspace.stsci.edu/display/JWQLPROJ/Instrument+Monitor+Overview" target="_blank">Innerspace</a>.
 
         <br><br>

--- a/jwql/website/apps/jwql/templates/base.html
+++ b/jwql/website/apps/jwql/templates/base.html
@@ -66,6 +66,9 @@
 		            	</div>
 		          	</li>
 		      		{% endfor %}
+		      		<li class="nav-item active">
+	            		<a class="nav-link" href="https://jwql.readthedocs.io/en/latest/">Documentation<span class="sr-only">(current)</span></a>
+	          		</li>
 	        	</ul>
 	        </div>
 


### PR DESCRIPTION
I added a "Documentation" button the top navbar in the base.html template. Maybe once the documentation fills out, we should swap out the button for a pull down menu that links to the documentation pages that are of the most interest?