### PR TITLE
[WIP] pytest xfail on monitor_mast tests

### DIFF
--- a/jwql/tests/test_monitor_mast.py
+++ b/jwql/tests/test_monitor_mast.py
@@ -17,6 +17,8 @@ Use
         pytest -s test_monitor_mast.py
 """
 
+import pytest
+
 from jwql.jwql_monitors import monitor_mast as mm
 from jwql.utils.utils import JWST_INSTRUMENTS
 
@@ -41,6 +43,7 @@ def test_filtered_instrument_keywords():
     assert kw[0] != kw[1] != kw[2] != kw[3] != kw[4]
 
 
+@pytest.mark.xfail
 def test_instrument_inventory_filtering():
     """Test to see that the instrument inventory can be filtered"""
     filt = 'GR150R'


### PR DESCRIPTION
This PR is intended to temporarily mark necessary tests in `test_monitor_mast` as `xfail` so that our Jenkins build ignores them.  This gets around the issue presented in #187 until we can solve #186 and fix our requests to `astroquery.mast`