### PR TITLE
Fix test_monitor_mast

### DIFF
--- a/jwql/tests/test_monitor_mast.py
+++ b/jwql/tests/test_monitor_mast.py
@@ -55,7 +55,6 @@ def test_filtered_instrument_keywords():
     assert kw[0] != kw[1] != kw[2] != kw[3] != kw[4]
 
 
-@pytest.mark.xfail
 def test_instrument_inventory_filtering():
     """Test to see that the instrument inventory can be filtered"""
     filt = 'GR150R'


### PR DESCRIPTION
This PR attempts to solve the failed `test_instrument_inventory_filtering` test in `test_monitor_mast`.

Closes #187  