### PR TITLE
Improve URLs

### DIFF
--- a/jwql/utils/utils.py
+++ b/jwql/utils/utils.py
@@ -59,6 +59,11 @@ INSTRUMENTS_SHORTHAND = {'gui': 'FGS',
                          'nis': 'NIRISS',
                          'nrc': 'NIRCam',
                          'nrs': 'NIRSpec'}
+INSTRUMENTS_CAPITALIZED = {'fgs': 'FGS',
+                           'miri': 'MIRI',
+                           'nircam': 'NIRCam',
+                           'niriss': 'NIRISS',
+                           'nirspec': 'NIRSpec'}
 
 
 def ensure_dir_exists(fullpath):

--- a/jwql/utils/utils.py
+++ b/jwql/utils/utils.py
@@ -29,7 +29,8 @@ from jwql.utils import permissions
 
 __location__ = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__)))
 
-FILE_SUFFIX_TYPES = ['uncal', 'cal', 'rateints', 'rate', 'trapsfilled', 'uncal']
+FILE_SUFFIX_TYPES = ['uncal', 'cal', 'rateints', 'rate', 'trapsfilled',
+                     'i2d', 'x1d', 's2d', 's3d', 'dark', 'ami', 'crf']
 JWST_INSTRUMENTS = sorted(['NIRISS', 'NIRCam', 'NIRSpec', 'MIRI', 'FGS'])
 JWST_DATAPRODUCTS = ['IMAGE', 'SPECTRUM', 'SED', 'TIMESERIES', 'VISIBILITY',
                      'EVENTLIST', 'CUBE', 'CATALOG', 'ENGINEERING', 'NULL']

--- a/jwql/website/apps/jwql/forms.py
+++ b/jwql/website/apps/jwql/forms.py
@@ -151,8 +151,8 @@ class FileSearchForm(forms.Form):
 
         # If they searched for a proposal
         if self.search_type == 'proposal':
-            return redirect('/jwql/{}/archive/{}'.format(self.instrument, search))
+            return redirect('/{}/archive/{}'.format(self.instrument, search))
 
         # If they searched for a file root
         elif self.search_type == 'fileroot':
-            return redirect('/jwql/{}/{}'.format(self.instrument, search))
+            return redirect('/{}/{}'.format(self.instrument, search))

--- a/jwql/website/apps/jwql/templates/view_image.html
+++ b/jwql/website/apps/jwql/templates/view_image.html
@@ -44,7 +44,7 @@
     		// Update the image download and header links
     		document.getElementById("download_fits").href = '{{ static("") }}filesystem/{{ file_root[:7] }}/' + fits_filename;
     		document.getElementById("download_jpg").href = jpg_filepath;
-    		document.getElementById("view_header").href = "/jwql/{{ inst }}/" + fits_filename + "/hdr/";
+    		document.getElementById("view_header").href = "/{{ inst }}/" + fits_filename + "/hdr/";
 
     		// Disable the "left" button, since this will be showing integ0
     		document.getElementById("int_before").disabled = true;

--- a/jwql/website/apps/jwql/urls.py
+++ b/jwql/website/apps/jwql/urls.py
@@ -45,23 +45,22 @@ from . import api_views
 from . import views
 
 app_name = 'jwql'
-
-api_instruments = 'nircam|NIRCam|niriss|NIRISS|nirspec|NIRSpec|miri|MIRI|fgs|FGS'
+instruments = 'nircam|NIRCam|niriss|NIRISS|nirspec|NIRSpec|miri|MIRI|fgs|FGS'
 
 urlpatterns = [
     path('', views.home, name='home'),
     path('about/', views.about, name='about'),
     path('dashboard/', views.dashboard, name='dashboard'),
-    path('jwql/<str:inst>/', views.instrument, name='instrument'),
-    path('jwql/<str:inst>/archive/', views.archived_proposals, name='archive'),
-    path('jwql/<str:inst>/unlooked/', views.unlooked_images, name='unlooked'),
-    path('jwql/<str:inst>/<str:file_root>/', views.view_image, name='view_image'),
-    path('jwql/<str:inst>/<str:file>/hdr/', views.view_header, name='view_header'),
-    path('jwql/<str:inst>/archive/<str:proposal>', views.archive_thumbnails, name='archive_thumb'),
+    re_path(r'^(?P<inst>({}))/$'.format(instruments), views.instrument, name='instrument'),
+    re_path(r'^(?P<inst>({}))/archive/$'.format(instruments), views.archived_proposals, name='archive'),
+    re_path(r'^(?P<inst>({}))/unlooked/$'.format(instruments), views.unlooked_images, name='unlooked'),
+    re_path(r'^(?P<inst>({}))/(?P<file_root>[\w]+)/$'.format(instruments), views.view_image, name='view_image'),
+    re_path(r'^(?P<inst>({}))/(?P<file>.+)/hdr/$'.format(instruments), views.view_header, name='view_header'),
+    re_path(r'^(?P<inst>({}))/archive/(?P<proposal>[\d]{{5}})/$'.format(instruments), views.archive_thumbnails, name='archive_thumb'),
     path('api/proposals/', api_views.all_proposals, name='all_proposals'),
-    path('api/<str:inst>/proposals/', api_views.instrument_proposals, name='instrument_proposals'),
-    re_path(r'^api/(?P<inst>({}))/preview_images/$'.format(api_instruments), api_views.preview_images_by_instrument, name='preview_images_by_instrument'),
-    re_path(r'^api/(?P<inst>({}))/thumbnails/$'.format(api_instruments), api_views.thumbnails_by_instrument, name='thumbnails_by_instrument'),
+    re_path(r'^api/(?P<inst>({}))/proposals/$'.format(instruments), api_views.instrument_proposals, name='instrument_proposals'),
+    re_path(r'^api/(?P<inst>({}))/preview_images/$'.format(instruments), api_views.preview_images_by_instrument, name='preview_images_by_instrument'),
+    re_path(r'^api/(?P<inst>({}))/thumbnails/$'.format(instruments), api_views.thumbnails_by_instrument, name='thumbnails_by_instrument'),
     re_path(r'^api/(?P<proposal>[\d]{5})/filenames/$', api_views.filenames_by_proposal, name='filenames_by_proposal'),
     re_path(r'^api/(?P<proposal>[\d]{5})/preview_images/$', api_views.preview_images_by_proposal, name='preview_images_by_proposal'),
     re_path(r'^api/(?P<proposal>[\d]{5})/thumbnails/$', api_views.thumbnails_by_proposal, name='preview_images_by_proposal'),

--- a/jwql/website/apps/jwql/views.py
+++ b/jwql/website/apps/jwql/views.py
@@ -45,7 +45,7 @@ from .data_containers import get_image_info
 from .data_containers import get_proposal_info
 from .data_containers import thumbnails
 from .forms import FileSearchForm
-from jwql.utils.utils import get_config, JWST_INSTRUMENTS, MONITORS
+from jwql.utils.utils import get_config, JWST_INSTRUMENTS, MONITORS, INSTRUMENTS_CAPITALIZED
 
 
 FILESYSTEM_DIR = os.path.join(get_config()['jwql_dir'], 'filesystem')
@@ -89,6 +89,8 @@ def archived_proposals(request, inst):
     HttpResponse object
         Outgoing response sent to the webpage
     """
+    # Ensure the instrument is correctly capitalized
+    inst = INSTRUMENTS_CAPITALIZED[inst.lower()]
 
     template = 'archive.html'
 
@@ -127,6 +129,9 @@ def archive_thumbnails(request, inst, proposal):
     HttpResponse object
         Outgoing response sent to the webpage
     """
+    # Ensure the instrument is correctly capitalized
+    inst = INSTRUMENTS_CAPITALIZED[inst.lower()]
+
     template = 'thumbnails.html'
     context = thumbnails(inst, proposal)
 
@@ -207,6 +212,9 @@ def instrument(request, inst):
     HttpResponse object
         Outgoing response sent to the webpage
     """
+    # Ensure the instrument is correctly capitalized
+    inst = INSTRUMENTS_CAPITALIZED[inst.lower()]
+
     template = 'instrument.html'
     url_dict = {'FGS': 'http://jwst-docs.stsci.edu/display/JTI/Fine+Guidance+Sensor%2C+FGS?q=fgs',
                 'MIRI': 'http://jwst-docs.stsci.edu/display/JTI/Mid-Infrared+Instrument%2C+MIRI',
@@ -238,6 +246,9 @@ def unlooked_images(request, inst):
     HttpResponse object
         Outgoing response sent to the webpage
     """
+    # Ensure the instrument is correctly capitalized
+    inst = INSTRUMENTS_CAPITALIZED[inst.lower()]
+
     template = 'thumbnails.html'
     context = thumbnails(inst)
 
@@ -261,6 +272,9 @@ def view_header(request, inst, file):
     HttpResponse object
         Outgoing response sent to the webpage
     """
+    # Ensure the instrument is correctly capitalized
+    inst = INSTRUMENTS_CAPITALIZED[inst.lower()]
+
     template = 'view_header.html'
     header = get_header_info(file)
     file_root = '_'.join(file.split('_')[:-1])
@@ -292,6 +306,9 @@ def view_image(request, inst, file_root, rewrite=False):
     HttpResponse object
         Outgoing response sent to the webpage
     """
+    # Ensure the instrument is correctly capitalized
+    inst = INSTRUMENTS_CAPITALIZED[inst.lower()]
+
     template = 'view_image.html'
     image_info = get_image_info(file_root, rewrite)
     context = {'inst': inst,


### PR DESCRIPTION
This PR does the following:
- Removes `jwql` from the beginning of all URLs
- Uses regular expressions to restrict instrument input in URLs (á la @bourque)
- Makes all URLs flexible to input either capitalized or lowercase instruments
- Adds more suffixes to the list that `filename_parser` accepts

No tests yet, but I'm hoping to get to those with #220.

Closes #211.