### PR TITLE
Update generate_preview_images to use constants.py module

### DIFF
--- a/jwql/jwql_monitors/generate_preview_images.py
+++ b/jwql/jwql_monitors/generate_preview_images.py
@@ -34,14 +34,10 @@ import re
 import numpy as np
 
 from jwql.utils import permissions
-from jwql.utils.logging_functions import configure_logging
-from jwql.utils.logging_functions import log_info
-from jwql.utils.logging_functions import log_fail
+from jwql.utils.constants import NIRCAM_LONGWAVE_DETECTORS, NIRCAM_SHORTWAVE_DETECTORS
+from jwql.utils.logging_functions import configure_logging, log_info, log_fail
 from jwql.utils.preview_image import PreviewImage
-from jwql.utils.utils import get_config
-from jwql.utils.utils import filename_parser
-from jwql.utils.utils import NIRCAM_LONGWAVE_DETECTORS
-from jwql.utils.utils import NIRCAM_SHORTWAVE_DETECTORS
+from jwql.utils.utils import get_config, filename_parser
 
 # Size of NIRCam inter- and intra-module chip gaps
 SW_MOD_GAP = 1387  # pixels = int(43 arcsec / 0.031 arcsec/pixel)

--- a/jwql/jwql_monitors/generate_preview_images.py
+++ b/jwql/jwql_monitors/generate_preview_images.py
@@ -633,8 +633,8 @@ def group_filenames(input_files):
         suffix = filename_parts['suffix']
 
         observation_base = 'jw{}{}{}_{}{}{}_{}_'.format(
-                        program, observation, visit, visit_group,
-                        parallel, activity, exposure)
+            program, observation, visit, visit_group,
+            parallel, activity, exposure)
 
         if detector in NIRCAM_SHORTWAVE_DETECTORS:
             detector_str = 'NRC[AB][1234]'


### PR DESCRIPTION
This PR updates the `generate_preview_images` module to use the new `constants.py` module to import the `NIRCAM_SHORTWAVE_DETECTORS` and `NIRCAM_LONGWAVE_DETECTORS` data.

Closes #266 