### PR TITLE
More API views tests

### DIFF
--- a/jwql/tests/test_api_views.py
+++ b/jwql/tests/test_api_views.py
@@ -23,22 +23,36 @@ import pytest
 import urllib.request
 
 from jwql.utils.utils import get_base_url
+from jwql.utils.constants import JWST_INSTRUMENT_NAMES
+
+urls = []
+
+# Generic URLs
+urls.append('api/proposals/')  # all_proposals
+
+# Instrument-specific URLs
+for instrument in JWST_INSTRUMENT_NAMES:
+    urls.append('api/{}/proposals/'.format(instrument))  # instrument_proposals
+    urls.append('api/{}/preview_images/'.format(instrument))  # preview_images_by_instrument
+    urls.append('api/{}/thumbnails/'.format(instrument))  # thumbnails_by_instrument
+
+# Proposal-specific URLs
+proposals = ['86700'  # FGS
+            ]
+for proposal in proposals:
+    urls.append('api/{}/filenames/'.format(proposal))  # filenames_by_proposal
+    urls.append('api/{}/preview_images/'.format(proposal))  # preview_images_by_proposal
+    urls.append('api/{}/thumbnails/'.format(proposal))  # thumbnails_by_proposal
+
+# Filename-specific URLs
+rootnames = ['jw86700005001_02101_00001_guider1'  # FGS
+]
+for rootname in rootnames:
+    urls.append('api/{}/filenames/'.format(rootname))  # filenames_by_rootname
+    urls.append('api/{}/preview_images/'.format(rootname))  # preview_images_by_rootname
+    urls.append('api/{}/thumbnails'.format(rootname))  # thumbnails_by_rootname
 
 
-urls = [
-    'api/proposals/',  # all_proposals
-    'api/86700/filenames/',  # filenames_by_proposal
-    'api/jw86700005001_02101_00001_guider1/filenames/',  # filenames_by_rootname
-    'api/fgs/proposals/',  # instrument_proposals
-    'api/fgs/preview_images/',  # preview_images_by_instrument
-    'api/86700/preview_images/',  # preview_images_by_proposal
-    'api/jw86700005001_02101_00001_guider1/preview_images/',  # preview_images_by_rootname
-    'api/fgs/thumbnails/',  # thumbnails_by_instrument
-    'api/86700/thumbnails/',  # thumbnails_by_proposal
-    'api/jw86700005001_02101_00001_guider1/thumbnails/']  # thumbnails_by_rootname
-
-
-@pytest.mark.xfail
 @pytest.mark.parametrize('url', urls)
 def test_api_views(url):
     """Test to see if the given ``url`` returns a populated JSON object
@@ -53,6 +67,7 @@ def test_api_views(url):
     # Build full URL
     base_url = get_base_url()
     url = '{}/{}'.format(base_url, url)
+    print('Testing {}'.format(url))
 
     # Determine the type of data to check for based on the url
     data_type = url.split('/')[-2]

--- a/jwql/tests/test_api_views.py
+++ b/jwql/tests/test_api_views.py
@@ -37,20 +37,26 @@ for instrument in JWST_INSTRUMENT_NAMES:
     urls.append('api/{}/thumbnails/'.format(instrument))  # thumbnails_by_instrument
 
 # Proposal-specific URLs
-proposals = ['86700'  # FGS
-            ]
+proposals = ['86700',  # FGS
+             '98012',  # MIRI
+             '93025',  # NIRCam
+             '00308',  # NIRISS
+             '96213']  # NIRSpec
 for proposal in proposals:
     urls.append('api/{}/filenames/'.format(proposal))  # filenames_by_proposal
     urls.append('api/{}/preview_images/'.format(proposal))  # preview_images_by_proposal
     urls.append('api/{}/thumbnails/'.format(proposal))  # thumbnails_by_proposal
 
 # Filename-specific URLs
-rootnames = ['jw86700005001_02101_00001_guider1'  # FGS
-]
+rootnames = ['jw86600007001_02101_00001_guider2',  # FGS
+             'jw98012001001_02102_00001_mirimage',  # MIRI
+             'jw93025001001_02102_00001_nrca2',  # NIRCam
+             'jw00308001001_02101_00001_nis',  # NIRISS
+             'jw96213001001_02101_00001_nrs1']  # NIRSpec
 for rootname in rootnames:
     urls.append('api/{}/filenames/'.format(rootname))  # filenames_by_rootname
     urls.append('api/{}/preview_images/'.format(rootname))  # preview_images_by_rootname
-    urls.append('api/{}/thumbnails'.format(rootname))  # thumbnails_by_rootname
+    urls.append('api/{}/thumbnails/'.format(rootname))  # thumbnails_by_rootname
 
 
 @pytest.mark.parametrize('url', urls)

--- a/jwql/tests/test_api_views.py
+++ b/jwql/tests/test_api_views.py
@@ -59,6 +59,7 @@ for rootname in rootnames:
     urls.append('api/{}/thumbnails/'.format(rootname))  # thumbnails_by_rootname
 
 
+@pytest.mark.xfail
 @pytest.mark.parametrize('url', urls)
 def test_api_views(url):
     """Test to see if the given ``url`` returns a populated JSON object

--- a/jwql/website/apps/jwql/data_containers.py
+++ b/jwql/website/apps/jwql/data_containers.py
@@ -530,7 +530,6 @@ def get_thumbnails_by_instrument(inst):
     # Get subset of preview images that match the filenames
     thumbnails = [item for item in thumbnails if os.path.basename(item).split('_integ')[0] in filenames]
 
-
     return thumbnails
 
 

--- a/jwql/website/apps/jwql/data_containers.py
+++ b/jwql/website/apps/jwql/data_containers.py
@@ -355,13 +355,11 @@ def get_instrument_proposals(instrument):
     """
 
     service = "Mast.Jwst.Filtered.{}".format(instrument)
-    params = {"columns": "filename",
+    params = {"columns": "program",
               "filters": []}
     response = Mast.service_request_async(service, params)
     results = response[0].json()['data']
-
-    filenames = [result['filename'] for result in results]
-    proposals = list(set(filename_parser(filename)['program_id'] for filename in filenames))
+    proposals = list(set(result['program'] for result in results))
 
     return proposals
 
@@ -395,17 +393,11 @@ def get_preview_images_by_instrument(inst):
     # Parse the results to get the rootnames
     filenames = [result['filename'].split('.')[0] for result in results]
 
-    # Build list of available preview images
-    preview_images = []
-    for filename in filenames:
-        proposal = filename_parser(filename)['program_id']
-        preview_images.extend(glob.glob(os.path.join(
-            PREVIEW_IMAGE_FILESYSTEM,
-            'jw{}'.format(proposal),
-            '{}*.jpg'.format(filename))))
+    # Get list of all preview_images
+    preview_images = glob.glob(os.path.join(PREVIEW_IMAGE_FILESYSTEM, '*', '*.jpg'))
 
-    # Only return the filenames
-    preview_images = [os.path.basename(preview_image) for preview_image in preview_images]
+    # Get subset of preview images that match the filenames
+    preview_images = [item for item in preview_images if os.path.basename(item).split('_integ')[0] in filenames]
 
     return preview_images
 
@@ -532,17 +524,12 @@ def get_thumbnails_by_instrument(inst):
     # Parse the results to get the rootnames
     filenames = [result['filename'].split('.')[0] for result in results]
 
-    # Build list of available preview images
-    thumbnails = []
-    for filename in filenames:
-        proposal = filename_parser(filename)['program_id']
-        thumbnails.extend(glob.glob(os.path.join(
-            THUMBNAIL_FILESYSTEM,
-            'jw{}'.format(proposal),
-            '{}*.thumb'.format(filename))))
+    # Get list of all thumbnails
+    thumbnails = glob.glob(os.path.join(THUMBNAIL_FILESYSTEM, '*', '*.thumb'))
 
-    # Only return the filenames
-    thumbnails = [os.path.basename(thumbnail) for thumbnail in thumbnails]
+    # Get subset of preview images that match the filenames
+    thumbnails = [item for item in thumbnails if os.path.basename(item).split('_integ')[0] in filenames]
+
 
     return thumbnails
 


### PR DESCRIPTION
This PR adds several tests to `test_api_views` in order to test more instruments, proposals, and filenames.  It also refactors a few of the functions in `data_containers` in order to speed them up, as I was finding some of the views to be really slow when dealing with a large amount of data.

Closes #232 