### PR TITLE
Add custom error message if config.json is missing

### DIFF
--- a/jwql/utils/utils.py
+++ b/jwql/utils/utils.py
@@ -183,7 +183,16 @@ def get_config():
     settings : dict
         A dictionary that holds the contents of the config file.
     """
-    with open(os.path.join(__location__, 'config.json'), 'r') as config_file:
+    config_file_location = os.path.join(__location__, 'config.json')
+
+    if not os.path.isfile(config_file_location):
+        raise FileNotFoundError('The JWQL package requires a configuration file (config.json) '
+                                'to be placed within the jwql/utils directory. '
+                                'This file is missing. Please read the relevant wiki page '
+                                '(https://github.com/spacetelescope/jwql/wiki/'
+                                'Config-file) for more information.')
+
+    with open(config_file_location, 'r') as config_file:
         settings = json.load(config_file)
 
     return settings


### PR DESCRIPTION
Adds a custom message to the `FileNotFoundError` that arises when the `config.json` file is missing, including a link to the new wiki page about it. (Thanks #287!)

Closes #274.