### PR TITLE
Webpage template branch

### DIFF
--- a/WEBPAGE_TEMPLATE.md
+++ b/WEBPAGE_TEMPLATE.md
@@ -1,21 +1,19 @@
 # Using the `webpage-template` branch to develop a webpage
 
-The `webpage-template` branch includes a number of template files and functions. These are designed to make it easier for a contributor who is unfamiliar with web development to write a new page for the web application. They includes the following:
+The `webpage-template` branch includes a number of template files and functions. These are designed to make it easier for a contributor who is unfamiliar with web development to write a new page for the web application.
+
+The files and functions that you can edit are the following:
 
 | Template File/Function | Description | Location |
 | ---------------------- | ----------- | -------- |
-| HTML template   | file containing HTML used to render web page content (text, links, photos, tables, etc.) | `jwql/website/apps/jwql/templates/WEBPAGE_TEMPLATE.html` |
-| view function template | python function that passes data to an HTML template | `WEBSITE_TEMPLATE()` in `jwql/website/apps/jwql/views.py` |
-| URL entry template  | list item that maps a URL to a view | `jwql/website/apps/jwql/urls.py` |
-| data container function  | python function that manipulates data for the view function | `website_template_data()` in `jwql/website/apps/jwql/data_containers.py` |
-
-* Interfaces to the existing `monitor_template` to demonstrate how the web app and package connect
-
-
+| **HTML template**   | file containing HTML used to render web page content (text, links, photos, tables, etc.) | `jwql/website/apps/jwql/templates/WEBPAGE_TEMPLATE.html` |
+| **view function template** | python function that passes data to an HTML template | `website_template()` in `jwql/website/apps/jwql/views.py` |
+| **URL entry template**  | list item that maps a URL to a view | `jwql/website/apps/jwql/urls.py` |
+| **data container function**  | python function that manipulates data for the view function | `website_template_data()` in `jwql/website/apps/jwql/data_containers.py` |
 
 *To learn more about topics like HTML templates, views, and URLs, see the [JWQL intro to web apps](https://github.com/spacetelescope/jwql/blob/master/presentations/JWQL_web_app.pdf).*
 
------------------
+
 
 ## How to view the template content
 
@@ -23,7 +21,7 @@ The `webpage-template` branch includes a number of template files and functions.
 
 1. Create a copy of the `webpage-template` branch and set it up to push to your fork:
 
-    ```bash
+    ```
     git checkout -b <your_desired_branch_name> upstream/webpage-template
     git push -u origin <your_desired_branch_name>
     ```
@@ -42,7 +40,6 @@ The `webpage-template` branch includes a number of template files and functions.
 
 1. Open the template web page in your browser: http://127.0.0.1:8000/webpage_template
 
------------------
 
 ## How to customize the template content
 
@@ -74,7 +71,7 @@ The `webpage-template` branch includes a number of template files and functions.
 ### 4. Share your work!
 - When you are ready to share your new page to the JWQL team for review, follow the directions on our [Contribution Guide](https://github.com/spacetelescope/jwql/wiki/git-&-GitHub-workflow-for-contributing) to submit a pull request.
 
------------------
+
 
 ## Helpful Resources for Web Development
 - HTML Documentation and Examples: https://www.w3schools.com/html/default.asp
@@ -82,6 +79,6 @@ The `webpage-template` branch includes a number of template files and functions.
 - Bootstrap Documentation: https://getbootstrap.com/docs/4.3/getting-started/introduction/
 - Jinja2 HTML Template Documentation: http://jinja.pocoo.org/docs/2.10/templates/
 
------------------
+
 
 *If you have questions about any part of this guide, please contact lchambers@stsci.edu and bourque@stsci.edu.*

--- a/WEBPAGE_TEMPLATE.md
+++ b/WEBPAGE_TEMPLATE.md
@@ -6,7 +6,8 @@ The `webpage-template` branch includes a number of template files and functions.
 | ---------------------- | ----------- | -------- |
 | HTML template   | file containing HTML used to render web page content (text, links, photos, tables, etc.) | `jwql/website/apps/jwql/templates/WEBPAGE_TEMPLATE.html` |
 | view function template | python function that passes data to an HTML template | `WEBSITE_TEMPLATE()` in `jwql/website/apps/jwql/views.py` |
-| URL entry template  | list item that maps a URL to a view | `jwql/website/apps/jwql/urls.py`
+| URL entry template  | list item that maps a URL to a view | `jwql/website/apps/jwql/urls.py` |
+| data container function  | python function that manipulates data for the view function | `website_template_data()` in `jwql/website/apps/jwql/data_containers.py` |
 
 * Interfaces to the existing `monitor_template` to demonstrate how the web app and package connect
 
@@ -20,10 +21,11 @@ The `webpage-template` branch includes a number of template files and functions.
 
 1. Make sure you have a fork of the `jwql` repo that points to `spacetelescope/jwql` as `upstream`. (See the [contribution guide](https://github.com/spacetelescope/jwql/wiki/git-&-GitHub-workflow-for-contributing) if you need to set this up.)
 
-1. Create a copy of the `webpage-template` branch:
+1. Create a copy of the `webpage-template` branch and set it up to push to your fork:
 
     ```bash
     git checkout -b <your_desired_branch_name> upstream/webpage-template
+    git push -u origin <your_desired_branch_name>
     ```
 
 1. Activate your [`jwql` virtual environment](https://github.com/spacetelescope/jwql#environment-installation):
@@ -32,7 +34,7 @@ The `webpage-template` branch includes a number of template files and functions.
     source activate jwql
     ```
 
-1. Start a remote server to run the web app:
+1. Start a local server to run the web app:
 
     ```bash
     python jwql/website/manage.py runserver
@@ -40,7 +42,46 @@ The `webpage-template` branch includes a number of template files and functions.
 
 1. Open the template web page in your browser: http://127.0.0.1:8000/webpage_template
 
+-----------------
 
 ## How to customize the template content
 
+*Even though we present these as separate steps here, don't take them as strictly chronological. It is often easiest to edit a webpage's HTML, view, and supporting functions all at the same time, so you can see how they affect one another.*
 
+### 1. Update `urls.py` to point to the desired URL
+- Change the string and the `name=` argument in the `path()` function to be the desired URL name.
+
+- If you want to make a nested URL, (e.g. `miri/my_web_page`), look at other URLs in `urls.py` for examples.
+
+- Be sure to check that the paths are ordered such that the [URL dispatcher](https://docs.djangoproject.com/en/2.1/topics/http/urls/#example) can find them all correctly. Reorder them if this is not the case!
+
+### 2. Update the view and data container functions
+
+- Update the `data_containers.webpage_template_data()` function to be useful to you. Read in the contents of files, query the MAST archive, or use the functions in the `jwql` package! Be sure to `return` the data you need so that it is easily accessible with a function call.
+
+- Import this data in `views.webpage_template()`. Add any new entries to the `context` dictionary so your data will be passed to your HTML web page.
+
+- Change the data container function name in `data_containers.py` to a more descriptive name than `webpage_template_data()`, and be sure to change the import statement and function calls in `views.py` to match your new function name.
+
+- Change the view function name in `views.py` to a more descriptive name than `webpage_template()`, and be sure to change the entry in `urls.py` to match your new view name.
+
+### 3. Update the HTML template
+
+- Play around with `WEBPAGE_TEMPLATE.html` to display the information that you have passed in from `views.py`. If you are confused about how to access your data and structure the template, take a look at the [Jinja template documentation](http://jinja.pocoo.org/docs/2.10/templates/). Don't be afraid to add new text, links, buttons, or Bokeh plots. Use the local server that you set up above to see the changes you make in your browser.
+
+- Change the HTML template name to a more descriptive name than `WEBPAGE_TEMPLATE.html`. Be sure to change the `template` variable in your view to match your new template name.
+
+### 4. Share your work!
+- When you are ready to share your new page to the JWQL team for review, follow the directions on our [Contribution Guide](https://github.com/spacetelescope/jwql/wiki/git-&-GitHub-workflow-for-contributing) to submit a pull request.
+
+-----------------
+
+## Helpful Resources for Web Development
+- HTML Documentation and Examples: https://www.w3schools.com/html/default.asp
+- CSS Documentation and Examples: https://www.w3schools.com/css/default.asp
+- Bootstrap Documentation: https://getbootstrap.com/docs/4.3/getting-started/introduction/
+- Jinja2 HTML Template Documentation: http://jinja.pocoo.org/docs/2.10/templates/
+
+-----------------
+
+*If you have questions about any part of this guide, please contact lchambers@stsci.edu and bourque@stsci.edu.*

--- a/WEBPAGE_TEMPLATE.md
+++ b/WEBPAGE_TEMPLATE.md
@@ -1,8 +1,10 @@
 # Using the `webpage-template` branch to develop a webpage
 
-The `webpage-template` branch includes a number of template files and functions. These are designed to make it easier for a contributor who is unfamiliar with web development to write a new page for the web application.
+The `webpage-template` branch includes template code - files and functions - that are designed to make it easier for a contributor who is unfamiliar with web development to write a new page for the JWQL web application.
 
-The files and functions that you can edit are the following:
+These template resources both 1) make up a kind of webpage-skeleton that can be used as a foundation and built upon and 2) contain example code that is hopefully useful.
+
+The files and functions on the `webpage-template` branch that are designed to be edited are the following:
 
 | Template File/Function | Description | Location |
 | ---------------------- | ----------- | -------- |

--- a/WEBPAGE_TEMPLATE.md
+++ b/WEBPAGE_TEMPLATE.md
@@ -1,0 +1,46 @@
+# Using the `webpage-template` branch to develop a webpage
+
+The `webpage-template` branch includes a number of template files and functions. These are designed to make it easier for a contributor who is unfamiliar with web development to write a new page for the web application. They includes the following:
+
+| Template File/Function | Description | Location |
+| ---------------------- | ----------- | -------- |
+| HTML template   | file containing HTML used to render web page content (text, links, photos, tables, etc.) | `jwql/website/apps/jwql/templates/WEBPAGE_TEMPLATE.html` |
+| view function template | python function that passes data to an HTML template | `WEBSITE_TEMPLATE()` in `jwql/website/apps/jwql/views.py` |
+| URL entry template  | list item that maps a URL to a view | `jwql/website/apps/jwql/urls.py`
+
+* Interfaces to the existing `monitor_template` to demonstrate how the web app and package connect
+
+
+
+*To learn more about topics like HTML templates, views, and URLs, see the [JWQL intro to web apps](https://github.com/spacetelescope/jwql/blob/master/presentations/JWQL_web_app.pdf).*
+
+-----------------
+
+## How to view the template content
+
+1. Make sure you have a fork of the `jwql` repo that points to `spacetelescope/jwql` as `upstream`. (See the [contribution guide](https://github.com/spacetelescope/jwql/wiki/git-&-GitHub-workflow-for-contributing) if you need to set this up.)
+
+1. Create a copy of the `webpage-template` branch:
+
+    ```bash
+    git checkout -b <your_desired_branch_name> upstream/webpage-template
+    ```
+
+1. Activate your [`jwql` virtual environment](https://github.com/spacetelescope/jwql#environment-installation):
+
+    ```bash
+    source activate jwql
+    ```
+
+1. Start a remote server to run the web app:
+
+    ```bash
+    python jwql/website/manage.py runserver
+    ```
+
+1. Open the template web page in your browser: http://127.0.0.1:8000/webpage_template
+
+
+## How to customize the template content
+
+

--- a/jwql/website/apps/jwql/data_containers.py
+++ b/jwql/website/apps/jwql/data_containers.py
@@ -27,6 +27,8 @@ import os
 from astropy.io import fits
 from astropy.time import Time
 from astroquery.mast import Mast
+from bokeh.embed import components
+from bokeh.plotting import figure
 import numpy as np
 
 from .forms import MnemonicSearchForm, MnemonicQueryForm
@@ -42,6 +44,46 @@ PREVIEW_IMAGE_FILESYSTEM = os.path.join(get_config()['jwql_dir'], 'preview_image
 THUMBNAIL_FILESYSTEM = os.path.join(get_config()['jwql_dir'], 'thumbnails')
 PACKAGE_DIR = os.path.dirname(__location__.split('website')[0])
 REPO_DIR = os.path.split(PACKAGE_DIR)[0]
+
+
+def webpage_template_data():
+    """An example data container function for the webpage template.
+
+    Define variables to pass to the webpage_template view, including
+    the output of a Bokeh plot to embed.
+
+    Returns
+    -------
+    jwst_launch_date : int
+        The current expected JWST launch date
+    plot_data : list
+        A list containing the JavaScript and HTML content for the
+        Bokeh plot
+    """
+    # Define a single variable to pass
+    jwst_launch_date = 2021
+
+    # Define a basic bokeh plot showing value as a function of time.
+    # Start by defining the data for the plot.
+    list_of_dates = ['2018-02-11 00:00:00.000', '2018-02-12 00:00:00.000',
+                     '2018-02-13 00:00:00.000', '2018-02-14 00:00:00.000',
+                     '2018-02-15 00:00:00.000', '2018-02-16 00:00:00.000',
+                     '2018-02-17 00:00:00.000']
+    date = Time(list_of_dates, format='iso').datetime
+    avg_temp = [33, 36, 42, 43, 56, 44, 34]
+
+    # Build the plot with Bokeh
+    p1 = figure(tools='pan,box_zoom,reset,wheel_zoom,save', x_axis_type='datetime',
+                title='Baltimore Winter Temperatures', x_axis_label='Date',
+                y_axis_label='Average Temperature (Degrees F)')
+    p1.line(date, avg_temp, line_width=1, line_color='blue', line_dash='dashed')
+    p1.circle(date, avg_temp, color='blue')
+
+    # Save out the JavaScript and HTML
+    script, div = components(p1)
+    plot_data = [div, script]
+
+    return jwst_launch_date, plot_data
 
 
 def get_acknowledgements():

--- a/jwql/website/apps/jwql/templates/WEBPAGE_TEMPLATE.html
+++ b/jwql/website/apps/jwql/templates/WEBPAGE_TEMPLATE.html
@@ -1,0 +1,66 @@
+<!--This line tells the HTML file to read the contents of base.html before
+loading the contents of WEBPAGE_TEMPLATE.html-->
+{% extends "base.html" %}
+
+
+<!--The "preamble" block below contains content that goes in the page <head> tag-->
+{% block preamble %}
+
+    <!--Put the webpage title here:-->
+    <title>Webpage Title - JWQL</title>
+
+{% endblock %}
+
+<!--The "content" block below contains content that goes in the page <body> tag-->
+{% block content %}
+
+    <main role="main" class="container">
+
+        <!--Add a heading-->
+        <h1>This is a level 1 heading</h1>
+
+        <!--Horizontal line-->
+        <hr>
+
+        <!--Include an image located at jwql/website/apps/jwql/static/img/-->
+        <div style="text-align: center"><img src={{ static('img/jwql_logo_full_transparent.png') }} width=20%></div><br>
+
+        Some text under the h1 tag.<br>
+        More text after a line break.
+
+        <br>
+        <br>
+
+        <!--Add another heading (you can go up to h5)-->
+        <h2>A level 2 heading</h2>
+
+        <!--An inline link-->
+        Include a <a href="https://www.w3schools.com/tags/tag_a.asp" target="_blank">link</a>.
+
+        <br>
+        <br>
+
+        <!--Add a bulleted list-->
+        <h3>A hard-coded list</h3>
+        <ul>
+            <li>First</li>
+            <li>Second</li>
+            <li>Last</li>
+        </ul>
+
+        <br>
+
+
+        <!--Add another list using Jinja template for loop and Django variables-->
+        <h3>A dynamically-coded list</h3>
+        <ul>
+        {% for person in acknowledgements %}
+            <li>{{ person }}</li>
+        {% endfor %}
+        </ul>
+
+        <!--Include a bokeh plot-->
+
+    </main>
+
+{% endblock %}

--- a/jwql/website/apps/jwql/templates/WEBPAGE_TEMPLATE.html
+++ b/jwql/website/apps/jwql/templates/WEBPAGE_TEMPLATE.html
@@ -26,7 +26,10 @@ loading the contents of WEBPAGE_TEMPLATE.html-->
         <div style="text-align: center"><img src={{ static('img/jwql_logo_full_transparent.png') }} width=20%></div><br>
 
         Some text under the h1 tag.<br>
-        More text after a line break.
+        More text after a line break.<br>
+
+        <!--Use a Django variable passed from views.webpage_template-->
+        JWST is scheduled to launch in {{ launch_date }}... 🤞
 
         <br>
         <br>
@@ -36,6 +39,10 @@ loading the contents of WEBPAGE_TEMPLATE.html-->
 
         <!--An inline link-->
         Include a <a href="https://www.w3schools.com/tags/tag_a.asp" target="_blank">link</a>.
+        <br>
+
+        <!--Or a Bootstrap button to download an image at jwql/website/apps/jwql/static/img!-->
+        <a id="download_example" class="btn btn-primary my-2 mx-2" role="button" href='{{ static("img/hubble_image.jpg") }}' download>Download Hubble Image</a>
 
         <br>
         <br>
@@ -51,15 +58,21 @@ loading the contents of WEBPAGE_TEMPLATE.html-->
         <br>
 
 
-        <!--Add another list using Jinja template for loop and Django variables-->
         <h3>A dynamically-coded list</h3>
+        <!--Add another list using Jinja for loop and Django variables-->
         <ul>
-        {% for person in acknowledgements %}
-            <li>{{ person }}</li>
+        {% for instrument in inst_list %}
+            <li>{{ instrument }}</li>
         {% endfor %}
         </ul>
 
         <!--Include a bokeh plot-->
+        <h3>A Bokeh Plot</h3>
+        <!--Import Bokeh package-->
+        <link href="https://cdn.pydata.org/bokeh/release/bokeh-1.0.1.min.css" rel="stylesheet" type="text/css">
+        <!--Import Bokeh JavaScript and HTML-->
+        {{ plot_data[1] | safe }}
+        {{ plot_data[0] | safe }}
 
     </main>
 

--- a/jwql/website/apps/jwql/urls.py
+++ b/jwql/website/apps/jwql/urls.py
@@ -55,6 +55,9 @@ urlpatterns = [
     # Home
     path('', views.home, name='home'),
 
+    # WEBPAGE TEMPLATE
+    path('webpage_template', views.webpage_template, name='webpage_template'),
+
     # Authentication
     path('login/', oauth.login, name='login'),
     path('logout/', oauth.logout, name='logout'),

--- a/jwql/website/apps/jwql/views.py
+++ b/jwql/website/apps/jwql/views.py
@@ -48,6 +48,7 @@ from .data_containers import get_image_info
 from .data_containers import get_proposal_info
 from .data_containers import thumbnails
 from .data_containers import thumbnails_ajax
+from .data_containers import webpage_template_data
 from .forms import FileSearchForm
 from .oauth import auth_info
 from jwql.utils.constants import JWST_INSTRUMENT_NAMES, MONITORS, JWST_INSTRUMENT_NAMES_MIXEDCASE
@@ -71,12 +72,13 @@ def webpage_template(request):
     # Define which HTML template to render
     template = 'WEBPAGE_TEMPLATE.html'
 
-    # Define any variables to pass to the web page
-    acknowledgements = get_acknowledgements()
+    # Define variables with data from data_containers.py
+    launch, plot_data = webpage_template_data()
 
-    # Wrap all needed variables into a Python dictionary
+    # Pack all needed variables into a Python dictionary
     context = {
-        'acknowledgements': acknowledgements,
+        'launch_date': launch,
+        'plot_data': plot_data,
         'inst': '', # Leave as empty string or instrument name; Required for navigation bar
         'inst_list': JWST_INSTRUMENT_NAMES, # Do not edit; Required for navigation bar
         'tools': MONITORS, # Do not edit; Required for navigation bar

--- a/jwql/website/apps/jwql/views.py
+++ b/jwql/website/apps/jwql/views.py
@@ -56,6 +56,7 @@ from jwql.utils.utils import get_base_url, get_config
 
 FILESYSTEM_DIR = os.path.join(get_config()['jwql_dir'], 'filesystem')
 
+
 def webpage_template(request):
     """Generate the ``WEBPAGE_TEMPLATE`` page
 
@@ -79,10 +80,10 @@ def webpage_template(request):
     context = {
         'launch_date': launch,
         'plot_data': plot_data,
-        'inst': '', # Leave as empty string or instrument name; Required for navigation bar
-        'inst_list': JWST_INSTRUMENT_NAMES, # Do not edit; Required for navigation bar
-        'tools': MONITORS, # Do not edit; Required for navigation bar
-        'user': None # Do not edit; Required for authentication
+        'inst': '',  # Leave as empty string or instrument name; Required for navigation bar
+        'inst_list': JWST_INSTRUMENT_NAMES,  # Do not edit; Required for navigation bar
+        'tools': MONITORS,  # Do not edit; Required for navigation bar
+        'user': None  # Do not edit; Required for authentication
     }
 
     # Return a HTTP response with the template and dictionary of variables

--- a/jwql/website/apps/jwql/views.py
+++ b/jwql/website/apps/jwql/views.py
@@ -55,6 +55,37 @@ from jwql.utils.utils import get_base_url, get_config
 
 FILESYSTEM_DIR = os.path.join(get_config()['jwql_dir'], 'filesystem')
 
+def webpage_template(request):
+    """Generate the ``WEBPAGE_TEMPLATE`` page
+
+    Parameters
+    ----------
+    request : HttpRequest object
+        Incoming request from the webpage
+
+    Returns
+    -------
+    HttpResponse object
+        Outgoing response sent to the webpage
+    """
+    # Define which HTML template to render
+    template = 'WEBPAGE_TEMPLATE.html'
+
+    # Define any variables to pass to the web page
+    acknowledgements = get_acknowledgements()
+
+    # Wrap all needed variables into a Python dictionary
+    context = {
+        'acknowledgements': acknowledgements,
+        'inst': '', # Leave as empty string or instrument name; Required for navigation bar
+        'inst_list': JWST_INSTRUMENT_NAMES, # Do not edit; Required for navigation bar
+        'tools': MONITORS, # Do not edit; Required for navigation bar
+        'user': None # Do not edit; Required for authentication
+    }
+
+    # Return a HTTP response with the template and dictionary of variables
+    return render(request, template, context)
+
 
 @auth_info
 def about(request, user):


### PR DESCRIPTION
My attempt to make a set of template files that a new contributor can use to get a head start developing a new web page.

I have tried to write extensive directions into a new markdown page, `WEBPAGE_TEMPLATE.md`, which should hopefully point to the right new files and functions, and explain how to use the branch as a template. Please let me know which parts of those directions is unclear!

Note that this PR merges into `upstream/webpage-template` rather than `master`. The instructions file, `WEBPAGE_TEMPLATE.md`, will need to be merged separately into `master`, but I have designed the other files to live specifically in a new `upstream/webpage-template` branch so that they can be used out-of-the-box without cluttering the existing code.

...This does mean that updates to `master` would need to be periodically pulled into `upstream/webpage-template`. If someone has a better idea for how to do this, please share!

Closes #293.