### PR TITLE
Update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ The `jwql` application is currently under heavy development.  The `1.0` release 
 
 ## Installation
 
+Getting `jwql` up and running on your own computer requires four steps, detailed below:
+1. Cloning the GitHub repository
+1. Installing the `conda`environment
+1. Installing the python package
+1. Setting up the configuration file
+
 ### Prerequisites
 
 It is highly suggested that contributors have a working installation of `anaconda` or `miniconda` for Python 3.6.  Downloads and installation instructions are  available here:
@@ -33,27 +39,25 @@ It is highly suggested that contributors have a working installation of `anacond
 
 Requirements for contributing to the `jwql` package will be included in the `jwql` `conda` environment, which is included in our installation instructions below. Further package requirements will be provided for `jwql` by a `setup.py` script included in the repository.
 
-### Package Installation
+### Clone the `jwql` repo
 
-You first need to install the current version of `jwql`. The simplest way to do this is to go to the directory you want your copy of the repository to be in and clone the repoistory there. Once you are in the directory you can do the following:
+You first need to clone the current version of `jwql`. The simplest way to do this is to go to the directory you want your copy of the repository to be in and clone the repository there. Once you are in the directory you can do the following:
 
 ```
 git clone https://github.com/spacetelescope/jwql.git
 cd jwql
-python setup.py develop
 ```
 
 or, if you would rather use `SSH` instead of `https`, type
 ```
 git clone git@github.com:spacetelescope/jwql.git
 cd jwql
-python setup.py develop
 ```
 instead, and then proceed as stated.
 
 ### Environment Installation
 
-Following the download of the `jwql` package, contributors can then install the `jwql` `conda` environment via the `environment.yml` file, which contains all of the dependencies for the project.  First, one should ensure that their version of `conda` is up to date:
+Following the download of the `jwql` repository, contributors can then install the `jwql` `conda` environment via the `environment.yml` file, which contains all of the dependencies for the project.  First, one should ensure that their version of `conda` is up to date:
 
 ```
 conda update conda
@@ -70,6 +74,15 @@ Lastly, one can create the `jwql` environment via the `environment.yml` file:
 ```
 conda env create -f environment.yml
 ```
+
+### Package Installation
+
+Next, you need to install the `jwql` package. While still in the directory with the `jwql` clone, you can do the following:
+
+```
+python setup.py develop
+```
+The package should now appear if you run `conda list jwql`.
 
 ### Configuration File
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ conda env create -f environment.yml
 
 ### Package Installation
 
-Next, you need to install the `jwql` package. While still in the directory with the `jwql` clone, you can do the following:
+Next, you need to install the `jwql` package. While still in the `jwql/` directory, run the following command to set up the package:
 
 ```
 python setup.py develop


### PR DESCRIPTION
As @cracraft and I were setting up a JWQL environment on her laptop this morning, we ran into a number of problems with the documentation for how to set up the environment.

We realized that the order of the `README.md` file doesn't quite make sense. It lists how to clone the repo and install the package before how to set up the JWQL environment. We figured you want to set up the environment *before* you install the package, otherwise you'll 1) have installed the package in whatever environment you were in before, and 2) will still have to re-install it after you make the `jwql` environment.

I have reordered the `README.md` file to reflect this.

We also noticed some problems with the documentation on the wiki, so I've made the following changes:
- Add section to the [Environment Installation](https://github.com/spacetelescope/jwql/wiki/Environment-Installation) page that copies the instructions for how to install the environment from the `README.md`
- Add instructions to the [workflow page](https://github.com/spacetelescope/jwql/wiki/git-&-GitHub-workflow-for-contributing) for how to clone your fork/set up `upstream` with HTTP and SSH

@cracraft can you let me know if these changes look okay? Or if I missed anything?