### PR TITLE
auth.mast example notebook

### DIFF
--- a/notebooks/integrating_auth_mast_service.ipynb
+++ b/notebooks/integrating_auth_mast_service.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "**This notebook serves to demonstrate how to integrate the `auth.mast` service into a Django web application.  The code was adopted from the solution derived for the `jwql` web application.  Much of the code was written by Christian Mesh of the Archive Science Branch.  Thank you Christian!**\n",
     "\n",
-    "**Please note that this notebook does not work right out of the box.  There are various tokens and metadata that must be provided, and the code within is designed for a specific project.  It may be beneficial to structure the code in a different way for different applications.  This notebook simply serves as a guide.**\n",
+    "**Please note that this notebook does not work right out of the box, and some of the cells will not run without error.  There are various tokens and metadata that must be provided, and the code within is designed for a specific project.  It may be beneficial to structure the code in a different way for different applications.  This notebook simply serves as a guide.**\n",
     "\n",
     "**Resources:**\n",
     "- The `auth.mast` service can be found here: https://auth.mast.stsci.edu/\n",

--- a/notebooks/integrating_auth_mast_service.ipynb
+++ b/notebooks/integrating_auth_mast_service.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "**This notebook serves to demonstrate how to integrate the `auth.mast` service into a Django web application.  The code was adopted from the solution derived for the `jwql` web application.  Much of the code was written by Christian Mesh of the Archive Science Branch.  Thank you Christian!**\n",
     "\n",
-    "**Please note that this notebook does not work right out of the box, and some of the cells will not run without error.  There are various tokens and metadata that must be provided, and the code within is designed for a specific project.  It may be beneficial to structure the code in a different way for different applications.  This notebook simply serves as a guide.**\n",
+    "**Please note that this notebook merely serves as a reference, and does not work right out of the box -- the cells within are not meant to be executed, and executing most of them would result in an error.  There are various tokens and metadata that must be provided, and the code within is designed for a specific project.  It may be beneficial to structure the code in a different way for different applications.  This notebook simply serves as a guide.**\n",
     "\n",
     "**Resources:**\n",
     "- The `auth.mast` service can be found here: https://auth.mast.stsci.edu/\n",
@@ -56,6 +56,13 @@
     "client_secret = ''  # Provided by ASB\n",
     "auth_mast = 'auth.mast.stsci.edu'  # or can use authdev.mast.stsci.edu for dev\n",
     "base_url = 'https://myapp.stsci.edu'  # whatever URL your application uses"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "*Note that the `client_id` and `client_secret` are tokens that are specific to the application.  To obtain these tokens, please contact Christian Mesh (cmesh@stsci.edu) or someone else from the ASB branch*"
    ]
   },
   {

--- a/notebooks/integrating_auth_mast_service.ipynb
+++ b/notebooks/integrating_auth_mast_service.ipynb
@@ -1,0 +1,455 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**This notebook serves to demonstrate how to integrate the `auth.mast` service into a Django web application.  The code was adopted from the solution derived for the `jwql` web application.  Much of the code was written by Christian Mesh of the Archive Science Branch.  Thank you Christian!**\n",
+    "\n",
+    "**Please note that this notebook does not work right out of the box.  There are various tokens and metadata that must be provided, and the code within is designed for a specific project.  It may be beneficial to structure the code in a different way for different applications.  This notebook simply serves as a guide.**\n",
+    "\n",
+    "**Resources:**\n",
+    "- The `auth.mast` service can be found here: https://auth.mast.stsci.edu/\n",
+    "- The development version of the `auth.mast` service can be found here:  https://auth.mastdev.stsci.edu/\n",
+    "\n",
+    "\n",
+    "**In this bare-bones example, we assume the following directory structure for the `django` web application:**\n",
+    "\n",
+    "```\n",
+    "website/   \n",
+    "    apps/\n",
+    "        my_app/\n",
+    "            views.py\n",
+    "            urls.py\n",
+    "            templates/\n",
+    "                some_webpage.html\n",
+    "```\n",
+    "\n",
+    "**Required third-party libraries**\n",
+    "\n",
+    "- `authlib`\n",
+    "- `django`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Necessary imports\n",
+    "import requests\n",
+    "\n",
+    "from authlib.django.client import OAuth\n",
+    "from django.shortcuts import redirect, render\n",
+    "from django.urls import path"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set some necessary global parameters\n",
+    "client_id = ''  # Provided by ASB\n",
+    "client_secret = ''  # Provided by ASB\n",
+    "auth_mast = 'auth.mast.stsci.edu'  # or can use authdev.mast.stsci.edu for dev\n",
+    "base_url = 'https://myapp.stsci.edu'  # whatever URL your application uses"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Registering the application with `auth.mast`\n",
+    "\n",
+    "*The following function should be placed within the scope of the `views.py` module*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def register_oauth():\n",
+    "    \"\"\"Register the ``my_app`` application with the ``auth.mast``\n",
+    "    authentication service.\n",
+    "\n",
+    "    Returns\n",
+    "    -------\n",
+    "    oauth : Object\n",
+    "        An object containing methods to authenticate a user, provided\n",
+    "        by the ``auth.mast`` service.\n",
+    "    \"\"\"\n",
+    "\n",
+    "    oauth = OAuth()\n",
+    "    client_kwargs = {'scope': 'mast:user:info'}\n",
+    "    oauth.register(\n",
+    "        'mast_auth',\n",
+    "        client_id='{}'.format(client_id),\n",
+    "        client_secret='{}'.format(client_secret),\n",
+    "        access_token_url='https://{}/oauth/access_token?client_secret={}'.format(auth_mast, client_secret),\n",
+    "        access_token_params=None,\n",
+    "        refresh_token_url=None,\n",
+    "        authorize_url='https://{}/oauth/authorize'.format(auth_mast),\n",
+    "        api_base_url='https://{}/1.1/'.format(auth_mast),\n",
+    "        client_kwargs=client_kwargs)\n",
+    "\n",
+    "    return oauth"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "MY_APP_OAUTH = register_oauth()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Convenience Decorators\n",
+    "\n",
+    "*The following decorators can be used to easily pass authenticaion metadata to various views within your web application, as will be demonstrated below.  These decorators should be placed within the scope of `views.py`*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def auth_info(fn):\n",
+    "    \"\"\"A decorator function that will return user metadata from the\n",
+    "    authentication along with what is returned by the original function.\n",
+    "\n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    fn : function\n",
+    "        The function to decorate\n",
+    "\n",
+    "    Returns\n",
+    "    -------\n",
+    "    user_info : function\n",
+    "        The decorated function\n",
+    "    \"\"\"\n",
+    "\n",
+    "    def user_info(request, **kwargs):\n",
+    "        \"\"\"Store authenticated user credentials in a cookie and return\n",
+    "        it.  If the user is not authenticated, store no credentials in\n",
+    "        the cookie.\n",
+    "\n",
+    "        Parameters\n",
+    "        ----------\n",
+    "        request : HttpRequest object\n",
+    "            Incoming request from the webpage\n",
+    "\n",
+    "        Returns\n",
+    "        -------\n",
+    "        fn : function\n",
+    "            The decorated function\n",
+    "        \"\"\"\n",
+    "\n",
+    "        cookie = request.COOKIES.get(\"ASB-AUTH\")\n",
+    "\n",
+    "        # If user is authenticated, return user credentials\n",
+    "        if cookie is not None:\n",
+    "            response = requests.get(\n",
+    "                'https://{}/info'.format(auth_mast),\n",
+    "                headers={'Accept': 'application/json',\n",
+    "                         'Authorization': 'token {}'.format(cookie)})\n",
+    "            response = response.json()\n",
+    "\n",
+    "        # If user is not authenticated, return no credentials\n",
+    "        else:\n",
+    "            response = {'ezid' : None, \"anon\": True}\n",
+    "\n",
+    "        return fn(request, response, **kwargs)\n",
+    "\n",
+    "    return user_info"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def auth_required(fn):\n",
+    "    \"\"\"A decorator function that requires the passed function to have\n",
+    "    authentication through ``auth.mast`` set up.\n",
+    "\n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    fn : function\n",
+    "        The function to decorate\n",
+    "\n",
+    "    Returns\n",
+    "    -------\n",
+    "    check_auth : function\n",
+    "        The decorated function\n",
+    "    \"\"\"\n",
+    "\n",
+    "    @auth_info\n",
+    "    def check_auth(request, user):\n",
+    "        \"\"\"Check if the user is authenticated through ``auth.mast``.\n",
+    "        If not, perform the authorization.\n",
+    "\n",
+    "        Parameters\n",
+    "        ----------\n",
+    "        request : HttpRequest object\n",
+    "            Incoming request from the webpage\n",
+    "        user : dict\n",
+    "            A dictionary of user credentials\n",
+    "\n",
+    "        Returns\n",
+    "        -------\n",
+    "        fn : function\n",
+    "            The decorated function\n",
+    "        \"\"\"\n",
+    "\n",
+    "        # If user is currently anonymous, require a login\n",
+    "        if user[\"anon\"]:\n",
+    "            # Redirect to oauth login\n",
+    "            redirect_uri = os.path.join(base_url, 'authorize')\n",
+    "            return MY_APP_OAUTH.mast_auth.authorize_redirect(request, redirect_uri)\n",
+    "\n",
+    "        return fn(request, user)\n",
+    "\n",
+    "    return check_auth"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Authentication-related URLs\n",
+    "\n",
+    "*The following URLs serve as the URLs that point to individual authentication-related views within the `django` web application (e.g. `login`, `logout`, etc).  They should be placed in `apps.my_app.urls.py`.*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your app probably has some existing URLs:\n",
+    "urlpatterns = [\n",
+    "    path('', views.home, name='home'),\n",
+    "    path('about/', views.about, name='about'),\n",
+    "]\n",
+    "\n",
+    "# These are the authenticaion related views we will build\n",
+    "auth_urlpatterns = [\n",
+    "    path('login/', views.login, name='login'),\n",
+    "    path('logout/', views.logout, name='logout'),\n",
+    "    path('authorize/', views.authorize, name='authorize'),\n",
+    "]\n",
+    "\n",
+    "# Add these to the existing URL patterns\n",
+    "urlpatterns += auth_urlpatters"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Authentication-related Views\n",
+    "\n",
+    "*The following functions serve as individual authentication-related views within the `django` web application.  They should be placed within the scope of `views.py`*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def authorize(request):\n",
+    "    \"\"\"Spawn the authentication process for the user\n",
+    "\n",
+    "    The authentication process involves retreiving an access token\n",
+    "    from ``auth.mast`` and porting the data to a cookie.\n",
+    "\n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    request : HttpRequest object\n",
+    "        Incoming request from the webpage\n",
+    "\n",
+    "    Returns\n",
+    "    -------\n",
+    "    HttpResponse object\n",
+    "        Outgoing response sent to the webpage\n",
+    "    \"\"\"\n",
+    "\n",
+    "    # Get auth.mast token\n",
+    "    token = MY_APP_OAUTH.mast_auth.authorize_access_token(request, headers={'Accept': 'application/json'})\n",
+    "\n",
+    "    # Set secure cookie parameters\n",
+    "    cookie_args = {}\n",
+    "    cookie_args['domain'] = 'myapp.stsci.edu'\n",
+    "    cookie_args['secure'] = True  \n",
+    "    cookie_args['httponly'] = True\n",
+    "\n",
+    "    # Set the cookie and redirect to home\n",
+    "    response = redirect(\"/\")\n",
+    "    response.set_cookie(\"ASB-AUTH\", token[\"access_token\"], **cookie_args)\n",
+    "\n",
+    "    return response"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@auth_required\n",
+    "def login(request, user):\n",
+    "    \"\"\"Spawn a login process for the user\n",
+    "\n",
+    "    The ``auth_requred`` decorator is used to require that the user\n",
+    "    authenticate through ``auth.mast``, then the user is redirected\n",
+    "    back to the homepage.\n",
+    "\n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    request : HttpRequest object\n",
+    "        Incoming request from the webpage\n",
+    "    user : dict\n",
+    "        A dictionary of user credentials.\n",
+    "\n",
+    "    Returns\n",
+    "    -------\n",
+    "    HttpResponse object\n",
+    "        Outgoing response sent to the webpage\n",
+    "    \"\"\"\n",
+    "\n",
+    "    return redirect(\"/\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def logout(request):\n",
+    "    \"\"\"Spawn a logout process for the user\n",
+    "\n",
+    "    Upon logout, the user's ``auth.mast`` credientials are removed and\n",
+    "    the user is redirected back to the homepage.\n",
+    "\n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    request : HttpRequest object\n",
+    "        Incoming request from the webpage\n",
+    "    user : dict\n",
+    "        A dictionary of user credentials.\n",
+    "\n",
+    "    Returns\n",
+    "    -------\n",
+    "    HttpResponse object\n",
+    "        Outgoing response sent to the webpage\n",
+    "    \"\"\"\n",
+    "\n",
+    "    response = redirect(\"/\")\n",
+    "    response.delete_cookie(\"ASB-AUTH\")\n",
+    "\n",
+    "    return response\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Accessing authentication metadata within other views\n",
+    "\n",
+    "*The following demonstrates how to use the `@auth_info` decorator on an example view in order to utilize authentication metadata.  In this example, we will consider \"some_webpage\" in which we only want to show content if the user is authenticated.  We assume that this function is placed within the scope of `views.py`*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@auth_info\n",
+    "def some_webpage(request, user):\n",
+    "    \"\"\"Generate the ``some_webpage`` page.\n",
+    "\n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    request : HttpRequest object\n",
+    "        Incoming request from the webpage\n",
+    "\n",
+    "    Returns\n",
+    "    -------\n",
+    "    HttpResponse object\n",
+    "        Outgoing response sent to the webpage\n",
+    "    \"\"\"\n",
+    "    template = 'some_webpage.html'\n",
+    "    context = {'user': user}\n",
+    "\n",
+    "    return render(request, template, context)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "*The `some_webpage.html` file now has access to the `user` data, which is the cookie provided by `auth.mast`.  Here is an example of what a `div` in `some_webpage.html` might look like; it provides a login/logout button, and displays the user's `ezid`.  In this example, we use the `jinja2` templating language to access `user`, however, one might use the built in `django` templating language.*"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```html\n",
+    "<div>\n",
+    "    {% if user.ezid %}\n",
+    "        <p>{{ user.ezid }}</p>\n",
+    "        <a role=\"button\" class=\"btn btn-primary\" href='https://myapp.stsci.edu/logout'>logout</a>\n",
+    "    {% else %}\n",
+    "        <a role=\"button\" class=\"btn btn-primary\" href='https://myapp.stsci.edu/login'>login</a>\n",
+    "    {% endif %}\n",
+    "</div>\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "*To see which information is contained within the `user` cookie, visit https://auth.mastdev.stsci.edu/info*"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This PR adds a `jupyter` notebook with examples showing how to integrate the `auth.mast` service into a `django` web application.  Hopefully it can be useful for others at ST wishing to integrate `auth.mast` like we have done! 