### PR TITLE
Reset database

### DIFF
--- a/docs/source/database.rst
+++ b/docs/source/database.rst
@@ -7,3 +7,9 @@ database_interface.py
 .. automodule:: jwql.database.database_interface
     :members:
     :undoc-members:
+
+reset_database.py
+-----------------
+.. automodule:: jwql.database.reset_database
+    :members:
+    :undoc-members:

--- a/jwql/database/database_interface.py
+++ b/jwql/database/database_interface.py
@@ -208,7 +208,7 @@ class Monitor(base):
     monitor_name = Column(String(), nullable=False)
     start_time = Column(DateTime, nullable=False)
     end_time = Column(DateTime, nullable=True)
-    status = Column(Enum('SUCESS', 'FAILURE'), nullable=True)
+    status = Column(Enum('SUCESS', 'FAILURE', name='monitor_status'), nullable=True)
     affected_tables = Column(postgresql.ARRAY(String, dimensions=1), nullable=True)
     log_file = Column(String(), nullable=False)
 

--- a/jwql/database/reset_database.py
+++ b/jwql/database/reset_database.py
@@ -19,7 +19,9 @@ Dependencies
 ------------
 
     Users must have a ``config.json`` configuration file with a proper
-    ``connection_string`` key that points to the ``jwqldb`` database
+    ``connection_string`` key that points to the ``jwqldb`` database.
+    The ``connection_string`` format is
+    ``postgresql+psycopg2://user:password@host:port/database``.
 """
 
 from jwql.database.database_interface import base
@@ -29,6 +31,9 @@ from jwql.utils.utils import get_config
 if __name__ == '__main__':
 
     connection_string = get_config()['connection_string']
+    server_type = connection_string.split('@')[-1][0]
+
+    assert server_type != 'p', 'Cannot reset production database!'
 
     prompt = ('About to reset all tables for database instance {}. Do you '
               'wish to proceed? (y/n)\n'.format(connection_string))

--- a/jwql/database/reset_database.py
+++ b/jwql/database/reset_database.py
@@ -1,0 +1,40 @@
+#! /usr/bin/env python
+
+"""Reset all tables in the ``jwqldb`` database.
+
+Authors
+-------
+
+    - Matthew Bourque
+
+Use
+---
+
+    This script is intended to be used in the command line:
+    ::
+
+        python reset_database.py
+
+Dependencies
+------------
+
+    Users must have a ``config.json`` configuration file with a proper
+    ``connection_string`` key that points to the ``jwqldb`` database
+"""
+
+from jwql.database.database_interface import base
+from jwql.utils.utils import get_config
+
+
+if __name__ == '__main__':
+
+    connection_string = get_config()['connection_string']
+
+    prompt = ('About to reset all tables for database instance {}. Do you '
+              'wish to proceed? (y/n)\n'.format(connection_string))
+    response = input(prompt)
+
+    if response.lower() == 'y':
+        base.metadata.drop_all()
+        base.metadata.create_all()
+        print('\nDatabase instance {} has been reset'.format(connection_string))


### PR DESCRIPTION
This PR adds a `reset_database.py` module, which will reset the database given in the `connection_string` key in the `config.json` config file.  This can be used to easily reset the development database.