### PR TITLE
Add FileNotFoundError to "raises" for filename_parser test

### DIFF
--- a/jwql/tests/test_utils.py
+++ b/jwql/tests/test_utils.py
@@ -271,7 +271,8 @@ def test_filename_parser(filename, solution):
     assert filename_parser(filename) == solution
 
 
-@pytest.mark.xfail(raises=ValueError, reason='Known non-compliant files in filesystem')
+@pytest.mark.xfail(raises=(FileNotFoundError, ValueError), 
+                   reason='Known non-compliant files in filesystem; User must manually supply config file.')
 def test_filename_parser_whole_filesystem():
     """Test the filename_parser on all files currently in the filesystem.
     """


### PR DESCRIPTION
While looking at the Jenkins build for the latest pyup PR, I discovered 2 problems:
1. `test_filename_parser_whole_filesystem` in `test_utils` did not include a `FileNotFoundError` in its list of errors that are acceptable for the `xfail`
2. Perhaps more concerningly, the Jenkins build did not mark the build as a failure, despite this error

Here is the build: https://ssbjenkins.stsci.edu/blue/organizations/jenkins/STScI%2Fjwql/detail/PR-330/2/pipeline/18

This PR addresses 1, but not 2. Not sure who to ask about 2, since I thought #303 would have solved this.