### PR TITLE
Release-driven git workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ The following is a bare-bones example of a best work flow for contributing to th
 4. Create a branch on that personal fork.
 5. Make your software changes.
 6. Push that branch to your personal GitHub repository (i.e. `origin`).
-7. On the `spacetelescope` `jwql` repository, create a pull request that merges the branch into `spacetelescope:master`.
+7. On the `spacetelescope` `jwql` repository, create a pull request that merges the branch into `spacetelescope:develop`.
 8. Assign a reviewer from the team for the pull request.
 9. Iterate with the reviewer over any needed changes until the reviewer accepts and merges your branch.
 10. Delete your local copy of your branch.

--- a/style_guide/style_guide.md
+++ b/style_guide/style_guide.md
@@ -2,7 +2,7 @@ Python Code Style Guide for `jwql`
 =================================
 
 This document serves as a style guide for all `jwql` software development.  Any requested contribution to the `jwql` code repository should be checked against this guide, and any violation of the guide should be fixed before the code is committed to
-the `master` branch.  Please refer to the accompanying [`example.py`](https://github.com/spacetelescope/jwql/blob/master/style_guide/example.py) script for a example code that abides by this style guide.
+the `master` or `develop` branch.  Please refer to the accompanying [`example.py`](https://github.com/spacetelescope/jwql/blob/master/style_guide/example.py) script for a example code that abides by this style guide.
 
 Prerequisite Reading
 --------------------
@@ -74,7 +74,7 @@ To the extent possible, `jwql` shall define frequently-used variable types/value
 
 - **JWST instrument names**: In all internal references and structures (e.g. dictionaries) instrument names shall be all lower-case strings, i.e. one of `fgs`, `miri`, `niriss`, `nircam`, `nirspec`. When variations are required for interfaces, e.g. `Nircam` for MAST, `NIRCam` or `NIRCAM` for SIAF, etc. these should be defined as dictionaries in [`jwql/utils/constants.py`](https://github.com/spacetelescope/jwql/blob/master/jwql/utils/constants.py) and imported from there.
 
-- **Program/proposal identifiers**: JWST program IDs shall be stored and referred to internally as integers and parsed to strings only when needed. For example, the inputs `"001144"` and `"1144"` shall both be converted to an integer variable with value `1144`.  
+- **Program/proposal identifiers**: JWST program IDs shall be stored and referred to internally as integers and parsed to strings only when needed. For example, the inputs `"001144"` and `"1144"` shall both be converted to an integer variable with value `1144`.
 
 
 Tools and Library Recommendations


### PR DESCRIPTION
This PR updates our documentation to describe a new release-driven git workflow for the `jwql` project.  Updated documents include:

- `README.md`
- `style_guide.md`
- The wiki for [`git`/GitHub workflow](https://github.com/spacetelescope/jwql/wiki/git-&-GitHub-workflow-for-contributing)
- The wiki for [software releases](https://github.com/spacetelescope/jwql/wiki/Software-Releases)
- The wiki for [Checklist for Contributors and Reviewers of PRs](https://github.com/spacetelescope/jwql/wiki/Checklist-for-Contributors-and-Reviewers-of-Pull-Requests)

Closes #295