### PR TITLE
Improve test_preview_image

### DIFF
--- a/jwql/tests/test_preview_image.py
+++ b/jwql/tests/test_preview_image.py
@@ -76,10 +76,15 @@ def get_test_fits_files():
     filenames : list
         List of filepaths to FITS files
     """
+    # Get the files from central store
     if not ON_JENKINS:
         filenames = glob.glob(os.path.join(get_config()['test_dir'], '*.fits'))
         assert len(filenames) > 0
         return filenames
+
+    # Or return an empty list
+    else:
+        return []
 
 
 @pytest.mark.skipif(ON_JENKINS, reason='Requires access to central storage.')

--- a/jwql/tests/test_preview_image.py
+++ b/jwql/tests/test_preview_image.py
@@ -6,6 +6,7 @@ Authors
 -------
 
     - Johannes Sahlmann
+    - Lauren Chambers
 
 
 Use
@@ -22,6 +23,7 @@ Use
 import glob
 import os
 import pytest
+import shutil
 
 from astropy.io import fits
 
@@ -47,10 +49,20 @@ def test_directory(test_dir=TEST_DIRECTORY):
         Path to directory used for testing
 
     """
-    os.mkdir(test_dir)  # creates directory
+    # Set up local test directory
+    if not os.path.isdir(test_dir):
+        os.mkdir(test_dir)  # creates directory
     yield test_dir
+
+    # Tear down local test directory and any files within
     if os.path.isdir(test_dir):
-        os.rmdir(test_dir)
+        shutil.rmtree(test_dir)
+
+    # Empty test directory on central storage
+    jpgs = glob.glob(os.path.join(get_config()['test_dir'], '*.jpg'))
+    thumbs = glob.glob(os.path.join(get_config()['test_dir'], '*.thumbs'))
+    for file in jpgs + thumbs:
+        os.remove(file)
 
 
 @pytest.mark.skipif(os.path.expanduser('~') == '/home/jenkins',

--- a/jwql/tests/test_preview_image.py
+++ b/jwql/tests/test_preview_image.py
@@ -33,6 +33,9 @@ from jwql.utils.utils import get_config
 # directory to be created and populated during tests running
 TEST_DIRECTORY = os.path.join(os.environ['HOME'], 'preview_image_test')
 
+# Determine if tests are being run on jenkins
+ON_JENKINS = os.path.expanduser('~') == '/home/jenkins'
+
 
 @pytest.fixture(scope="module")
 def test_directory(test_dir=TEST_DIRECTORY):
@@ -65,9 +68,23 @@ def test_directory(test_dir=TEST_DIRECTORY):
         os.remove(file)
 
 
-@pytest.mark.skipif(os.path.expanduser('~') == '/home/jenkins',
-                    reason='Requires access to central storage.')
-def test_make_image(test_directory):
+def get_test_fits_files():
+    """Get a list of the FITS files on central storage to make preview images.
+
+    Returns
+    -------
+    filenames : list
+        List of filepaths to FITS files
+    """
+    if not ON_JENKINS:
+        filenames = glob.glob(os.path.join(get_config()['test_dir'], '*.fits'))
+        assert len(filenames) > 0
+        return filenames
+
+
+@pytest.mark.skipif(ON_JENKINS, reason='Requires access to central storage.')
+@pytest.mark.parametrize('filename', get_test_fits_files())
+def test_make_image(test_directory, filename):
     """Use PreviewImage.make_image to create preview images of a sample
     JWST exposure.
 
@@ -78,44 +95,41 @@ def test_make_image(test_directory):
     ----------
     test_directory : str
         Path of directory used for testing
+    filename : str
+        Path of FITS image to generate preview of
     """
 
-    filenames = glob.glob(os.path.join(get_config()['test_dir'], '*.fits'))
-    assert len(filenames) > 0
+    header = fits.getheader(filename)
 
-    for filename in filenames:
-
-        header = fits.getheader(filename)
-
-        # Create and save the preview image or thumbnail
-        for create_thumbnail in [False, True]:
-            try:
-                image = PreviewImage(filename, "SCI")
-                image.clip_percent = 0.01
-                image.scaling = 'log'
-                image.cmap = 'viridis'
-                image.output_format = 'jpg'
-                image.thumbnail = create_thumbnail
-
-                if create_thumbnail:
-                    image.thumbnail_output_directory = test_directory
-                else:
-                    image.preview_output_directory = test_directory
-
-                image.make_image()
-            except ValueError as error:
-                print(error)
+    # Create and save the preview image or thumbnail
+    for create_thumbnail in [False, True]:
+        try:
+            image = PreviewImage(filename, "SCI")
+            image.clip_percent = 0.01
+            image.scaling = 'log'
+            image.cmap = 'viridis'
+            image.output_format = 'jpg'
+            image.thumbnail = create_thumbnail
 
             if create_thumbnail:
-                extension = 'thumb'
+                image.thumbnail_output_directory = test_directory
             else:
-                extension = 'jpg'
+                image.preview_output_directory = test_directory
 
-            # list of preview images
-            preview_image_filenames = glob.glob(os.path.join(test_directory, '*.{}'.format(
-                extension)))
-            assert len(preview_image_filenames) == header['NINTS']
+            image.make_image()
+        except ValueError as error:
+            print(error)
 
-            # clean up: delete preview images
-            for file in preview_image_filenames:
-                os.remove(file)
+        if create_thumbnail:
+            extension = 'thumb'
+        else:
+            extension = 'jpg'
+
+        # list of preview images
+        preview_image_filenames = glob.glob(os.path.join(test_directory, '*.{}'.format(
+            extension)))
+        assert len(preview_image_filenames) == header['NINTS']
+
+        # clean up: delete preview images
+        for file in preview_image_filenames:
+            os.remove(file)

--- a/jwql/tests/test_preview_image.py
+++ b/jwql/tests/test_preview_image.py
@@ -28,7 +28,7 @@ import shutil
 from astropy.io import fits
 
 from jwql.utils.preview_image import PreviewImage
-from jwql.utils.utils import get_config
+from jwql.utils.utils import get_config, ensure_dir_exists
 
 # directory to be created and populated during tests running
 TEST_DIRECTORY = os.path.join(os.environ['HOME'], 'preview_image_test')
@@ -53,8 +53,7 @@ def test_directory(test_dir=TEST_DIRECTORY):
 
     """
     # Set up local test directory
-    if not os.path.isdir(test_dir):
-        os.mkdir(test_dir)  # creates directory
+    ensure_dir_exists(test_dir)
     yield test_dir
 
     # Tear down local test directory and any files within


### PR DESCRIPTION
I have been struggling with tests failing locally, and I traced it back to not enough things being deleted in the teardown script for `test_preview_image`. (It wasn't the permissions thing after all, @bourque!)

This PR:
- Adds an `if `statement to avoid errors for making the local test directory if it already exists
- Removes all files in the local test directory during teardown
- Removes all thumbnails/jpgs in the test directory on central storage during teardown (Though now I am less sure as to why having files there was causing problems... hopefully this doesn't break anything unexpected?)
- Parameterizes `test_make_image()`