### PR TITLE
Fix dashboard

### DIFF
--- a/jwql/website/apps/jwql/data_containers.py
+++ b/jwql/website/apps/jwql/data_containers.py
@@ -30,14 +30,13 @@ import tempfile
 from astropy.io import fits
 from astropy.time import Time
 from astroquery.mast import Mast
-import numpy as np
 
 from jwql.edb.edb_interface import mnemonic_inventory
 from jwql.edb.engineering_database import get_mnemonic, get_mnemonic_info
 from jwql.instrument_monitors.miri_monitors.data_trending import dashboard as miri_dash
 from jwql.instrument_monitors.nirspec_monitors.data_trending import dashboard as nirspec_dash
 from jwql.jwql_monitors import monitor_cron_jobs
-from jwql.utils.constants import MONITORS
+from jwql.utils.constants import MONITORS, JWST_INSTRUMENT_NAMES_MIXEDCASE
 from jwql.utils.preview_image import PreviewImage
 from jwql.utils.utils import get_config, filename_parser
 from .forms import MnemonicSearchForm, MnemonicQueryForm, MnemonicExplorationForm
@@ -145,24 +144,9 @@ def get_dashboard_components():
     """
 
     output_dir = get_config()['outputs']
-    name_dict = {
-        '': {
-            'name': '',
-            'plots': {}
-        },
-        'monitor_mast': {
-            'name': 'Database Monitor',
-            'plots': {'database_monitor_jwst': 'JWST',
-                      'database_monitor_caom': 'JWST (CAOM)'},
-         },
-        'monitor_filesystem': {
-            'name': 'Filesystem Monitor',
-            'plots': {'filecount_type': 'Total File Counts by Type',
-                      'size_type': 'Total File Sizes by Type',
-                      'filecount': 'Total File Counts',
-                      'system_stats': 'System Statistics'},
-        }
-    }
+    name_dict = {'': '',
+                 'monitor_mast': 'Database Monitor',
+                 'monitor_filesystem': 'Filesystem Monitor'}
 
     # Run the cron job monitor to produce an updated table
     monitor_cron_jobs.status(production_mode=True)
@@ -174,34 +158,35 @@ def get_dashboard_components():
 
         # Only continue if the dashboard knows how to build that monitor
         if monitor_name in name_dict.keys():
-            formatted_monitor_name = name_dict[monitor_name]['name']
+            formatted_monitor_name = name_dict[monitor_name]
             dashboard_components[formatted_monitor_name] = {}
             for fname in file_list:
                 if 'component' in fname:
                     full_fname = '{}/{}'.format(monitor_name, fname)
                     plot_name = fname.split('_component')[0]
 
-                    # Only continue if the dashboard knows how to build that plot
-                    if plot_name in name_dict[monitor_name]['plots'].keys():
-                        formatted_plot_name = name_dict[monitor_name]['plots'][plot_name]
+                    # Generate formatted plot name
+                    formatted_plot_name = plot_name.title().replace('_', ' ')
+                    for lowercase, mixed_case in JWST_INSTRUMENT_NAMES_MIXEDCASE.items():
+                        formatted_plot_name = formatted_plot_name.replace(lowercase.capitalize(), mixed_case)
+                    formatted_plot_name = formatted_plot_name.replace('Jwst', 'JWST')
+                    formatted_plot_name = formatted_plot_name.replace('Caom', 'CAOM')
 
-                        # Get the div
-                        html_file = full_fname.split('.')[0] + '.html'
-                        with open(os.path.join(output_dir, html_file)) as f:
-                            div = f.read()
+                    # Get the div
+                    html_file = full_fname.split('.')[0] + '.html'
+                    with open(os.path.join(output_dir, html_file), 'r') as f:
+                        div = f.read()
 
-                        # Get the script
-                        js_file = full_fname.split('.')[0] + '.js'
-                        with open(os.path.join(output_dir, js_file)) as f:
-                            script = f.read()
+                    # Get the script
+                    js_file = full_fname.split('.')[0] + '.js'
+                    with open(os.path.join(output_dir, js_file), 'r') as f:
+                        script = f.read()
 
-                        print('FORMATTED MONITOR NAME:', formatted_monitor_name)
-                        print('PLOT NAME:', plot_name)
-                        # Save to dictionary
-                        dashboard_components[formatted_monitor_name][formatted_plot_name] = [div, script]
+                    # Save to dictionary
+                    dashboard_components[formatted_monitor_name][formatted_plot_name] = [div, script]
 
     # Add HTML that cannot be saved as components to the dictionary
-    with open(os.path.join(output_dir, 'monitor_cron_jobs', 'cron_status_table.html')) as f:
+    with open(os.path.join(output_dir, 'monitor_cron_jobs', 'cron_status_table.html'), 'r') as f:
         cron_status_table_html = f.read()
     dashboard_html = {}
     dashboard_html['Cron Job Monitor'] = cron_status_table_html


### PR DESCRIPTION
Closes #375.

This PR fixes the bug where the dashboard page does not load, throwing an error.

I got around it by adding checks in `data_containers/get_dashboard_components()` to only attempt to load HTML/JavaScript files from known monitors. I also added a feature to programmatically generate formatted plot names from the component files.

This means that a developer adding a new monitor to the dashboard page will need to explicitly add the monitor to `name_dict` in `data_containers/get_dashboard_components()` for it to be loaded. However, once a monitor is added to that dictionary, every plot in the output directory for that monitor will be shown.