### PR TITLE
Update Codecov settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 [![Build Status](https://ssbjenkins.stsci.edu/job/STScI/job/jwql/job/master/badge/icon)](https://ssbjenkins.stsci.edu/job/STScI/job/jwql/job/master/)
 [![Documentation Status](https://readthedocs.org/projects/jwql/badge/?version=latest)](https://jwql.readthedocs.io/en/latest/?badge=latest)
 [![STScI](https://img.shields.io/badge/powered%20by-STScI-blue.svg?colorA=707170&colorB=3e8ddd&style=flat)](http://www.stsci.edu)
+[![codecov](https://codecov.io/gh/spacetelescope/jwql/branch/develop/graph/badge.svg)](https://codecov.io/gh/spacetelescope/jwql)
 
 
 The JWST Quicklook Application (`JWQL`) is a database-driven web application and automation framework for use by the JWST instrument teams to monitor and trend the health, stability, and performance of the JWST instruments.  The system is comprised of the following:

--- a/codecov.yml
+++ b/codecov.yml
@@ -5,12 +5,12 @@ codecov:
 coverage:
   precision: 2
   round: down
-  range: "70...100"
+  range: "0...75"
 
   status:
-    project: yes
-    patch: yes
-    changes: no
+    project: off
+    patch: off
+    changes: off
 
 parsers:
   gcov:
@@ -21,11 +21,16 @@ parsers:
       macro: no
 
 comment:
-  layout: "header, diff"
+  layout: "header, diff, files"
   behavior: default
   require_changes: no
 
 ignore:
-  - "jwql/website/"
   - "jwql/database/"
+  - "jwql/instrument_monitors/miri_monitors/data_trending/plots/"
+  - "jwql/instrument_monitors/nirspec_monitors/data_trending/plots/"
+  - "jwql/website/"
   - "*__init__.py*"
+  - "**/*.html"
+  - "**/*.js"
+  - "**/*.css"

--- a/codecov.yml
+++ b/codecov.yml
@@ -29,7 +29,6 @@ ignore:
   - "jwql/database/"
   - "jwql/instrument_monitors/miri_monitors/data_trending/plots/"
   - "jwql/instrument_monitors/nirspec_monitors/data_trending/plots/"
-  - "jwql/website/"
   - "*__init__.py*"
   - "**/*.html"
   - "**/*.js"


### PR DESCRIPTION
Closes #367.

This PR updates `codecov.yml` to:
- Have a more forgiving color code, where 0% coverage is red and 75% is green (it was previously 70 and 100!!!)
- Hopefully stop adding checks to the CI that can mark the build as failed
- Add more information about the files changed by any given PR
- Ignore data trending plot files and HTML/CSS/JS files
- Include some website files in the coverage report