### PR TITLE
Adjust Jenkins node label to allow execution on RT system.

### DIFF
--- a/JenkinsfileRT
+++ b/JenkinsfileRT
@@ -3,7 +3,7 @@ if (utils.scm_checkout()) return
 
 // Define each build configuration, copying and overriding values as necessary.
 bc0 = new BuildConfig()
-bc0.nodetype = "linux-stable"
+bc0.nodetype = "linux"
 bc0.name = "debug"
 bc0.build_cmds = ["conda env update --file=environment.yml",
 	       	  "with_env -n jwql python setup.py install"]
@@ -20,3 +20,4 @@ bc0.failedFailureThresh = 1
 // Iterate over configurations that define the (distibuted) build matrix.
 // Spawn a host of the given nodetype for each combination and run in parallel.
 utils.run([bc0])
+


### PR DESCRIPTION
The node label `linux-stable` is only honored on the CI system. The periodically scheduled RT job will continue to fail until the node label is changed.