### PR TITLE
Add sed command to remove invalid attrs from junit xml

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,7 @@ withCredentials([string(
           "python setup.py install"]
       bc.test_cmds = [
           "pytest -s --junitxml=results.xml --cov=./jwql/ --cov-report=xml:coverage.xml",
-          "sed -i 's/file=\".*\"//g;s/line=\".*\"//g' results.xml",
+          "sed -i 's/file=\"[^\"]*\"//g;s/line=\"[^\"]*\"//g;s/skips=\"[^\"]*\"//g' results.xml",
           "codecov --token=${codecov_token}",
           "mkdir -v reports",
           "mv -v coverage.xml reports/coverage.xml"]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,6 +23,7 @@ withCredentials([string(
           "python setup.py install"]
       bc.test_cmds = [
           "pytest -s --junitxml=results.xml --cov=./jwql/ --cov-report=xml:coverage.xml",
+          "sed -i 's/file=\".*\"//g;s/line=\".*\"//g' coverage.xml",
           "codecov --token=${codecov_token}",
           "mkdir -v reports",
           "mv -v coverage.xml reports/coverage.xml"]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,7 @@ withCredentials([string(
           "python setup.py install"]
       bc.test_cmds = [
           "pytest -s --junitxml=results.xml --cov=./jwql/ --cov-report=xml:coverage.xml",
-          "sed -i 's/file=\".*\"//g;s/line=\".*\"//g' coverage.xml",
+          "sed -i 's/file=\".*\"//g;s/line=\".*\"//g' results.xml",
           "codecov --token=${codecov_token}",
           "mkdir -v reports",
           "mv -v coverage.xml reports/coverage.xml"]


### PR DESCRIPTION
Addresses an issue found in #398 (this does not address the specific failing test, only the issue where the failing test is not failing the build)

Pytest failures are not failing the build for python 3.5. This was due to the latest version of pytest for python 3.5 is pytest 3.8.1. Junit family config option was added in pytest 4.2 which is needed to make the pytest junit xml ingestible by jenkins.

Added sed command to (hopefully) manually strip unknown attributes from the xml to please jenkins.