### PR TITLE
Fix test_get_pipeline_steps for python 3.5

### DIFF
--- a/jwql/tests/test_pipeline_tools.py
+++ b/jwql/tests/test_pipeline_tools.py
@@ -64,7 +64,7 @@ def test_get_pipeline_steps():
     instrument
     """
 
-    # FGS, NIRCam, and NIRISS have the same required steps
+    # FGS, NIRCam, and NIRISS
     instruments = ['fgs', 'nircam', 'niriss']
     for instrument in instruments:
         req_steps = pipeline_tools.get_pipeline_steps(instrument)
@@ -76,9 +76,12 @@ def test_get_pipeline_steps():
             steps_dict[step] = True
         for step in not_required:
             steps_dict[step] = False
-        assert dict(req_steps) == dict(steps_dict)
+        # Only test steps that have a value of True
+        req_steps = OrderedDict((k, v) for k, v in req_steps.items() if v is True)
+        steps_dict = OrderedDict((k, v) for k, v in steps_dict.items() if v is True)
+        assert req_steps == steps_dict
 
-    # NIRSpec and MIRI have different required steps
+    # NIRSpec
     nrs_req_steps = pipeline_tools.get_pipeline_steps('nirspec')
     nrs_steps = ['group_scale', 'dq_init', 'saturation', 'superbias', 'refpix', 'linearity',
                  'dark_current', 'jump', 'rate']
@@ -88,8 +91,12 @@ def test_get_pipeline_steps():
         nrs_dict[step] = True
     for step in not_required:
         nrs_dict[step] = False
-    assert dict(nrs_req_steps) == dict(nrs_dict)
+    # Only test steps that have a value of True
+    nrs_req_steps = OrderedDict((k, v) for k, v in nrs_req_steps.items() if v is True)
+    nrs_dict = OrderedDict((k, v) for k, v in nrs_dict.items() if v is True)
+    assert nrs_req_steps == nrs_dict
 
+    # MIRI
     miri_req_steps = pipeline_tools.get_pipeline_steps('miri')
     miri_steps = ['dq_init', 'saturation', 'firstframe', 'lastframe',
                   'linearity', 'rscd', 'dark_current', 'refpix', 'jump', 'rate']
@@ -99,7 +106,10 @@ def test_get_pipeline_steps():
         miri_dict[step] = True
     for step in not_required:
         miri_dict[step] = False
-    assert dict(miri_req_steps) == dict(miri_dict)
+    # Only test steps that have a value of True
+    miri_req_steps = OrderedDict((k, v) for k, v in miri_req_steps.items() if v is True)
+    miri_dict = OrderedDict((k, v) for k, v in miri_dict.items() if v is True)
+    assert miri_req_steps == miri_dict
 
 
 @pytest.mark.skipif(os.path.expanduser('~') == '/home/jenkins',

--- a/jwql/tests/test_pipeline_tools.py
+++ b/jwql/tests/test_pipeline_tools.py
@@ -56,7 +56,7 @@ def test_completed_pipeline_steps():
                                   ('jump', True),
                                   ('rate', True)])
 
-    assert completed_steps == true_completed
+    assert dict(completed_steps) == dict(true_completed)
 
 
 def test_get_pipeline_steps():
@@ -67,16 +67,16 @@ def test_get_pipeline_steps():
     # FGS, NIRCam, and NIRISS have the same required steps
     instruments = ['fgs', 'nircam', 'niriss']
     for instrument in instruments:
-      req_steps = pipeline_tools.get_pipeline_steps(instrument)
-      steps = ['dq_init', 'saturation', 'superbias', 'refpix', 'linearity',
-               'persistence', 'dark_current', 'jump', 'rate']
-      not_required = ['group_scale', 'ipc', 'firstframe', 'lastframe', 'rscd']
-      steps_dict = OrderedDict({})
-      for step in steps:
-          steps_dict[step] = True
-      for step in not_required:
-          steps_dict[step] = False
-      assert req_steps == steps_dict
+        req_steps = pipeline_tools.get_pipeline_steps(instrument)
+        steps = ['dq_init', 'saturation', 'superbias', 'refpix', 'linearity',
+                 'persistence', 'dark_current', 'jump', 'rate']
+        not_required = ['group_scale', 'ipc', 'firstframe', 'lastframe', 'rscd']
+        steps_dict = OrderedDict({})
+        for step in steps:
+            steps_dict[step] = True
+        for step in not_required:
+            steps_dict[step] = False
+        assert dict(req_steps) == dict(steps_dict)
 
     # NIRSpec and MIRI have different required steps
     nrs_req_steps = pipeline_tools.get_pipeline_steps('nirspec')
@@ -88,7 +88,7 @@ def test_get_pipeline_steps():
         nrs_dict[step] = True
     for step in not_required:
         nrs_dict[step] = False
-    assert nrs_req_steps == nrs_dict
+    assert dict(nrs_req_steps) == dict(nrs_dict)
 
     miri_req_steps = pipeline_tools.get_pipeline_steps('miri')
     miri_steps = ['dq_init', 'saturation', 'firstframe', 'lastframe',
@@ -99,7 +99,7 @@ def test_get_pipeline_steps():
         miri_dict[step] = True
     for step in not_required:
         miri_dict[step] = False
-    assert miri_req_steps == miri_dict
+    assert dict(miri_req_steps) == dict(miri_dict)
 
 
 @pytest.mark.skipif(os.path.expanduser('~') == '/home/jenkins',


### PR DESCRIPTION
This PR modifies `test_pipeline_tools` in order to get the tests within to pass in a Python 3.5 environment.

Closes #398 
