### PR TITLE
Fix web app redirect issues

### DIFF
--- a/jwql/website/apps/jwql/oauth.py
+++ b/jwql/website/apps/jwql/oauth.py
@@ -121,7 +121,8 @@ def authorize(request):
     cookie_args['httponly'] = True
 
     # Set the cookie
-    response = redirect(PREV_PAGE)
+    if PREV_PAGE is not '':
+        response = redirect(PREV_PAGE)
     response.set_cookie("ASB-AUTH", token["access_token"], **cookie_args)
 
     return response

--- a/jwql/website/apps/jwql/oauth.py
+++ b/jwql/website/apps/jwql/oauth.py
@@ -48,7 +48,7 @@ import jwql
 from jwql.utils.constants import MONITORS
 from jwql.utils.utils import get_base_url, get_config
 
-PREV_PAGE = ''
+PREV_PAGE = '/'
 
 
 def register_oauth():
@@ -121,8 +121,7 @@ def authorize(request):
     cookie_args['httponly'] = True
 
     # Set the cookie
-    if PREV_PAGE is not '':
-        response = redirect(PREV_PAGE)
+    response = redirect(PREV_PAGE)
     response.set_cookie("ASB-AUTH", token["access_token"], **cookie_args)
 
     return response


### PR DESCRIPTION
This PR fixes a bug wherein the web app crashes on the dev server when trying to redirect to the previous page after login; if the user has not yet visited another page within the web app, there exists no view for the previous page.

Addresses concerns in #406 