### PR TITLE
Add bokeh version test

### DIFF
--- a/jwql/tests/test_plotting.py
+++ b/jwql/tests/test_plotting.py
@@ -21,9 +21,11 @@ Use
 import glob
 import os
 import re
+import sys
 
 import bokeh
 from pandas import DataFrame
+import pytest
 
 from jwql.utils.plotting import bar_chart
 
@@ -46,6 +48,8 @@ def test_bar_chart():
     assert str(type(plt)) == "<class 'bokeh.plotting.figure.Figure'>"
 
 
+@pytest.mark.skipif(sys.version_info[:2] != (3, 6),
+                    reason="Web server run on Python 3.6")
 def test_bokeh_version():
     """Make sure that the current version of Bokeh matches the version being
     used in all the web app HTML templates.

--- a/jwql/tests/test_plotting.py
+++ b/jwql/tests/test_plotting.py
@@ -65,6 +65,7 @@ def test_bokeh_version():
 
         # Find all of the times "bokeh-#.#.#' appears in a template
         html_versions = re.findall(r'(?<=bokeh-)\d+\.\d+\.\d+', content)
+        html_versions += re.findall(r'(?<=bokeh-widgets-)\d+\.\d+\.\d+', content)
 
         # Make sure they all match the environment version
         for version in html_versions:


### PR DESCRIPTION
I was inspired (frustrated?) by #425 to write up a quick test that will fail if the Bokeh versions in our HTML templates don't match our environment.

(This will fail Jenkins until #429 is merged.)