### PR TITLE
Increase width of footer object containing jwql version number

### DIFF
--- a/jwql/website/apps/jwql/static/css/jwql.css
+++ b/jwql/website/apps/jwql/static/css/jwql.css
@@ -482,7 +482,7 @@ display : inline;
 /*Format the version identifier text in bottom corner*/
 #version-div {
   float: right;
-  width: 120px;
+  width: 180px;
   text-align: right;
   color: white;
   font-size: 12px


### PR DESCRIPTION
This PR fixes a bug that was causing the JWQL version number in the footer of the web app to fall below the footer itself.

Simple fix. I increased the size of the text box containing the version number and it returned to the footer where it should be.

Closes #435