### PR TITLE
Update web app to use django 2.2

### DIFF
--- a/environment_python_3_6.yml
+++ b/environment_python_3_6.yml
@@ -7,7 +7,7 @@ dependencies:
 - astroquery=0.3.9
 - bokeh=1.2.0
 - crds>=7.2.7
-- django=2.1.7
+- django=2.2.1
 - inflection=0.3.1
 - ipython=7.5.0
 - jinja2=2.10
@@ -26,6 +26,7 @@ dependencies:
 - sphinx=2.1.0
 - sphinx_rtd_theme=0.1.9
 - sqlalchemy=1.3.4
+- sqlparse=0.3.0
 - stsci_rtd_theme=0.0.2
 - twine=1.13.0
 - pip:

--- a/jwql/website/apps/jwql/views.py
+++ b/jwql/website/apps/jwql/views.py
@@ -383,7 +383,7 @@ def instrument(request, inst):
     return render(request, template, context)
 
 
-def not_found(request):
+def not_found(request, *kwargs):
     """Generate a ``not_found`` page
 
     Parameters

--- a/jwql/website/jwql_proj/settings.py
+++ b/jwql/website/jwql_proj/settings.py
@@ -73,9 +73,22 @@ TEMPLATES = [
         'OPTIONS': {
             'environment': 'jwql.website.jwql_proj.jinja2.environment',
             'extensions': ['jwql.website.jwql_proj.jinja2.DjangoNow'],
-            'context_processors': ['jwql.website.apps.jwql.context_processors.base_context'],
+            'context_processors': [
+                'jwql.website.apps.jwql.context_processors.base_context',
+            ],
         },
-    }
+    },
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.contrib.auth.context_processors.auth',
+                'django.contrib.messages.context_processors.messages'
+            ],
+        },
+    },
 ]
 
 WSGI_APPLICATION = 'jwql.website.jwql_proj.wsgi.application'


### PR DESCRIPTION
This PR provides various changes to get the web app working with `django` version 2.2. 

The new version requires the existence of a define `django.template.backends.django.DjangoTemplates` `TEMPLATE`.  Also, some `not_found` requests now also require additional parameters such as `exception`, which have been wrapped up in a `*args` parameter.