### PR TITLE
Fix guass_peak typo in column names

### DIFF
--- a/jwql/database/monitor_table_definitions/fgs/fgs_dark_dark_current.txt
+++ b/jwql/database/monitor_table_definitions/fgs/fgs_dark_dark_current.txt
@@ -4,7 +4,7 @@ MEAN, float
 STDEV, float
 SOURCE_FILES, string_array_1d
 GAUSS_AMPLITUDE, float_array_1d
-GUASS_PEAK, float_array_1d
+GAUSS_PEAK, float_array_1d
 GAUSS_WIDTH, float_array_1d
 GAUSS_CHISQ, float
 DOUBLE_GAUSS_AMPLITUDE1, float_array_1d

--- a/jwql/database/monitor_table_definitions/miri/miri_dark_dark_current.txt
+++ b/jwql/database/monitor_table_definitions/miri/miri_dark_dark_current.txt
@@ -4,7 +4,7 @@ MEAN, float
 STDEV, float
 SOURCE_FILES, string_array_1d
 GAUSS_AMPLITUDE, float_array_1d
-GUASS_PEAK, float_array_1d
+GAUSS_PEAK, float_array_1d
 GAUSS_WIDTH, float_array_1d
 GAUSS_CHISQ, float
 DOUBLE_GAUSS_AMPLITUDE1, float_array_1d

--- a/jwql/database/monitor_table_definitions/nircam/nircam_dark_dark_current.txt
+++ b/jwql/database/monitor_table_definitions/nircam/nircam_dark_dark_current.txt
@@ -4,7 +4,7 @@ MEAN, float
 STDEV, float
 SOURCE_FILES, string_array_1d
 GAUSS_AMPLITUDE, float_array_1d
-GUASS_PEAK, float_array_1d
+GAUSS_PEAK, float_array_1d
 GAUSS_WIDTH, float_array_1d
 GAUSS_CHISQ, float
 DOUBLE_GAUSS_AMPLITUDE1, float_array_1d

--- a/jwql/database/monitor_table_definitions/niriss/niriss_dark_dark_current.txt
+++ b/jwql/database/monitor_table_definitions/niriss/niriss_dark_dark_current.txt
@@ -4,7 +4,7 @@ MEAN, float
 STDEV, float
 SOURCE_FILES, string_array_1d
 GAUSS_AMPLITUDE, float_array_1d
-GUASS_PEAK, float_array_1d
+GAUSS_PEAK, float_array_1d
 GAUSS_WIDTH, float_array_1d
 GAUSS_CHISQ, float
 DOUBLE_GAUSS_AMPLITUDE1, float_array_1d

--- a/jwql/database/monitor_table_definitions/nirspec/nirspec_dark_dark_current.txt
+++ b/jwql/database/monitor_table_definitions/nirspec/nirspec_dark_dark_current.txt
@@ -4,7 +4,7 @@ MEAN, float
 STDEV, float
 SOURCE_FILES, string_array_1d
 GAUSS_AMPLITUDE, float_array_1d
-GUASS_PEAK, float_array_1d
+GAUSS_PEAK, float_array_1d
 GAUSS_WIDTH, float_array_1d
 GAUSS_CHISQ, float
 DOUBLE_GAUSS_AMPLITUDE1, float_array_1d


### PR DESCRIPTION
This PR fixes typos in some of the column names of the *dark_dark_current database tables used by the dark current monitor. Prior to this fix, one of the column names was "guass_peak" when it should have been "gauss_peak".

Closes #452