### PR TITLE
Updates to 3.6 conda environment to get it working on a linux distro

### DIFF
--- a/environment_python_3_6.yml
+++ b/environment_python_3_6.yml
@@ -2,11 +2,11 @@ channels:
 - http://ssb.stsci.edu/astroconda-dev
 - defaults
 dependencies:
-- asdf=2.3.1
+- asdf=1.2.1
 - astropy>=3.1.2
 - astroquery=0.3.9
 - bokeh=1.3.2
-- crds>=7.2.7
+- crds=7.3.3
 - django=2.2.1
 - inflection=0.3.1
 - ipython=7.7.0
@@ -17,6 +17,7 @@ dependencies:
 - numpy=1.16.4
 - numpydoc=0.9.0
 - pandas=0.24.2
+- pip=19.1.1
 - postgresql=9.6.6
 - psycopg2=2.7.5
 - python=3.6.4
@@ -24,6 +25,7 @@ dependencies:
 - pytest=5.0.1
 - pytest-cov=2.7.1
 - pytest-html=1.19.0
+- setuptools=41.0.1
 - sphinx=2.1.0
 - sphinx_rtd_theme=0.1.9
 - sqlalchemy=1.3.5

--- a/environment_python_3_6.yml
+++ b/environment_python_3_6.yml
@@ -3,7 +3,6 @@ channels:
 - defaults
 dependencies:
 - asdf=1.2.1
-- astropy>=3.1.2
 - astroquery=0.3.9
 - bokeh=1.3.2
 - crds=7.3.3
@@ -34,6 +33,7 @@ dependencies:
 - twine=1.13.0
 - pip:
   - authlib==0.10
+  - astropy==3.2.1
   - codecov==2.0.15
   - jwedb>=0.0.3
   - pysiaf==0.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 asdf>=2.3.0
-astropy>=3.0
+astropy==3.2.1
 astroquery==0.3.9
 authlib==0.11
 bokeh==1.3.2

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ AUTHORS += 'Graham Kanarek, Catherine Martlin, Johannes Sahlmann'
 DESCRIPTION = 'The James Webb Space Telescope Quicklook Project'
 
 REQUIRES = [
-    'astropy',
+    'astropy>=3.2.1',
     'astroquery>=0.3.9',
     'authlib',
     'bokeh>=1.0',


### PR DESCRIPTION
This PR updates the `environment_python_3.6.yml`/`jwql-3.6` `conda` environment with some small tweaks to make sure the environment works on a linux distribution. I had run into some issues with the current environment when trying to install on a linux box.