### PR TITLE
Simplify conda environments

### DIFF
--- a/environment_python_3_5.yml
+++ b/environment_python_3_5.yml
@@ -1,37 +1,36 @@
 channels:
-- http://ssb.stsci.edu/astroconda-dev
 - defaults
+- http://ssb.stsci.edu/astroconda-dev
 dependencies:
-- asdf=2.3.0
-- astropy>=3.1.2
 - astroquery=0.3.9
-- bokeh=0.13.0
-- crds>=7.2.7
-- django=2.1.1
+- bokeh=1.3.2
+- django=2.2.1
+- flake8=3.7.7
 - inflection=0.3.1
-- ipython=6.5.0
+- ipython=7.7.0
 - jinja2=2.10
-- jsonschema>=2.6.0
+- jsonschema=2.6.0
 - jwst=0.13.0
-- matplotlib=3.0.0
-- numpy=1.15.2
-- numpydoc=0.8.0
-- pandas=0.23.4
+- matplotlib=3.1.0
+- numpy=1.16.4
+- numpydoc=0.9.0
+- pandas=0.24.2
+- pip=19.1.1
 - postgresql=9.6.6
 - psycopg2=2.7.5
-- python=3.5.6
-- python-dateutil=2.7.3
-- pytest=3.8.1
-- pytest-cov=2.6.0
-- pytest-html=1.19.0
-- sphinx=2.0.1
-- sphinx_rtd_theme=0.1.9
-- sqlalchemy=1.2.11
+- python=3.6.4
+- pytest=5.0.1
+- pytest-cov=2.7.1
+- scipy=1.3.0
+- setuptools=41.0.1
+- sphinx=2.1.0
+- sqlalchemy=1.3.5
 - stsci_rtd_theme=0.0.2
-- twine=1.11.0
+- twine=1.13.0
 - pip:
-  - authlib==0.10
+  - astropy==3.2.1
+  - authlib==0.11
   - codecov==2.0.15
   - jwedb>=0.0.3
-  - pysiaf==0.2.5
-  - sphinx-automodapi==0.10
+  - pysiaf==0.3.1
+  - pysqlite3==0.2.2

--- a/environment_python_3_5.yml
+++ b/environment_python_3_5.yml
@@ -28,6 +28,7 @@ dependencies:
 - stsci_rtd_theme=0.0.2
 - twine=1.13.0
 - pip:
+  - asdf==2.3.3
   - astropy==3.2.1
   - authlib==0.11
   - codecov==2.0.15

--- a/environment_python_3_6.yml
+++ b/environment_python_3_6.yml
@@ -28,6 +28,7 @@ dependencies:
 - stsci_rtd_theme=0.0.2
 - twine=1.13.0
 - pip:
+  - asdf==2.3.3
   - astropy==3.2.1
   - authlib==0.11
   - codecov==2.0.15

--- a/environment_python_3_6.yml
+++ b/environment_python_3_6.yml
@@ -1,17 +1,16 @@
 channels:
-- http://ssb.stsci.edu/astroconda-dev
 - defaults
+- http://ssb.stsci.edu/astroconda-dev
 dependencies:
-- asdf=1.2.1
 - astroquery=0.3.9
 - bokeh=1.3.2
-- crds=7.3.3
 - django=2.2.1
+- flake8=3.7.7
 - inflection=0.3.1
 - ipython=7.7.0
 - jinja2=2.10
 - jsonschema=2.6.0
-- jwst=0.13.1
+- jwst=0.13.0
 - matplotlib=3.1.0
 - numpy=1.16.4
 - numpydoc=0.9.0
@@ -20,21 +19,18 @@ dependencies:
 - postgresql=9.6.6
 - psycopg2=2.7.5
 - python=3.6.4
-- python-dateutil=2.7.5
 - pytest=5.0.1
 - pytest-cov=2.7.1
-- pytest-html=1.19.0
+- scipy=1.3.0
 - setuptools=41.0.1
 - sphinx=2.1.0
-- sphinx_rtd_theme=0.1.9
 - sqlalchemy=1.3.5
-- sqlparse=0.3.0
 - stsci_rtd_theme=0.0.2
 - twine=1.13.0
 - pip:
-  - authlib==0.10
   - astropy==3.2.1
+  - authlib==0.11
   - codecov==2.0.15
   - jwedb>=0.0.3
   - pysiaf==0.3.1
-  - sphinx-automodapi==0.10
+  - pysqlite3==0.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+asdf==2.3.3
 astropy==3.2.1
 astroquery==0.3.9
 authlib==0.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,10 @@
-asdf>=2.3.0
 astropy==3.2.1
 astroquery==0.3.9
 authlib==0.11
 bokeh==1.3.2
+codecov==2.0.15
 django==2.2.4
+flake8==3.7.7
 inflection==0.3.1
 ipython==7.7.0
 jinja2==2.10.1
@@ -15,11 +16,11 @@ numpydoc==0.9.1
 pandas==0.25.0
 psycopg2==2.8.3
 pysiaf==0.3.1
-python-dateutil==2.8.0
 pytest==5.0.1
 pytest-cov==2.7.1
+scipy==1.3.0
 sphinx==2.1.2
-sphinx-automodapi==0.11
 sqlalchemy==1.3.6
 stsci_rtd_theme==0.0.2
+twine==1.13.0
 git+https://github.com/spacetelescope/jwst@stable

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ REQUIRES = [
     'pandas',
     'psycopg2',
     'pysiaf',
-    'pysqlite3',
     'pytest',
     'pytest-cov',
     'scipy',

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ AUTHORS += 'Graham Kanarek, Catherine Martlin, Johannes Sahlmann, Ben Sunnquist'
 DESCRIPTION = 'The James Webb Space Telescope Quicklook Project'
 
 REQUIRES = [
+    'asdf>=2.3.3',
     'astropy>=3.2.1',
     'astroquery>=0.3.9',
     'authlib',

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,8 @@ from setuptools import find_packages
 
 VERSION = '0.21.0'
 
-AUTHORS = 'Matthew Bourque, Lauren Chambers, Misty Cracraft, Joe Filippazzo, Bryan Hilbert, '
-AUTHORS += 'Graham Kanarek, Catherine Martlin, Johannes Sahlmann'
+AUTHORS = 'Matthew Bourque, Misty Cracraft, Joe Filippazzo, Bryan Hilbert, '
+AUTHORS += 'Graham Kanarek, Catherine Martlin, Johannes Sahlmann, Ben Sunnquist'
 
 DESCRIPTION = 'The James Webb Space Telescope Quicklook Project'
 
@@ -14,21 +14,29 @@ REQUIRES = [
     'astroquery>=0.3.9',
     'authlib',
     'bokeh>=1.0',
+    'codecov',
     'django>=2.0',
+    'flake8',
+    'inflection',
+    'ipython',
     'jinja2',
     'jsonschema==2.6.0',
-    'jwedb',
-    'jwst',
+    'jwedb>=0.0.3',
+    'jwst==0.13.0',
     'matplotlib',
     'numpy',
     'numpydoc',
     'pandas',
     'psycopg2',
     'pysiaf',
+    'pysqlite3',
     'pytest',
+    'pytest-cov',
+    'scipy',
     'sphinx',
     'sqlalchemy',
-    'stsci_rtd_theme'
+    'stsci_rtd_theme',
+    'twine'
 ]
 
 setup(


### PR DESCRIPTION
This PR makes changes to the `jwql` `conda` environments, `setup.py`, and `requirements.txt` so that they are all consistent and only include those dependencies that are explicitly used within the `jwql` package.

Closes #481 