### PR TITLE
[WIP]: Add auto-complete for form fields

### DIFF
--- a/jwql/website/apps/jwql/api_views.py
+++ b/jwql/website/apps/jwql/api_views.py
@@ -214,7 +214,6 @@ class ProposalAutocomplete(autocomplete.Select2ListView):
         # 'results' as the key rather than 'proposals', just in case
         # autocomplete cares.
         proposals = get_all_proposals_no_leading_zeros()
-        #props_no_leading_zeros = [p.strip('0') for p in proposals]
         return proposals
 
 

--- a/jwql/website/apps/jwql/api_views.py
+++ b/jwql/website/apps/jwql/api_views.py
@@ -44,9 +44,11 @@ References
         ``https://docs.djangoproject.com/en/2.0/topics/http/views/``
 """
 
+from dal import autocomplete
 from django.http import JsonResponse
 
 from .data_containers import get_all_proposals
+from .data_containers import get_all_proposals_no_leading_zeros
 from .data_containers import get_filenames_by_proposal
 from .data_containers import get_filenames_by_rootname
 from .data_containers import get_instrument_proposals
@@ -204,6 +206,16 @@ def preview_images_by_rootname(request, rootname):
 
     preview_images = get_preview_images_by_rootname(rootname)
     return JsonResponse({'preview_images': preview_images}, json_dumps_params={'indent': 2})
+
+
+class ProposalAutocomplete(autocomplete.Select2ListView):
+    def get_list(self):
+        # This is essentially the same view as all_proposals, but with
+        # 'results' as the key rather than 'proposals', just in case
+        # autocomplete cares.
+        proposals = get_all_proposals_no_leading_zeros()
+        #props_no_leading_zeros = [p.strip('0') for p in proposals]
+        return proposals
 
 
 def thumbnails_by_instrument(request, inst):

--- a/jwql/website/apps/jwql/data_containers.py
+++ b/jwql/website/apps/jwql/data_containers.py
@@ -147,6 +147,20 @@ def get_all_proposals():
     return proposals
 
 
+def get_all_proposals_no_leading_zeros():
+    """Return a list of all proposals that exist in the filesystem.
+
+    Returns
+    -------
+    proposals : list
+        A list of proposal numbers for all proposals that exist in the
+        filesystem, with leading zeros stripped off
+    """
+    props = get_all_proposals()
+    props_no_leading_zeros = [p.strip('0') for p in props]
+    return props_no_leading_zeros
+
+
 def get_current_flagged_anomalies(rootname):
     """Return a list of currently flagged anomalies for the given
     ``rootname``

--- a/jwql/website/apps/jwql/forms.py
+++ b/jwql/website/apps/jwql/forms.py
@@ -93,33 +93,25 @@ class AnomalySubmitForm(forms.Form):
             data_dict[choice] = True
         di.engine.execute(di.Anomaly.__table__.insert(), data_dict)
 
-#def get_proposal_number_choice_list():
-#    return ['00001', '11111', '22222', '33333', '44444', '55555', '66666', '77777', '88888', '99999']
-
-FILESYSTEM_DIR = os.path.join(get_config()['jwql_dir'], 'filesystem')
-def get_all_proposals_no_leading_zeros():
-    """Return a list of all proposals that exist in the filesystem.
-
-    Returns
-    -------
-    proposals : list
-        A list of proposal numbers for all proposals that exist in the
-        filesystem, with leading zeros stripped off
-    """
-    proposals = glob.glob(os.path.join(FILESYSTEM_DIR, '*'))
-    proposals = [proposal.split('jw')[-1] for proposal in proposals]
-    proposals = [proposal for proposal in proposals if len(proposal) == 5]
-    props_no_leading_zeros = [p.strip('0') for p in proposals]
-    return props_no_leading_zeros
-
+#from django.db import models
+#class FileSearchModel(models.Model):
+#    search = models.CharField(max_length=500)
 
 
 class FileSearchForm(forms.Form):
     """Single-field form to search for a proposal or fileroot."""
+
+#    class Meta:
+#        model = FileSearchModel
+#        fields = ('__all__')
+#        widgets = {'search': autocomplete.ListSelect2(url='proposal-list-autocomplete')}
+
     search = forms.CharField(label='', max_length=500, required=True,
-                             queryset=get_all_proposals_no_leading_zeros(),
                              widget=autocomplete.ListSelect2(url='proposal-list-autocomplete'),
                              empty_value='Search')
+    #class Meta:
+    #    model = Proposal
+    #    fields = ('__all__')
     #search = autocomplete.ListSelect2(url='proposal-list-autocomplete')
 
     # Define search field

--- a/jwql/website/apps/jwql/forms.py
+++ b/jwql/website/apps/jwql/forms.py
@@ -47,6 +47,7 @@ import glob
 import os
 
 from astropy.time import Time, TimeDelta
+from dal import autocomplete
 from django import forms
 from django.shortcuts import redirect
 from jwedb.edb_interface import is_valid_mnemonic
@@ -54,6 +55,9 @@ from jwedb.edb_interface import is_valid_mnemonic
 from jwql.database import database_interface as di
 from jwql.utils.constants import ANOMALY_CHOICES, JWST_INSTRUMENT_NAMES_SHORTHAND
 from jwql.utils.utils import get_config, filename_parser
+#from jwql.website.apps.jwql import data_containers
+#from .data_containers import get_all_proposals_no_leading_zeros
+
 
 FILESYSTEM_DIR = os.path.join(get_config()['jwql_dir'], 'filesystem')
 
@@ -89,13 +93,38 @@ class AnomalySubmitForm(forms.Form):
             data_dict[choice] = True
         di.engine.execute(di.Anomaly.__table__.insert(), data_dict)
 
+#def get_proposal_number_choice_list():
+#    return ['00001', '11111', '22222', '33333', '44444', '55555', '66666', '77777', '88888', '99999']
+
+FILESYSTEM_DIR = os.path.join(get_config()['jwql_dir'], 'filesystem')
+def get_all_proposals_no_leading_zeros():
+    """Return a list of all proposals that exist in the filesystem.
+
+    Returns
+    -------
+    proposals : list
+        A list of proposal numbers for all proposals that exist in the
+        filesystem, with leading zeros stripped off
+    """
+    proposals = glob.glob(os.path.join(FILESYSTEM_DIR, '*'))
+    proposals = [proposal.split('jw')[-1] for proposal in proposals]
+    proposals = [proposal for proposal in proposals if len(proposal) == 5]
+    props_no_leading_zeros = [p.strip('0') for p in proposals]
+    return props_no_leading_zeros
+
+
 
 class FileSearchForm(forms.Form):
     """Single-field form to search for a proposal or fileroot."""
+    search = forms.CharField(label='', max_length=500, required=True,
+                             queryset=get_all_proposals_no_leading_zeros(),
+                             widget=autocomplete.ListSelect2(url='proposal-list-autocomplete'),
+                             empty_value='Search')
+    #search = autocomplete.ListSelect2(url='proposal-list-autocomplete')
 
     # Define search field
-    search = forms.CharField(label='', max_length=500, required=True,
-                             empty_value='Search')
+    #search = forms.CharField(label='', max_length=500, required=True,
+    #                         empty_value='Search')
 
     # Initialize attributes
     fileroot_dict = None

--- a/jwql/website/apps/jwql/urls.py
+++ b/jwql/website/apps/jwql/urls.py
@@ -70,7 +70,6 @@ urlpatterns = [
     path('about/', views.about, name='about'),
     path('dashboard/', views.dashboard, name='dashboard'),
     path('edb/', views.engineering_database, name='edb'),
-    re_path(r'^proposal-list-autocomplete/$', api_views.ProposalAutocomplete.as_view(), name='proposal-list-autocomplete'),
     re_path(r'^(?P<inst>({}))/$'.format(instruments), views.instrument, name='instrument'),
     re_path(r'^(?P<inst>({}))/archive/$'.format(instruments), views.archived_proposals, name='archive'),
     re_path(r'^(?P<inst>({}))/unlooked/$'.format(instruments), views.unlooked_images, name='unlooked'),
@@ -84,6 +83,7 @@ urlpatterns = [
 
     # REST API views
     path('api/proposals/', api_views.all_proposals, name='all_proposals'),
+    path('api/proposal_list_autocomplete/', api_views.ProposalAutocomplete.as_view(), name='proposal-list-autocomplete'),
     re_path(r'^api/(?P<inst>({}))/proposals/$'.format(instruments), api_views.instrument_proposals, name='instrument_proposals'),
     re_path(r'^api/(?P<inst>({}))/preview_images/$'.format(instruments), api_views.preview_images_by_instrument, name='preview_images_by_instrument'),
     re_path(r'^api/(?P<inst>({}))/thumbnails/$'.format(instruments), api_views.thumbnails_by_instrument, name='thumbnails_by_instrument'),

--- a/jwql/website/apps/jwql/urls.py
+++ b/jwql/website/apps/jwql/urls.py
@@ -70,6 +70,7 @@ urlpatterns = [
     path('about/', views.about, name='about'),
     path('dashboard/', views.dashboard, name='dashboard'),
     path('edb/', views.engineering_database, name='edb'),
+    re_path(r'^proposal-list-autocomplete/$', api_views.ProposalAutocomplete.as_view(), name='proposal-list-autocomplete'),
     re_path(r'^(?P<inst>({}))/$'.format(instruments), views.instrument, name='instrument'),
     re_path(r'^(?P<inst>({}))/archive/$'.format(instruments), views.archived_proposals, name='archive'),
     re_path(r'^(?P<inst>({}))/unlooked/$'.format(instruments), views.unlooked_images, name='unlooked'),

--- a/jwql/website/jwql_proj/settings.py
+++ b/jwql/website/jwql_proj/settings.py
@@ -45,6 +45,8 @@ ALLOWED_HOSTS = ['*']
 # Application definition
 INSTALLED_APPS = [
     'jwql.website.apps.jwql',
+    'dal',
+    'dal_select2',
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ REQUIRES = [
     'bokeh>=1.0',
     'codecov',
     'django>=2.0',
+    'django-autocomplete-light',
     'flake8',
     'inflection',
     'ipython',


### PR DESCRIPTION
This PR adds autocomplete to several of the fields on the webapp forms. This is done using django-autocomplete-lite, which is a new dependency. 

At the moment this is work in progress. I've started by trying to apply autocomplete to the proposal search field on the web app's main page.

Other fields that could benefit from autocomplete include several on the EDB page.