### PR TITLE
Fix typo in monitor table

### DIFF
--- a/jwql/database/database_interface.py
+++ b/jwql/database/database_interface.py
@@ -218,7 +218,7 @@ class Monitor(base):
     monitor_name = Column(String(), nullable=False)
     start_time = Column(DateTime, nullable=False)
     end_time = Column(DateTime, nullable=True)
-    status = Column(Enum('SUCESS', 'FAILURE', name='monitor_status'), nullable=True)
+    status = Column(Enum('SUCCESS', 'FAILURE', name='monitor_status'), nullable=True)
     affected_tables = Column(ARRAY(String, dimensions=1), nullable=True)
     log_file = Column(String(), nullable=False)
 


### PR DESCRIPTION
This PR fixes a small typo in the `status` field of the `monitor` database table.  This typo has been causing errors in the `dark_monitor` when it completes and tries to update this table. 