### PR TITLE
Allow arrow keys to change which integration image is showing

### DIFF
--- a/jwql/website/apps/jwql/templates/view_image.html
+++ b/jwql/website/apps/jwql/templates/view_image.html
@@ -109,6 +109,22 @@
 	    	<a>Lauren needs to figure out what to do with these: {{suffixes}}</a>
 	    {% endif %}
 
+        <!-- Allow right/left arrow keys to increase/decrease the integration image that is showing -->
+        <script> 
+            document.onkeydown = function(e) {
+                var file_root = "{{file_root|safe}}";
+                var num_ints = "{{num_ints|safe}}";
+                switch (e.keyCode) {
+                    case 37:
+                        change_int("left", file_root, num_ints);
+                        break;
+                    case 39:
+                        change_int("right", file_root, num_ints);
+                        break;
+                }
+            }
+        </script>
+
 	</main>
 
 {% endblock %}


### PR DESCRIPTION
This allows the right/left arrow keys to increase/decrease the integration image displaying.

I believe this is what we had in mind for https://github.com/spacetelescope/jwql/issues/143, basically just letting the arrow keys take the place of clicking the buttons.