### PR TITLE
Rollback Bokeh to version 1.3

### DIFF
--- a/environment_python_3_6.yml
+++ b/environment_python_3_6.yml
@@ -3,7 +3,7 @@ channels:
 - http://ssb.stsci.edu/astroconda
 dependencies:
 - astroquery=0.3.9
-- bokeh=1.4.0
+- bokeh=1.3.4
 - django=2.2.5
 - flake8=3.7.8
 - inflection=0.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ asdf==2.4.2
 astropy==3.2.3
 astroquery==0.3.10
 authlib==0.12.1
-bokeh==1.4.0
+bokeh==1.3.4
 codecov==2.0.15
 django==2.2.7
 flake8==3.7.9


### PR DESCRIPTION
This PR rolls back the `bokeh` version in the conda environment from version 1.4 to 1.3 to avoid errors described in #525 

Closes #525 