### PR TITLE
Fix typo in jwst installation version tag

### DIFF
--- a/environment_python_3_6.yml
+++ b/environment_python_3_6.yml
@@ -27,11 +27,11 @@ dependencies:
 - sqlalchemy=1.3.13
 - twine=2.0.0
 - pip:
-  - asdf==2.4.2
+  - asdf==2.5.1
   - astropy==4.0
   - authlib==0.13
   - codecov==2.0.15
   - jwedb>=0.0.3
   - pysqlite3==0.2.2
   - stsci_rtd_theme==0.0.2
-  - git+https://github.com/spacetelescope/jwst#0.13.0
+  - git+https://github.com/spacetelescope/jwst@0.15.0


### PR DESCRIPTION
This PR fixes a small typo that was causing the wrong version of the ``jwst`` package to be installed when using the environment file. Replacing the # symbol with the @ symbol allows the specified version to be installed. I updated the version to the latest released version. I also updated the version of ``asdf`` to match that required by 0.15.0 of the pipeline.