### PR TITLE
Update top level instrument JDox links

### DIFF
--- a/jwql/website/apps/jwql/views.py
+++ b/jwql/website/apps/jwql/views.py
@@ -424,11 +424,11 @@ def instrument(request, inst):
     inst = JWST_INSTRUMENT_NAMES_MIXEDCASE[inst.lower()]
 
     template = 'instrument.html'
-    url_dict = {'fgs': 'http://jwst-docs.stsci.edu/display/JTI/Fine+Guidance+Sensor%2C+FGS?q=fgs',
-                'miri': 'http://jwst-docs.stsci.edu/display/JTI/Mid+Infrared+Instrument',
-                'niriss': 'http://jwst-docs.stsci.edu/display/JTI/Near+Infrared+Imager+and+Slitless+Spectrograph',
-                'nirspec': 'http://jwst-docs.stsci.edu/display/JTI/Near+Infrared+Spectrograph',
-                'nircam': 'http://jwst-docs.stsci.edu/display/JTI/Near+Infrared+Camera'}
+    url_dict = {'fgs': 'https://jwst-docs.stsci.edu/jwst-observatory-hardware/fine-guidance-sensor',
+                'miri': 'https://jwst-docs.stsci.edu/mid-infrared-instrument',
+                'niriss': 'https://jwst-docs.stsci.edu/near-infrared-imager-and-slitless-spectrograph',
+                'nirspec': 'https://jwst-docs.stsci.edu/near-infrared-spectrograph',
+                'nircam': 'https://jwst-docs.stsci.edu/near-infrared-camera'}
 
     doc_url = url_dict[inst.lower()]
 

--- a/jwql/website/apps/jwql/views.py
+++ b/jwql/website/apps/jwql/views.py
@@ -690,7 +690,7 @@ def query_submit(request):
                'inst_list_chosen': anomaly_query_config.INSTRUMENTS_CHOSEN,
                'observing_modes_chosen': anomaly_query_config.OBSERVING_MODES_CHOSEN
                # 'thumbnails': get_thumbnails_all_instruments(inst_list_chosen)
-              }
+               }
 
     return render(request, template, context)
 


### PR DESCRIPTION
This PR updates the JDox links on our instrument pages to point to the current top-level pages. The links we previously had in there were no longer correct.