### PR TITLE
Update django OAuth import path

### DIFF
--- a/jwql/website/apps/jwql/oauth.py
+++ b/jwql/website/apps/jwql/oauth.py
@@ -41,7 +41,7 @@ Dependencies
 import os
 import requests
 
-from authlib.django.client import OAuth
+from authlib.integrations.django_client import OAuth
 from django.shortcuts import redirect, render
 
 import jwql


### PR DESCRIPTION
This path has been changed since v0.13.

Here is the compatible change guide:

https://gist.github.com/lepture/726e07a737b20f111d570d1d0437d5d4#file-rn-md