### PR TITLE
Fix readnoise webpage hanging issue

### DIFF
--- a/jwql/website/apps/jwql/monitor_pages/monitor_readnoise_bokeh.py
+++ b/jwql/website/apps/jwql/monitor_pages/monitor_readnoise_bokeh.py
@@ -151,6 +151,3 @@ class ReadnoiseMonitor(BokehTemplate):
         self.refs['readnoise_diff_image'].xgrid.grid_line_color = None
         self.refs['readnoise_diff_image'].ygrid.grid_line_color = None
         self.refs['readnoise_diff_image'].title.text_font_size = '30px'
-
-
-ReadnoiseMonitor()


### PR DESCRIPTION
This simple edit should fix the issue of the readnoise monitor accessing the database when just starting the web app, which was resulting in "hanging" database processes when running the web app. 

Now, it only accesses the database when you actually go to the readnoise monitor webpage and the database processes go away when you navigate to another monitor webpage, which I verified is the same behavior of other monitor webpages (e.g. the bad pixel webpage).