### PR TITLE
Speed up readnoise monitor webpage

### DIFF
--- a/jwql/website/apps/jwql/bokeh_containers.py
+++ b/jwql/website/apps/jwql/bokeh_containers.py
@@ -301,32 +301,36 @@ def readnoise_monitor_tabs(instrument):
     # Make a separate tab for each aperture
     tabs = []
     for aperture in FULL_FRAME_APERTURES[instrument.upper()]:
+        monitor_template = monitor_pages.ReadnoiseMonitor()
+        monitor_template.input_parameters = (instrument, aperture)
 
-        # Make a separate plot for each amp
+        # Add the mean readnoise vs time plots for each amp
         plots = []
         for amp in ['1', '2', '3', '4']:
-            monitor_template = monitor_pages.ReadnoiseMonitor()
-            monitor_template.input_parameters = (instrument, aperture, amp)
-            readnoise_plot = monitor_template.refs['mean_readnoise_figure']
+            readnoise_plot = monitor_template.refs['mean_readnoise_figure_amp{}'.format(amp)]
             readnoise_plot.sizing_mode = 'scale_width'  # Make sure the sizing is adjustable
             plots.append(readnoise_plot)
 
         # Add the readnoise difference image
         readnoise_diff_image = monitor_template.refs['readnoise_diff_image']
-        readnoise_diff_image.sizing_mode = 'scale_width'  # Make sure the sizing is adjustable
+        readnoise_diff_image.sizing_mode = 'scale_width'
+        readnoise_diff_image.margin = (0, 100, 0, 100)  # Add space around sides of figure
         plots.append(readnoise_diff_image)
 
         # Add the readnoise difference histogram
         readnoise_diff_hist = monitor_template.refs['readnoise_diff_hist']
+        readnoise_diff_hist.sizing_mode = 'scale_width'
+        readnoise_diff_hist.margin = (0, 190, 0, 190)
         plots.append(readnoise_diff_hist)
 
-        # Put the mean readnoise plots on the top row, and the difference image and
-        # histogram on the second row.
+        # Put the mean readnoise plots on the top row, the difference image on the
+        # second row, and the difference histogram on the bottom row.
         readnoise_layout = layout(
             plots[0:4],
-            plots[4:6]
+            plots[4:5],
+            plots[5:6]
         )
-        readnoise_layout.sizing_mode = 'scale_width'  # Make sure the sizing is adjustable
+        readnoise_layout.sizing_mode = 'scale_width'
         readnoise_tab = Panel(child=readnoise_layout, title=aperture)
         tabs.append(readnoise_tab)
 

--- a/jwql/website/apps/jwql/monitor_pages/yaml/monitor_readnoise_interface.yaml
+++ b/jwql/website/apps/jwql/monitor_pages/yaml/monitor_readnoise_interface.yaml
@@ -1,8 +1,8 @@
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-# Mean Readnoise vs Time Figures
+# Mean Readnoise vs Time Figures Amp1
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-- !ColumnDataSource: &mean_readnoise_source
-    ref: "mean_readnoise_source"
+- !ColumnDataSource: &mean_readnoise_source_amp1
+    ref: "mean_readnoise_source_amp1"
     data:
         time: []
         time_iso: []
@@ -10,29 +10,134 @@
         filename: []
         nints: []
         ngroups: []
-- !Range1d: &mean_readnoise_xr
-    ref: "mean_readnoise_xr"
+- !Range1d: &mean_readnoise_xr_amp1
+    ref: "mean_readnoise_xr_amp1"
     start: 0
     end: 1
     bounds: 'auto'
-- !Range1d: &mean_readnoise_yr
-    ref: "mean_readnoise_yr"
+- !Range1d: &mean_readnoise_yr_amp1
+    ref: "mean_readnoise_yr_amp1"
     start: 0
     end: 10
     bounds: 'auto'
-- !Figure: &mean_readnoise_figure
-    ref: "mean_readnoise_figure"
+- !Figure: &mean_readnoise_figure_amp1
+    ref: "mean_readnoise_figure_amp1"
     title: "Amp 1"
     x_axis_label: "Date"
     x_axis_type: "datetime"
     y_axis_label: "Mean readnoise [DN]"
-    x_range: *mean_readnoise_xr
-    y_range: *mean_readnoise_yr
+    x_range: *mean_readnoise_xr_amp1
+    y_range: *mean_readnoise_yr_amp1
     height: 800
     width: 800
     tools: "hover, wheel_zoom, pan, reset"
     elements:
-        - {'kind': 'circle', 'x': 'time', 'y': 'mean_rn', 'size': 6, 'source': *mean_readnoise_source}
+        - {'kind': 'circle', 'x': 'time', 'y': 'mean_rn', 'size': 6, 'source': *mean_readnoise_source_amp1}
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# Mean Readnoise vs Time Figures Amp2
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+- !ColumnDataSource: &mean_readnoise_source_amp2
+    ref: "mean_readnoise_source_amp2"
+    data:
+        time: []
+        time_iso: []
+        mean_rn: []
+        filename: []
+        nints: []
+        ngroups: []
+- !Range1d: &mean_readnoise_xr_amp2
+    ref: "mean_readnoise_xr_amp2"
+    start: 0
+    end: 1
+    bounds: 'auto'
+- !Range1d: &mean_readnoise_yr_amp2
+    ref: "mean_readnoise_yr_amp2"
+    start: 0
+    end: 10
+    bounds: 'auto'
+- !Figure: &mean_readnoise_figure_amp2
+    ref: "mean_readnoise_figure_amp2"
+    title: "Amp 2"
+    x_axis_label: "Date"
+    x_axis_type: "datetime"
+    y_axis_label: "Mean readnoise [DN]"
+    x_range: *mean_readnoise_xr_amp2
+    y_range: *mean_readnoise_yr_amp2
+    height: 800
+    width: 800
+    tools: "hover, wheel_zoom, pan, reset"
+    elements:
+        - {'kind': 'circle', 'x': 'time', 'y': 'mean_rn', 'size': 6, 'source': *mean_readnoise_source_amp2}
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# Mean Readnoise vs Time Figures Amp3
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+- !ColumnDataSource: &mean_readnoise_source_amp3
+    ref: "mean_readnoise_source_amp3"
+    data:
+        time: []
+        time_iso: []
+        mean_rn: []
+        filename: []
+        nints: []
+        ngroups: []
+- !Range1d: &mean_readnoise_xr_amp3
+    ref: "mean_readnoise_xr_amp3"
+    start: 0
+    end: 1
+    bounds: 'auto'
+- !Range1d: &mean_readnoise_yr_amp3
+    ref: "mean_readnoise_yr_amp3"
+    start: 0
+    end: 10
+    bounds: 'auto'
+- !Figure: &mean_readnoise_figure_amp3
+    ref: "mean_readnoise_figure_amp3"
+    title: "Amp 3"
+    x_axis_label: "Date"
+    x_axis_type: "datetime"
+    y_axis_label: "Mean readnoise [DN]"
+    x_range: *mean_readnoise_xr_amp3
+    y_range: *mean_readnoise_yr_amp3
+    height: 800
+    width: 800
+    tools: "hover, wheel_zoom, pan, reset"
+    elements:
+        - {'kind': 'circle', 'x': 'time', 'y': 'mean_rn', 'size': 6, 'source': *mean_readnoise_source_amp3}
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# Mean Readnoise vs Time Figures Amp4
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+- !ColumnDataSource: &mean_readnoise_source_amp4
+    ref: "mean_readnoise_source_amp4"
+    data:
+        time: []
+        time_iso: []
+        mean_rn: []
+        filename: []
+        nints: []
+        ngroups: []
+- !Range1d: &mean_readnoise_xr_amp4
+    ref: "mean_readnoise_xr_amp4"
+    start: 0
+    end: 1
+    bounds: 'auto'
+- !Range1d: &mean_readnoise_yr_amp4
+    ref: "mean_readnoise_yr_amp4"
+    start: 0
+    end: 10
+    bounds: 'auto'
+- !Figure: &mean_readnoise_figure_amp4
+    ref: "mean_readnoise_figure_amp4"
+    title: "Amp 4"
+    x_axis_label: "Date"
+    x_axis_type: "datetime"
+    y_axis_label: "Mean readnoise [DN]"
+    x_range: *mean_readnoise_xr_amp4
+    y_range: *mean_readnoise_yr_amp4
+    height: 800
+    width: 800
+    tools: "hover, wheel_zoom, pan, reset"
+    elements:
+        - {'kind': 'circle', 'x': 'time', 'y': 'mean_rn', 'size': 6, 'source': *mean_readnoise_source_amp4}
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # Readnoise Difference Image
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -44,9 +149,7 @@
         image: [[[0,0], [0, 0]]]
 - !Figure: &readnoise_diff_image
     ref: "readnoise_diff_image"
-    title: 'Readnoise difference with pipeline reference file'
-    height: 700
-    width: 700
+    title: 'Readnoise Difference (most recent dark - pipeline reffile)'
     elements:
         - {"kind": "image", "image": "image", "x": 0, "y": 0, "dh": 'dh', "dw": 'dh', "source": *diff_source}
     tools: ""
@@ -74,7 +177,7 @@
     y_axis_label: "Number of Pixels"
     x_range: *diff_hist_xr
     y_range: *diff_hist_yr
-    height: 300
+    height: 250
     width: 300
     tools: "hover, wheel_zoom, pan, reset"
     elements:


### PR DESCRIPTION
This PR modifies the creation of the readnoise monitor webpage to speed up the page load time. 

While it adds some repetition to the yaml file (i.e. the same issue noted by Matthew in this bias monitor PR https://github.com/spacetelescope/jwql/pull/680), it speeds up the page load time significantly, from ~12s to ~4s for NIRCam (the other instruments load almost instantly regardless).

I also made some modifications to the page layout to make the readnoise difference image less blurry and the page more responsive in general.

The new readnoise monitor page:
<img width="531" alt="Screen Shot 2021-01-15 at 3 46 58 PM" src="https://user-images.githubusercontent.com/16088329/104777814-5f1f1100-574a-11eb-9b74-db875396712f.png">