### PR TITLE
Update pipeline rscd step call

### DIFF
--- a/jwql/instrument_monitors/pipeline_tools.py
+++ b/jwql/instrument_monitors/pipeline_tools.py
@@ -33,7 +33,7 @@ from jwst.persistence import PersistenceStep
 from jwst.pipeline.calwebb_detector1 import Detector1Pipeline
 from jwst.ramp_fitting import RampFitStep
 from jwst.refpix import RefPixStep
-from jwst.rscd import RSCD_Step
+from jwst.rscd import RscdStep
 from jwst.saturation import SaturationStep
 from jwst.superbias import SuperBiasStep
 
@@ -50,7 +50,7 @@ PIPELINE_STEP_MAPPING = {'dq_init': DQInitStep, 'dark_current': DarkCurrentStep,
                          'firstframe': FirstFrameStep, 'group_scale': GroupScaleStep,
                          'ipc': IPCStep, 'jump': JumpStep, 'lastframe': LastFrameStep,
                          'linearity': LinearityStep, 'persistence': PersistenceStep,
-                         'rate': RampFitStep, 'refpix': RefPixStep, 'rscd': RSCD_Step,
+                         'rate': RampFitStep, 'refpix': RefPixStep, 'rscd': RscdStep,
                          'saturation': SaturationStep, 'superbias': SuperBiasStep}
 
 # Readout patterns that have nframes != a power of 2. These readout patterns


### PR DESCRIPTION
This PR updates the call to the JWST pipeline RSCD step, which changed naming formats to be consistent with the other pipeline steps.

I didn't see any other codes directly calling this step, so only `pipeline_tools` was updated.