### PR TITLE
Dark monitor exits gracefully when not enough files in filesystem

### DIFF
--- a/jwql/instrument_monitors/common_monitors/dark_monitor.py
+++ b/jwql/instrument_monitors/common_monitors/dark_monitor.py
@@ -750,7 +750,7 @@ class Dark():
                 # Check to see if there are enough new files to meet the
                 # monitor's signal-to-noise requirements
                 if len(new_entries) >= file_count_threshold:
-                    logging.info('\tSufficient new dark files found for {}, {} to run the dark monitor.'
+                    logging.info('\tMAST query has returned sufficient new dark files for {}, {} to run the dark monitor.'
                                  .format(self.instrument, self.aperture))
 
                     # Get full paths to the files
@@ -762,29 +762,42 @@ class Dark():
                             logging.warning('\t\tUnable to locate {} in filesystem. Not including in processing.'
                                             .format(file_entry['filename']))
 
-                    # Set up directories for the copied data
-                    ensure_dir_exists(os.path.join(self.output_dir, 'data'))
-                    self.data_dir = os.path.join(self.output_dir,
-                                                 'data/{}_{}'.format(self.instrument.lower(),
-                                                                     self.aperture.lower()))
-                    ensure_dir_exists(self.data_dir)
+                    # If it turns out that the monitor doesn't find enough
+                    # of the files returned by the MAST query to meet the threshold,
+                    # then the monitor will not be run
+                    if len(new_filenames) < file_count_threshold:
+                        logging.info(("\tFilesystem search for the files identified by MAST has returned {} files. "
+                                      "This is less than the required minimum number of files ({}) necessary to run "
+                                      "the monitor. Quitting.").format(len(new_filenames), file_count_threshold))
+                        monitor_run = False
+                    else:
+                        logging.info(("\tFilesystem search for the files identified by MAST has returned {} files.")
+                                    .format(len(new_filenames)))
+                        monitor_run = True
 
-                    # Copy files from filesystem
-                    dark_files, not_copied = copy_files(new_filenames, self.data_dir)
+                    if monitor_run:
+                        # Set up directories for the copied data
+                        ensure_dir_exists(os.path.join(self.output_dir, 'data'))
+                        self.data_dir = os.path.join(self.output_dir,
+                                                     'data/{}_{}'.format(self.instrument.lower(),
+                                                                         self.aperture.lower()))
+                        ensure_dir_exists(self.data_dir)
 
-                    logging.info('\tNew_filenames: {}'.format(new_filenames))
-                    logging.info('\tData dir: {}'.format(self.data_dir))
-                    logging.info('\tCopied to working dir: {}'.format(dark_files))
-                    logging.info('\tNot copied: {}'.format(not_copied))
+                        # Copy files from filesystem
+                        dark_files, not_copied = copy_files(new_filenames, self.data_dir)
 
-                    # Run the dark monitor
-                    self.process(dark_files)
-                    monitor_run = True
+                        logging.info('\tNew_filenames: {}'.format(new_filenames))
+                        logging.info('\tData dir: {}'.format(self.data_dir))
+                        logging.info('\tCopied to working dir: {}'.format(dark_files))
+                        logging.info('\tNot copied: {}'.format(not_copied))
+
+                        # Run the dark monitor
+                        self.process(dark_files)
 
                 else:
-                    logging.info(('\tDark monitor skipped. {} new dark files for {}, {}. {} new files are '
-                                  'required to run dark current monitor.').format(
-                        len(new_entries), instrument, aperture, file_count_threshold[0]))
+                    logging.info(('\tDark monitor skipped. MAST query has returned {} new dark files for '
+                                  '{}, {}. {} new files are required to run dark current monitor.')
+                                  .format(len(new_entries), instrument, aperture, file_count_threshold[0]))
                     monitor_run = False
 
                 # Update the query history

--- a/jwql/instrument_monitors/common_monitors/dark_monitor.py
+++ b/jwql/instrument_monitors/common_monitors/dark_monitor.py
@@ -772,7 +772,7 @@ class Dark():
                         monitor_run = False
                     else:
                         logging.info(("\tFilesystem search for the files identified by MAST has returned {} files.")
-                                    .format(len(new_filenames)))
+                                     .format(len(new_filenames)))
                         monitor_run = True
 
                     if monitor_run:
@@ -797,7 +797,7 @@ class Dark():
                 else:
                     logging.info(('\tDark monitor skipped. MAST query has returned {} new dark files for '
                                   '{}, {}. {} new files are required to run dark current monitor.')
-                                  .format(len(new_entries), instrument, aperture, file_count_threshold[0]))
+                                 .format(len(new_entries), instrument, aperture, file_count_threshold[0]))
                     monitor_run = False
 
                 # Update the query history
@@ -993,8 +993,8 @@ class Dark():
             degrees_of_freedom = len(hist) - 3.
             total_pix = np.sum(hist[positive])
             p_i = gauss_fit[positive] / total_pix
-            gaussian_chi_squared[key] = (np.sum((hist[positive] - (total_pix * p_i) ** 2) / (total_pix * p_i))
-                                         / degrees_of_freedom)
+            gaussian_chi_squared[key] = (np.sum((hist[positive] - (total_pix * p_i) ** 2) / (total_pix * p_i)) /
+                                        degrees_of_freedom)
 
             # Double Gaussian fit only for full frame data (and only for
             # NIRISS, NIRCam at the moment.)


### PR DESCRIPTION
Resolves #618 

This PR updates the dark monitor for the case where the MAST query returns enough data to proceed, but the identified files are not present in the filesystem. With this update, if the MAST query returns enough new files to proceed, the dark monitor will search the filesystem. If after the search, enough of the new files are present (relative to the required minimum number), then the dark monitor will run. If enough of the files identified by MAST are missing in the filesystem that the number of files is less than the threshold, the monitor will be skipped.