### PR TITLE
Patch for ReadTheDocs to find empty example config file

### DIFF
--- a/jwql/utils/utils.py
+++ b/jwql/utils/utils.py
@@ -123,12 +123,17 @@ def get_config():
     settings : dict
         A dictionary that holds the contents of the config file.
     """
-    config_file_location = os.path.join(__location__, 'config.json')
+    if os.environ.get('READTHEDOCS') == 'True':
+        # ReadTheDocs should use the example configuration file rather than the complete configuration file
+        config_file_location = os.path.join(__location__, 'example_config.json')
+    else:
+        # Users should complete their own configuration file and store it in the main jwql directory
+        config_file_location = os.path.join(__location__, 'config.json')
 
     # Make sure the file exists
     if not os.path.isfile(config_file_location):
         raise FileNotFoundError('The JWQL package requires a configuration file (config.json) '
-                                'to be placed within the jwql/utils directory. '
+                                'to be placed within the main jwql directory. '
                                 'This file is missing. Please read the relevant wiki page '
                                 '(https://github.com/spacetelescope/jwql/wiki/'
                                 'Config-file) for more information.')


### PR DESCRIPTION
ReadTheDocs is currently failing because it is looking for the `config.json` file which does not exist. An `example_config.json` file is used as an empty placeholder and description of what contents are needed in `config.json`. However, this file is updated by each user as it contains private information. Using the `example_config.json` naming convention, in addition to placing `config.json` in `.gitignore`, also prevents users from accidentally committing the complete configuration file to the JWQL repository. This patch uses the `READTHEDOCS` environment variable to determine whether JWQL should look for `example_config.json` or `config.json`.