### PR TITLE
[WIP]: Add function to filter out ASIC tuning data from mast results

### DIFF
--- a/jwql/utils/constants.py
+++ b/jwql/utils/constants.py
@@ -114,6 +114,10 @@ APERTURES_PER_INSTRUMENT = {'NIRCAM': ['NRCA1_FULL', 'NRCA2_FULL', 'NRCA3_FULL',
                             'MIRI': ['MIRIM_FULL', 'MIRIM_MASKLYOT', 'MIRIM_SLITLESSPRISM', 'MIRIM_SUB256',
                                      'MIRIM_SUB128', 'MIRIM_SLIT']}
 
+# Observing templates used for ASIC tuning. MAST query results that
+# have one of these templates will be ignored
+ASIC_TEMPLATES = ['ISIM ASIC Tuning']
+
 # Bad pixel types by the type of data used to find them
 BAD_PIXEL_TYPES = ['DEAD', 'HOT', 'LOW_QE', 'RC', 'OPEN', 'ADJ_OPEN', 'TELEGRAPH', 'OTHER_BAD_PIXEL']
 DARKS_BAD_PIXEL_TYPES = ['HOT', 'RC', 'OTHER_BAD_PIXEL', 'TELEGRAPH']


### PR DESCRIPTION
This PR adds code to the instrument monitors such that any ASIC tuning data returned by the MAST query will be ignored. ASIC tuning data will have suspect pixel values since readout properties will be non-nominal for these data. We don't want these pixel values contaminating measures of dark current, readnoise, etc.

Files are excluded by checking the 'template' keyword in the dictionaries returned by the MAST query.

- [ ] Find out if there are instrument-specific ASIC tuning template names. Currently the code only looks for the value that NIRCam uses.
- [ ] More testing required. Will need to reset the database tables in order to fully test.
- [ ] Add the filtering function to the readnoise, bias, and bad pixel monitors (cosmic ray monitor?)
