### PR TITLE
Made plotting limits robust to missing data

### DIFF
--- a/jwql/website/apps/jwql/monitor_pages/monitor_bias_bokeh.py
+++ b/jwql/website/apps/jwql/monitor_pages/monitor_bias_bokeh.py
@@ -179,5 +179,5 @@ class BiasMonitor(BokehTemplate):
                 if len(bias_vals) != 0:
                     self.refs['mean_bias_xr_amp{}_{}'.format(amp, kind)].start = expstarts.min() - timedelta(days=3)
                     self.refs['mean_bias_xr_amp{}_{}'.format(amp, kind)].end = expstarts.max() + timedelta(days=3)
-                    self.refs['mean_bias_yr_amp{}_{}'.format(amp, kind)].start = bias_vals.min() - 20
-                    self.refs['mean_bias_yr_amp{}_{}'.format(amp, kind)].end = bias_vals.max() + 20
+                    self.refs['mean_bias_yr_amp{}_{}'.format(amp, kind)].start = min(x for x in bias_vals if x is not None) - 20
+                    self.refs['mean_bias_yr_amp{}_{}'.format(amp, kind)].end = max(x for x in bias_vals if x is not None) + 20

--- a/jwql/website/apps/jwql/monitor_pages/monitor_readnoise_bokeh.py
+++ b/jwql/website/apps/jwql/monitor_pages/monitor_readnoise_bokeh.py
@@ -119,8 +119,8 @@ class ReadnoiseMonitor(BokehTemplate):
             if len(readnoise_vals) != 0:
                 self.refs['mean_readnoise_xr_amp{}'.format(amp)].start = expstarts.min() - timedelta(days=3)
                 self.refs['mean_readnoise_xr_amp{}'.format(amp)].end = expstarts.max() + timedelta(days=3)
-                self.refs['mean_readnoise_yr_amp{}'.format(amp)].start = readnoise_vals.min() - 1
-                self.refs['mean_readnoise_yr_amp{}'.format(amp)].end = readnoise_vals.max() + 1
+                self.refs['mean_readnoise_yr_amp{}'.format(amp)].start = min(x for x in readnoise_vals if x is not None) - 1
+                self.refs['mean_readnoise_yr_amp{}'.format(amp)].end = max(x for x in readnoise_vals if x is not None) + 1
 
     def update_readnoise_diff_plots(self):
         """Updates the readnoise difference image and histogram"""


### PR DESCRIPTION
This PR should fix https://github.com/spacetelescope/jwql/issues/834 by making the scale limits calculation for the bias and readnoise monitors robust to missing data.

The data that caused this issue shouldn't exist in flight - it was a subarray with incorrect header info calling it full frame, which doesnt have multiple output channels so those database columns were blank for it, causing the crash.