### PR TITLE
[WIP]: Speed up archive webpages

### DIFF
--- a/jwql/website/apps/jwql/data_containers.py
+++ b/jwql/website/apps/jwql/data_containers.py
@@ -476,7 +476,18 @@ def get_expstart(instrument, rootname):
     return expstart
 
 
-def get_filenames_by_instrument(instrument, restriction='all'):
+def mast_query(instrument, colnames, filters=[]):
+    """Query MAST and return data for the specified colnames, using
+    the specified filters
+    """
+    service = INSTRUMENT_SERVICE_MATCH[instrument]
+    params = {"columns": "filename, isRestricted", "filters": filters}
+    response = Mast.service_request_async(service, params)
+    result = response[0].json()
+    return result
+
+
+def get_filenames_by_instrument(instrument, restriction='all', query_file=None, query_response=None):
     """Returns a list of filenames that match the given ``instrument``.
 
     Parameters
@@ -493,13 +504,13 @@ def get_filenames_by_instrument(instrument, restriction='all'):
     filenames : list
         A list of files that match the given instrument.
     """
-
-    service = INSTRUMENT_SERVICE_MATCH[instrument]
-
-    # Query for filenames
-    params = {"columns": "filename, isRestricted", "filters": []}
-    response = Mast.service_request_async(service, params)
-    result = response[0].json()
+    if not query_file and not query_response:
+        result = mast_query(instrument, "filename, isRestricted")
+    elif query_response:
+        result = query_response
+    elif query_file:
+        with open(query_file) as fobj:
+            result = fobj.readlines()
 
     # Determine filenames to return based on restriction parameter
     if restriction == 'all':
@@ -954,7 +965,7 @@ def get_thumbnails_all_instruments(parameters):
 
     # Determine whether or not queried anomalies are flagged
     final_subset = []
-    
+
     if anomalies != {'miri': [], 'nirspec': [], 'niriss': [], 'nircam': [], 'fgs': []}:
         for thumbnail in thumbnails_subset:
             components = thumbnail.split('_')

--- a/jwql/website/apps/jwql/views.py
+++ b/jwql/website/apps/jwql/views.py
@@ -62,6 +62,7 @@ from .data_containers import get_header_info
 from .data_containers import get_image_info
 from .data_containers import get_proposal_info
 from .data_containers import get_thumbnails_all_instruments
+from .data_containers import mast_query
 from .data_containers import nirspec_trending
 from .data_containers import random_404_page
 from .data_containers import get_jwqldb_table_view_components
@@ -271,8 +272,9 @@ def archived_proposals_ajax(request, inst):
     inst = JWST_INSTRUMENT_NAMES_MIXEDCASE[inst.lower()]
 
     # Get list of all files for the given instrument
-    filenames_public = get_filenames_by_instrument(inst, restriction='public')
-    filenames_proprietary = get_filenames_by_instrument(inst, restriction='proprietary')
+    filename_query = mast_query(inst, "filename, isRestricted")
+    filenames_public = get_filenames_by_instrument(inst, restriction='public', query_response=filename_query)
+    filenames_proprietary = get_filenames_by_instrument(inst, restriction='proprietary', query_response=filename_query)
 
     # Determine locations to the files
     filenames = []


### PR DESCRIPTION
This PR contains edits designed to speed up the creation and display of the archive web pages. It seems like the main changes that need to be made are reducing the number of MAST queries being made. Timing tests on the test server recently showed that each MAST query performed within get_filenames_by_instrument() was taking 90 seconds.

The only change made so far is to cut the number of MAST queries in get_filenames_by_instrument() from 2 to 1. Most likely more changes will be necessary.

Resolves #816