### PR TITLE
View header for chosen file type

### DIFF
--- a/jwql/website/apps/jwql/data_containers.py
+++ b/jwql/website/apps/jwql/data_containers.py
@@ -568,7 +568,7 @@ def get_filenames_by_rootname(rootname):
     return filenames
 
 
-def get_header_info(filename):
+def get_header_info(filename, filetype):
     """Return the header information for a given ``filename``.
 
     Parameters
@@ -576,6 +576,8 @@ def get_header_info(filename):
     filename : str
         The name of the file of interest, without the extension
         (e.g. ``'jw86600008001_02101_00007_guider2_uncal'``).
+    filetype : str
+        The type of the file of interest, (e.g. ``'uncal'``)
 
     Returns
     -------
@@ -587,7 +589,7 @@ def get_header_info(filename):
     header_info = {}
 
     # Open the file
-    fits_filepath = filesystem_path(filename, search='*_rate.fits')
+    fits_filepath = filesystem_path(filename, search=f'*_{filetype}.fits')
     hdulist = fits.open(fits_filepath)
 
     # Extract header information from file

--- a/jwql/website/apps/jwql/static/js/jwql.js
+++ b/jwql/website/apps/jwql/static/js/jwql.js
@@ -24,7 +24,7 @@ function change_filetype(type, file_root, num_ints, inst) {
     var num_ints = JSON.parse(num_ints);
 
     // Propogate the text fields showing the filename and APT parameters
-    var fits_filename = file_root + '_' + type
+    var fits_filename = file_root + '_' + type;
     document.getElementById("jpg_filename").innerHTML = file_root + '_' + type + '_integ0.jpg';
     document.getElementById("fits_filename").innerHTML = fits_filename + '.fits';
     document.getElementById("proposal").innerHTML = file_root.slice(2,7);
@@ -33,15 +33,15 @@ function change_filetype(type, file_root, num_ints, inst) {
     document.getElementById("detector").innerHTML = file_root.split('_')[3];
 
     // Show the appropriate image
-    var img = document.getElementById("image_viewer")
+    var img = document.getElementById("image_viewer");
     var jpg_filepath = '/static/preview_images/' + file_root.slice(0,7) + '/' + file_root + '_' + type + '_integ0.jpg';
     img.src = jpg_filepath;
     img.alt = jpg_filepath;
 
     // Reset the slider values
-    document.getElementById("slider_range").value = 1
-    document.getElementById("slider_range").max = num_ints[type]
-    document.getElementById("slider_val").innerHTML = 1
+    document.getElementById("slider_range").value = 1;
+    document.getElementById("slider_range").max = num_ints[type];
+    document.getElementById("slider_val").innerHTML = 1;
 
     // Update the integration changing buttons
     if (num_ints[type] > 1) {
@@ -53,7 +53,7 @@ function change_filetype(type, file_root, num_ints, inst) {
     // Update the image download and header links
     // document.getElementById("download_fits").href = '/static/filesystem/' + file_root.slice(0,7) + '/' + fits_filename + '.fits';
     // document.getElementById("download_jpg").href = jpg_filepath;
-    document.getElementById("view_header").href = '/' + inst + '/' + fits_filename + '/header/';
+    document.getElementById("view_header").href = '/' + inst + '/' + file_root + '/header-'+type+'/';
 
     // Disable the "left" button, since this will be showing integ0
     document.getElementById("int_before").disabled = true;

--- a/jwql/website/apps/jwql/static/js/jwql.js
+++ b/jwql/website/apps/jwql/static/js/jwql.js
@@ -43,10 +43,6 @@ function change_filetype(type, file_root, num_ints, inst) {
     document.getElementById("slider_range").max = num_ints[type]
     document.getElementById("slider_val").innerHTML = 1
 
-    // Update the number of integrations
-    var int_counter = document.getElementById("int_count");
-    int_counter.innerHTML = 'Displaying integration 1/' + num_ints[type];
-
     // Update the integration changing buttons
     if (num_ints[type] > 1) {
         document.getElementById("int_after").disabled = false;
@@ -55,8 +51,8 @@ function change_filetype(type, file_root, num_ints, inst) {
     }
 
     // Update the image download and header links
-    document.getElementById("download_fits").href = '/static/filesystem/' + file_root.slice(0,7) + '/' + fits_filename + '.fits';
-    document.getElementById("download_jpg").href = jpg_filepath;
+    // document.getElementById("download_fits").href = '/static/filesystem/' + file_root.slice(0,7) + '/' + fits_filename + '.fits';
+    // document.getElementById("download_jpg").href = jpg_filepath;
     document.getElementById("view_header").href = '/' + inst + '/' + fits_filename + '/header/';
 
     // Disable the "left" button, since this will be showing integ0

--- a/jwql/website/apps/jwql/static/js/jwql.js
+++ b/jwql/website/apps/jwql/static/js/jwql.js
@@ -53,7 +53,7 @@ function change_filetype(type, file_root, num_ints, inst) {
     // Update the image download and header links
     // document.getElementById("download_fits").href = '/static/filesystem/' + file_root.slice(0,7) + '/' + fits_filename + '.fits';
     // document.getElementById("download_jpg").href = jpg_filepath;
-    document.getElementById("view_header").href = '/' + inst + '/' + file_root + '/header-'+type+'/';
+    document.getElementById("view_header").href = '/' + inst + '/' + file_root + '_' + type + '/header/';
 
     // Disable the "left" button, since this will be showing integ0
     document.getElementById("int_before").disabled = true;

--- a/jwql/website/apps/jwql/templates/view_header.html
+++ b/jwql/website/apps/jwql/templates/view_header.html
@@ -9,7 +9,7 @@
 {% block content %}
 
     <main role="main" class="container">
-    	<h4>{{ filename }} - {{file_type}}</h4><h>
+    	<h4>{{ filename }}_{{file_type}}</h4><h>
 
     	<p>
             <a class="btn btn-primary my-2 mx-2" role="button" href={{ url('jwql:view_image', args=[inst, file_root]) }}>View Image</a>

--- a/jwql/website/apps/jwql/templates/view_header.html
+++ b/jwql/website/apps/jwql/templates/view_header.html
@@ -9,7 +9,7 @@
 {% block content %}
 
     <main role="main" class="container">
-    	<h4>{{ filename }}</h4><h>
+    	<h4>{{ filename }} - {{file_type}}</h4><h>
 
     	<p>
             <a class="btn btn-primary my-2 mx-2" role="button" href={{ url('jwql:view_image', args=[inst, file_root]) }}>View Image</a>

--- a/jwql/website/apps/jwql/templates/view_image.html
+++ b/jwql/website/apps/jwql/templates/view_image.html
@@ -35,11 +35,11 @@
 		<br>
 
 		<!-- Buttons for viewing header, downloading files -->
-		<p>
-			<a id="view_header" class="btn btn-primary mx-2" role="button" href="#">View Header</a>
-			<!-- <a id="download_fits" class="btn btn-primary my-2 mx-2" role="button" href='{{ static("") }}preview_images/{{ file_root[:7] }}/{{ file_root }}' download>Download FITS</a>
-			<a id="download_jpg" class="btn btn-primary my-2 mx-2" role="button" href='{{ static("") }}preview_images/{{ file_root[:7] }}/{{ jpg }}' download>Download JPEG</a> -->
-		</p>
+        <p>
+            <a id="view_header" class="btn btn-primary mx-2" role="button" href="#">View Header</a>
+            <!-- <a id="download_fits" class="btn btn-primary my-2 mx-2" role="button" href='{{ static("") }}preview_images/{{ file_root[:7] }}/{{ file_root }}' download>Download FITS</a>
+            <a id="download_jpg" class="btn btn-primary my-2 mx-2" role="button" href='{{ static("") }}preview_images/{{ file_root[:7] }}/{{ jpg }}' download>Download JPEG</a> -->
+        </p>
 
         <div class="row">
 
@@ -59,7 +59,7 @@
                     <p>Integration: <span id="slider_val"></span></p>
                 </div>
             </div>
-            
+
             <!-- Display the anomaly form -->
             <div class="col-xl-3 text-left">
                 <!--Load the file search form from the view-->
@@ -105,21 +105,19 @@
         }
         </script>
 
-				<!-- Determine which filetype should be shown on load -->
-		    {% if 'cal' in suffixes %}
-		    	<script>change_filetype('cal', '{{file_root}}', '{{num_ints}}', '{{inst}}');</script>
-		    {% elif 'rate' in suffixes %}
-		    	<script>change_filetype('rate', '{{file_root}}', '{{num_ints}}', '{{inst}}');</script>
-		    {% elif 'uncal' in suffixes %}
-		    	<script>change_filetype('uncal', '{{file_root}}', '{{num_ints}}', '{{inst}}');</script>
-		    {% elif suffixes|length == 1 %}
-		    	<script>change_filetype('{{suffixes.0}}', '{{file_root}}', '{{num_ints}}', '{{inst}}');</script>
-		    {% else %}
-		    	<a>Lauren needs to figure out what to do with these: {{suffixes}}</a>
-		    {% endif %}
+        <!-- Determine which filetype should be shown on load -->
+        {% if 'cal' in suffixes %}
+            <script>change_filetype('cal', '{{file_root}}', '{{num_ints}}', '{{inst}}');</script>
+        {% elif 'rate' in suffixes %}
+            <script>change_filetype('rate', '{{file_root}}', '{{num_ints}}', '{{inst}}');</script>
+        {% elif 'uncal' in suffixes %}
+            <script>change_filetype('uncal', '{{file_root}}', '{{num_ints}}', '{{inst}}');</script>
+        {% elif suffixes|length == 1 %}
+            <script>change_filetype('{{suffixes.0}}', '{{file_root}}', '{{num_ints}}', '{{inst}}');</script>
+        {% else %}
+            <a>Lauren needs to figure out what to do with these: {{suffixes}}</a>
+        {% endif %}
 
-
-
-	</main>
+    </main>
 
 {% endblock %}

--- a/jwql/website/apps/jwql/templates/view_image.html
+++ b/jwql/website/apps/jwql/templates/view_image.html
@@ -115,7 +115,7 @@
         {% elif suffixes|length == 1 %}
             <script>change_filetype('{{suffixes.0}}', '{{file_root}}', '{{num_ints}}', '{{inst}}');</script>
         {% else %}
-            <a>Lauren needs to figure out what to do with these: {{suffixes}}</a>
+            <a>Unable to show image for: {{suffixes}}</a>
         {% endif %}
 
     </main>

--- a/jwql/website/apps/jwql/templates/view_image.html
+++ b/jwql/website/apps/jwql/templates/view_image.html
@@ -22,6 +22,9 @@
     	FITS Filename: <a id="fits_filename"></a><br>
     	JPG Filename: <a id="jpg_filename"></a><br><br>
 
+			<!-- Set meta data -->
+			<meta id="image-data" data-inst="{{inst}}" data-suffix="{{suffixes}}" data-fileroot="{{file_root}}" data-numints="{{num_ints}}">
+
     	<!-- Allow the user to change the file type that is being displayed -->
     	View File Type:
     	<a href="https://jwst-pipeline.readthedocs.io/en/latest/jwst/data_products/product_types.html" target="_blank">
@@ -35,11 +38,11 @@
 		<br>
 
 		<!-- Buttons for viewing header, downloading files -->
-    	<p>
-	    	<a id="view_header" class="btn btn-primary mx-2" role="button" href="{{ url('jwql:view_header', args=[inst, file_root]) }}">View Header</a>
-            <!-- <a id="download_fits" class="btn btn-primary my-2 mx-2" role="button" href='{{ static("") }}preview_images/{{ file_root[:7] }}/{{ file_root }}' download>Download FITS</a>
-            <a id="download_jpg" class="btn btn-primary my-2 mx-2" role="button" href='{{ static("") }}preview_images/{{ file_root[:7] }}/{{ jpg }}' download>Download JPEG</a> -->
-	    </p>
+		<p>
+			<a id="view_header" class="btn btn-primary mx-2" role="button" href="#" onclick="setHeaderUrl()">View Header</a>
+			<!-- <a id="download_fits" class="btn btn-primary my-2 mx-2" role="button" href='{{ static("") }}preview_images/{{ file_root[:7] }}/{{ file_root }}' download>Download FITS</a>
+			<a id="download_jpg" class="btn btn-primary my-2 mx-2" role="button" href='{{ static("") }}preview_images/{{ file_root[:7] }}/{{ jpg }}' download>Download JPEG</a> -->
+		</p>
 
         <div class="row">
 
@@ -105,19 +108,42 @@
         }
         </script>
 
+				<!-- Functions to determine which filetype should be shown on load and set the filetype for the header button -->
+				<script type="text/javascript">
+					var inst = $('#image-data').data().inst;
+					var suffixes = $('#image-data').data().suffix.replace("[", "").replace("]", "").replaceAll("'", "").split(", ");
+					var file_root = $('#image-data').data().fileroot;
+					var num_ints = $('#image-data').data().numints;
 
-	    <!-- Determine which filetype should be shown on load -->
-	    {% if 'cal' in suffixes %}
-	    	<script>change_filetype('cal', '{{file_root}}', '{{num_ints}}', '{{inst}}');</script>
-	    {% elif 'rate' in suffixes %}
-	    	<script>change_filetype('rate', '{{file_root}}', '{{num_ints}}', '{{inst}}');</script>
-	    {% elif 'uncal' in suffixes %}
-	    	<script>change_filetype('uncal', '{{file_root}}', '{{num_ints}}', '{{inst}}');</script>
-	    {% elif suffixes|length == 1 %}
-	    	<script>change_filetype('{{suffixes.0}}', '{{file_root}}', '{{num_ints}}', '{{inst}}');</script>
-	    {% else %}
-	    	<a>Lauren needs to figure out what to do with these: {{suffixes}}</a>
-	    {% endif %}
+					function onLoad() {
+						if (suffixes.indexOf('cal') > -1){
+							var initial_file_type = 'cal';
+						}
+						else if (suffixes.indexOf('rate') > -1) {
+							var initial_file_type = 'rate';
+						}
+						else if (suffixes.indexOf('uncal') > -1) {
+							var initial_file_type = 'uncal';
+						}
+						else {
+							var initial_file_type = suffixes[0];
+						}
+						return initial_file_type
+					}
+
+					var initial_file_type = onLoad();
+					change_filetype(initial_file_type, file_root, num_ints, inst);
+
+					function setHeaderUrl() {
+						console.log('setHeaderUrl');
+							var file_type = document.querySelector('input[name=filetype]:checked').value;
+							if (file_type == null){
+									var file_type = onLoad();
+							}
+						}
+
+				</script>
+
 
 	</main>
 

--- a/jwql/website/apps/jwql/templates/view_image.html
+++ b/jwql/website/apps/jwql/templates/view_image.html
@@ -22,9 +22,6 @@
     	FITS Filename: <a id="fits_filename"></a><br>
     	JPG Filename: <a id="jpg_filename"></a><br><br>
 
-			<!-- Set meta data -->
-			<meta id="image-data" data-inst="{{inst}}" data-suffix="{{suffixes}}" data-fileroot="{{file_root}}" data-numints="{{num_ints}}">
-
     	<!-- Allow the user to change the file type that is being displayed -->
     	View File Type:
     	<a href="https://jwst-pipeline.readthedocs.io/en/latest/jwst/data_products/product_types.html" target="_blank">

--- a/jwql/website/apps/jwql/templates/view_image.html
+++ b/jwql/website/apps/jwql/templates/view_image.html
@@ -39,7 +39,7 @@
 
 		<!-- Buttons for viewing header, downloading files -->
 		<p>
-			<a id="view_header" class="btn btn-primary mx-2" role="button" href="#" onclick="setHeaderUrl()">View Header</a>
+			<a id="view_header" class="btn btn-primary mx-2" role="button" href="#">View Header</a>
 			<!-- <a id="download_fits" class="btn btn-primary my-2 mx-2" role="button" href='{{ static("") }}preview_images/{{ file_root[:7] }}/{{ file_root }}' download>Download FITS</a>
 			<a id="download_jpg" class="btn btn-primary my-2 mx-2" role="button" href='{{ static("") }}preview_images/{{ file_root[:7] }}/{{ jpg }}' download>Download JPEG</a> -->
 		</p>
@@ -102,47 +102,25 @@
         var slider = document.getElementById("slider_range")
         var slider_val = document.getElementById("slider_val")
         slider_val.innerHTML = slider.value; // Display the default slider value
-        
+
         slider.oninput = function() {
           slider_val.innerHTML = this.value;
         }
         </script>
 
-				<!-- Functions to determine which filetype should be shown on load and set the filetype for the header button -->
-				<script type="text/javascript">
-					var inst = $('#image-data').data().inst;
-					var suffixes = $('#image-data').data().suffix.replace("[", "").replace("]", "").replaceAll("'", "").split(", ");
-					var file_root = $('#image-data').data().fileroot;
-					var num_ints = $('#image-data').data().numints;
+				<!-- Determine which filetype should be shown on load -->
+		    {% if 'cal' in suffixes %}
+		    	<script>change_filetype('cal', '{{file_root}}', '{{num_ints}}', '{{inst}}');</script>
+		    {% elif 'rate' in suffixes %}
+		    	<script>change_filetype('rate', '{{file_root}}', '{{num_ints}}', '{{inst}}');</script>
+		    {% elif 'uncal' in suffixes %}
+		    	<script>change_filetype('uncal', '{{file_root}}', '{{num_ints}}', '{{inst}}');</script>
+		    {% elif suffixes|length == 1 %}
+		    	<script>change_filetype('{{suffixes.0}}', '{{file_root}}', '{{num_ints}}', '{{inst}}');</script>
+		    {% else %}
+		    	<a>Lauren needs to figure out what to do with these: {{suffixes}}</a>
+		    {% endif %}
 
-					function onLoad() {
-						if (suffixes.indexOf('cal') > -1){
-							var initial_file_type = 'cal';
-						}
-						else if (suffixes.indexOf('rate') > -1) {
-							var initial_file_type = 'rate';
-						}
-						else if (suffixes.indexOf('uncal') > -1) {
-							var initial_file_type = 'uncal';
-						}
-						else {
-							var initial_file_type = suffixes[0];
-						}
-						return initial_file_type
-					}
-
-					var initial_file_type = onLoad();
-					change_filetype(initial_file_type, file_root, num_ints, inst);
-
-					function setHeaderUrl() {
-						console.log('setHeaderUrl');
-							var file_type = document.querySelector('input[name=filetype]:checked').value;
-							if (file_type == null){
-									var file_type = onLoad();
-							}
-						}
-
-				</script>
 
 
 	</main>

--- a/jwql/website/apps/jwql/urls.py
+++ b/jwql/website/apps/jwql/urls.py
@@ -83,7 +83,7 @@ urlpatterns = [
     re_path(r'^(?P<inst>({}))/archive/$'.format(instruments), views.archived_proposals, name='archive'),
     re_path(r'^(?P<inst>({}))/unlooked/$'.format(instruments), views.unlooked_images, name='unlooked'),
     re_path(r'^(?P<inst>({}))/(?P<file_root>[\w]+)/$'.format(instruments), views.view_image, name='view_image'),
-    re_path(r'^(?P<inst>({}))/(?P<filename>.+)/header-(?P<filetype>({}))/'.format(instruments, filetypes), views.view_header, name='view_header'),
+    re_path(r'^(?P<inst>({}))/(?P<filename>.+)_(?P<filetype>({}))/header/'.format(instruments, filetypes), views.view_header, name='view_header'),
     re_path(r'^(?P<inst>({}))/archive/(?P<proposal>[\d]{{1,5}})/$'.format(instruments), views.archive_thumbnails, name='archive_thumb'),
 
     # AJAX views

--- a/jwql/website/apps/jwql/urls.py
+++ b/jwql/website/apps/jwql/urls.py
@@ -50,6 +50,7 @@ from . import views
 
 app_name = 'jwql'
 instruments = 'nircam|NIRCam|niriss|NIRISS|nirspec|NIRSpec|miri|MIRI|fgs|FGS'
+filetypes = 'rate|cal|uncal|rateints|calints|trapsfilled|dark'
 
 urlpatterns = [
 
@@ -82,7 +83,7 @@ urlpatterns = [
     re_path(r'^(?P<inst>({}))/archive/$'.format(instruments), views.archived_proposals, name='archive'),
     re_path(r'^(?P<inst>({}))/unlooked/$'.format(instruments), views.unlooked_images, name='unlooked'),
     re_path(r'^(?P<inst>({}))/(?P<file_root>[\w]+)/$'.format(instruments), views.view_image, name='view_image'),
-    re_path(r'^(?P<inst>({}))/(?P<filename>.+)/header/$'.format(instruments), views.view_header, name='view_header'),
+    re_path(r'^(?P<inst>({}))/(?P<filename>.+)/header-(?P<filetype>({}))/'.format(instruments, filetypes), views.view_header, name='view_header'),
     re_path(r'^(?P<inst>({}))/archive/(?P<proposal>[\d]{{1,5}})/$'.format(instruments), views.archive_thumbnails, name='archive_thumb'),
 
     # AJAX views

--- a/jwql/website/apps/jwql/urls.py
+++ b/jwql/website/apps/jwql/urls.py
@@ -50,7 +50,6 @@ from . import views
 
 app_name = 'jwql'
 instruments = 'nircam|NIRCam|niriss|NIRISS|nirspec|NIRSpec|miri|MIRI|fgs|FGS'
-filetypes = 'rate|cal|uncal|rateints|calints|trapsfilled|dark'
 
 urlpatterns = [
 
@@ -83,7 +82,7 @@ urlpatterns = [
     re_path(r'^(?P<inst>({}))/archive/$'.format(instruments), views.archived_proposals, name='archive'),
     re_path(r'^(?P<inst>({}))/unlooked/$'.format(instruments), views.unlooked_images, name='unlooked'),
     re_path(r'^(?P<inst>({}))/(?P<file_root>[\w]+)/$'.format(instruments), views.view_image, name='view_image'),
-    re_path(r'^(?P<inst>({}))/(?P<filename>.+)_(?P<filetype>({}))/header/'.format(instruments, filetypes), views.view_header, name='view_header'),
+    re_path(r'^(?P<inst>({}))/(?P<filename>.+)_(?P<filetype>.+)/header/'.format(instruments), views.view_header, name='view_header'),
     re_path(r'^(?P<inst>({}))/archive/(?P<proposal>[\d]{{1,5}})/$'.format(instruments), views.archive_thumbnails, name='archive_thumb'),
 
     # AJAX views

--- a/jwql/website/apps/jwql/views.py
+++ b/jwql/website/apps/jwql/views.py
@@ -716,7 +716,7 @@ def view_header(request, inst, filename, filetype):
                'filename': filename,
                'file_root': file_root,
                'file_type': filetype,
-               'header_info': get_header_info(filename, filetype)} # filetype goes in here
+               'header_info': get_header_info(filename, filetype)}
 
     return render(request, template, context)
 

--- a/jwql/website/apps/jwql/views.py
+++ b/jwql/website/apps/jwql/views.py
@@ -687,7 +687,7 @@ def unlooked_images(request, inst):
     pass
 
 
-def view_header(request, inst, filename):
+def view_header(request, inst, filename, filetype):
     """Generate the header view page
 
     Parameters
@@ -698,6 +698,8 @@ def view_header(request, inst, filename):
         Name of JWST instrument
     filename : str
         FITS filename of selected image in filesystem
+    filetype :str
+        Type of file (e.g. 'uncal')
 
     Returns
     -------
@@ -713,7 +715,7 @@ def view_header(request, inst, filename):
     context = {'inst': inst,
                'filename': filename,
                'file_root': file_root,
-               'header_info': get_header_info(filename)}
+               'header_info': get_header_info(filename, filetype)} # filetype goes in here
 
     return render(request, template, context)
 

--- a/jwql/website/apps/jwql/views.py
+++ b/jwql/website/apps/jwql/views.py
@@ -698,14 +698,15 @@ def view_header(request, inst, filename, filetype):
         Name of JWST instrument
     filename : str
         FITS filename of selected image in filesystem
-    filetype :str
-        Type of file (e.g. 'uncal')
+    filetype : str
+        Type of file (e.g. ``uncal``)
 
     Returns
     -------
     HttpResponse object
         Outgoing response sent to the webpage
     """
+
     # Ensure the instrument is correctly capitalized
     inst = JWST_INSTRUMENT_NAMES_MIXEDCASE[inst.lower()]
 

--- a/jwql/website/apps/jwql/views.py
+++ b/jwql/website/apps/jwql/views.py
@@ -715,6 +715,7 @@ def view_header(request, inst, filename, filetype):
     context = {'inst': inst,
                'filename': filename,
                'file_root': file_root,
+               'file_type': filetype,
                'header_info': get_header_info(filename, filetype)} # filetype goes in here
 
     return render(request, template, context)


### PR DESCRIPTION
The "View Header" button now points to a page that shows the header of the image based on which radio button is clicked (rather than always showing the header of the rate image). The header page has the file type in the title and URL looks like `FGS/jw86700012001_02101_00001_guider1_rate/header/` or `FGS/jw86700012001_02101_00001_guider1_uncal/header/`.

I also did some random clean up:
- In `change_filetype` function in `jwql.js`, I added some missing semi-colons
- In `change_filetype` function in `jwql.js`, I removed or commented out lines that referenced code in `view_image.html` that had already been removed or commented out, which were causing errors. 
- In `view_image.html`, cleaned up some indentations that were off

Closes #803