### PR TITLE
Allow dark monitor to work for all instruments

### DIFF
--- a/jwql/utils/constants.py
+++ b/jwql/utils/constants.py
@@ -260,8 +260,8 @@ JWST_MAST_SERVICES = ['Mast.Jwst.Filtered.{}'.format(value.title()) for value in
 MONITORS = {
     'fgs': [('Bad Pixel Monitor', '/fgs/bad_pixel_monitor'),
             ('Readnoise Monitor', '/fgs/readnoise_monitor'),
-            ('Dark Current Monitor', '#')],
-    'miri': [('Dark Current Monitor', '#'),
+            ('Dark Current Monitor', '/fgs/dark_monitor')],
+    'miri': [('Dark Current Monitor', '/miri/dark_monitor'),
              ('Data Trending', '#'),
              ('Bad Pixel Monitor', '/miri/bad_pixel_monitor'),
              ('Readnoise Monitor', '/miri/readnoise_monitor'),
@@ -282,7 +282,7 @@ MONITORS = {
                ('AMI Calibrator Monitor', '#'),
                ('TSO RMS Monitor', '#'),
                ('Bias Monitor', '/niriss/bias_monitor'),
-               ('Dark Current Monitor', '#')],
+               ('Dark Current Monitor', '/niriss/dark_monitor')],
     'nirspec': [('Optical Short Monitor', '#'),
                 ('Bad Pixel Monitor', '/nirspec/bad_pixel_monitor'),
                 ('Readnoise Monitor', '/nirspec/readnoise_monitor'),
@@ -294,7 +294,7 @@ MONITORS = {
                 ('Instrument Model Updates', '#'),
                 ('Failed-open Shutter Monitor', '#'),
                 ('Bias Monitor', '/nirspec/bias_monitor'),
-                ('Dark Monitor', '#')]}
+                ('Dark Monitor', '/nirspec/dark_monitor')]}
 
 # Possible suffix types for coronograph exposures
 NIRCAM_CORONAGRAPHY_SUFFIX_TYPES = ['psfstack', 'psfalign', 'psfsub']

--- a/jwql/website/apps/jwql/bokeh_containers.py
+++ b/jwql/website/apps/jwql/bokeh_containers.py
@@ -232,7 +232,7 @@ def dark_monitor_tabs(instrument):
             [single_aperture]
         )
 
-    elif instrument == 'NIRSpec':
+    elif instrument in ['NIRSpec', 'FGS']:
         d1, d2 = histograms_all_apertures
         histogram_layout = layout(
             [d1, d2]
@@ -264,7 +264,7 @@ def dark_monitor_tabs(instrument):
             [single_aperture]
         )
 
-    elif instrument == 'NIRSpec':
+    elif instrument in ['NIRSpec', 'FGS']:
         d1, d2 = lines_all_apertures
         line_layout = layout(
             [d1, d2]
@@ -276,7 +276,7 @@ def dark_monitor_tabs(instrument):
     # Mean dark image tab
 
     # The three lines below work for displaying a single image
-    image = templates_all_apertures['NRCA3_FULL'].refs["mean_dark_image_figure"]
+    image = templates_all_apertures[full_apertures[0]].refs["mean_dark_image_figure"]
     image.sizing_mode = "scale_width"  # Make sure the sizing is adjustable
     image_layout = layout(image)
     image.height = 250  # Not working


### PR DESCRIPTION
Resolves #872 

This PR fixes a couple of small bugs in the dark monitor that were causing it to crash for instruments other than NIRCam.