### PR TITLE
Updated JDOX links so they don't produce 404 errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.fits
 *.ipynb_checkpoints/
 config.json
+.DS_Store
 build/
 dist/
 jwql.egg-info/

--- a/jwql/utils/constants.py
+++ b/jwql/utils/constants.py
@@ -344,8 +344,8 @@ TIME_SERIES_SUFFIX_TYPES = ['phot', 'whtlt']
 WFSC_SUFFIX_TYPES = ['wfscmb']
 
 # Concatenate all suffix types (ordered to ensure successful matching)
-FILE_SUFFIX_TYPES = GUIDER_SUFFIX_TYPES + GENERIC_SUFFIX_TYPES + \
-                    TIME_SERIES_SUFFIX_TYPES + NIRCAM_CORONAGRAPHY_SUFFIX_TYPES + \
+FILE_SUFFIX_TYPES = GUIDER_SUFFIX_TYPES + GENERIC_SUFFIX_TYPES + 
+                    TIME_SERIES_SUFFIX_TYPES + NIRCAM_CORONAGRAPHY_SUFFIX_TYPES + 
                     NIRISS_AMI_SUFFIX_TYPES + WFSC_SUFFIX_TYPES
 
 # Instrument Documentation Links

--- a/jwql/utils/constants.py
+++ b/jwql/utils/constants.py
@@ -344,9 +344,9 @@ TIME_SERIES_SUFFIX_TYPES = ['phot', 'whtlt']
 WFSC_SUFFIX_TYPES = ['wfscmb']
 
 # Concatenate all suffix types (ordered to ensure successful matching)
-FILE_SUFFIX_TYPES = GUIDER_SUFFIX_TYPES + GENERIC_SUFFIX_TYPES + 
-                    TIME_SERIES_SUFFIX_TYPES + NIRCAM_CORONAGRAPHY_SUFFIX_TYPES + 
-                    NIRISS_AMI_SUFFIX_TYPES + WFSC_SUFFIX_TYPES
+FILE_SUFFIX_TYPES = GUIDER_SUFFIX_TYPES + GENERIC_SUFFIX_TYPES + \
+    TIME_SERIES_SUFFIX_TYPES + NIRCAM_CORONAGRAPHY_SUFFIX_TYPES + \
+    NIRISS_AMI_SUFFIX_TYPES + WFSC_SUFFIX_TYPES
 
 # Instrument Documentation Links
 URL_DICT = {'fgs': 'https://jwst-docs.stsci.edu/jwst-observatory-hardware/jwst-fine-guidance-sensor',

--- a/jwql/utils/constants.py
+++ b/jwql/utils/constants.py
@@ -349,8 +349,8 @@ FILE_SUFFIX_TYPES = GUIDER_SUFFIX_TYPES + GENERIC_SUFFIX_TYPES + \
                     NIRISS_AMI_SUFFIX_TYPES + WFSC_SUFFIX_TYPES
 
 # Instrument Documentation Links
-URL_DICT = {'fgs': 'https://jwst-docs.stsci.edu/jwst-observatory-hardware/fine-guidance-sensor',
-            'miri': 'https://jwst-docs.stsci.edu/mid-infrared-instrument',
-            'niriss': 'https://jwst-docs.stsci.edu/near-infrared-imager-and-slitless-spectrograph',
-            'nirspec': 'https://jwst-docs.stsci.edu/near-infrared-spectrograph',
-            'nircam': 'https://jwst-docs.stsci.edu/near-infrared-camera'}
+URL_DICT = {'fgs': 'https://jwst-docs.stsci.edu/jwst-observatory-hardware/jwst-fine-guidance-sensor',
+            'miri': 'https://jwst-docs.stsci.edu/jwst-mid-infrared-instrument',
+            'niriss': 'https://jwst-docs.stsci.edu/jwst-near-infrared-imager-and-slitless-spectrograph',
+            'nirspec': 'https://jwst-docs.stsci.edu/jwst-near-infrared-spectrograph',
+            'nircam': 'https://jwst-docs.stsci.edu/jwst-near-infrared-camera'}

--- a/jwql/utils/utils.py
+++ b/jwql/utils/utils.py
@@ -190,7 +190,7 @@ def copy_files(files, out_dir):
                 shutil.copy2(input_file, out_dir)
                 success.append(input_new_path)
                 permissions.set_permissions(input_new_path)
-            except:
+            except Exception:
                 failed.append(input_file)
     return success, failed
 
@@ -527,15 +527,15 @@ def check_config_for_key(key):
         get_config()[key]
     except KeyError:
         raise KeyError(
-            'The key `{}` is not present in config.json. Please add it.'.format(key)
-            + ' See the relevant wiki page (https://github.com/spacetelescope/'
+            'The key `{}` is not present in config.json. Please add it.'.format(key) +
+            ' See the relevant wiki page (https://github.com/spacetelescope/' +
             'jwql/wiki/Config-file) for more information.'
         )
 
     if get_config()[key] == "":
         raise ValueError(
-            'Please complete the `{}` field in your config.json. '.format(key)
-            + ' See the relevant wiki page (https://github.com/spacetelescope/'
+            'Please complete the `{}` field in your config.json. '.format(key) + 
+            ' See the relevant wiki page (https://github.com/spacetelescope/' +
             'jwql/wiki/Config-file) for more information.'
         )
 

--- a/jwql/utils/utils.py
+++ b/jwql/utils/utils.py
@@ -429,8 +429,7 @@ def filename_parser(filename):
 
     # Raise error if unable to parse the filename
     except AttributeError:
-        jdox_url = 'https://jwst-docs.stsci.edu/display/JDAT/' \
-                   'File+Naming+Conventions+and+Data+Products'
+        jdox_url = 'https://jwst-docs.stsci.edu/understanding-jwst-data-files/jwst-data-file-naming-conventions'
         raise ValueError(
             'Provided file {} does not follow JWST naming conventions.  '
             'See {} for further information.'.format(filename, jdox_url)


### PR DESCRIPTION
In particular, this updates the instrument-specific "Documentation" links, as well as the JDox URL returned on an exception from utils.py filename_parser().

Closes #889 