### PR TITLE
Make Readnoise Monitor less memory-intensive 

### DIFF
--- a/jwql/instrument_monitors/common_monitors/readnoise_monitor.py
+++ b/jwql/instrument_monitors/common_monitors/readnoise_monitor.py
@@ -351,7 +351,7 @@ class Readnoise():
         readnoise = np.zeros((num_y, num_x))
         for idx in cols_idx:
             # Create a stack of correlated double sampling (CDS) images using input
-            # ramp data, combining multiple integrations if necessary. 
+            # ramp data, combining multiple integrations if necessary.
             for integration in range(num_ints):
                 if num_groups % 2 == 0:
                     cds = data[integration, 1::2, :, idx:idx+slice_width] - data[integration, ::2, :, idx:idx+slice_width]

--- a/jwql/instrument_monitors/common_monitors/readnoise_monitor.py
+++ b/jwql/instrument_monitors/common_monitors/readnoise_monitor.py
@@ -342,28 +342,34 @@ class Readnoise():
             The 2D readnoise image.
         """
 
-        # Create a stack of correlated double sampling (CDS) images using input
-        # ramp data, combining multiple integrations if necessary.
-        logging.info('\tCreating stack of CDS difference frames')
-        num_ints, num_groups, num_y, num_x = data.shape
-        for integration in range(num_ints):
-            if num_groups % 2 == 0:
-                cds = data[integration, 1::2, :, :] - data[integration, ::2, :, :]
-            else:
-                # Omit the last group if the number of groups is odd
-                cds = data[integration, 1::2, :, :] - data[integration, ::2, :, :][:-1]
-
-            if integration == 0:
-                cds_stack = cds
-            else:
-                cds_stack = np.concatenate((cds_stack, cds), axis=0)
-
-        # Calculate readnoise by taking the clipped stddev through CDS stack
         logging.info('\tCreating readnoise image')
-        clipped = sigma_clip(cds_stack, sigma=3.0, maxiters=3, axis=0)
-        readnoise = np.std(clipped, axis=0)
-        # converts masked array to normal array and fills missing data
-        readnoise = readnoise.filled(fill_value=np.nan)
+        num_ints, num_groups, num_y, num_x = data.shape
+
+        # Calculate the readnoise in slices to avoid memory issues on large files.
+        slice_width = 20
+        cols_idx = np.array(np.arange(num_x)[::slice_width])
+        readnoise = np.zeros((num_y, num_x))
+        for idx in cols_idx:
+            # Create a stack of correlated double sampling (CDS) images using input
+            # ramp data, combining multiple integrations if necessary. 
+            for integration in range(num_ints):
+                if num_groups % 2 == 0:
+                    cds = data[integration, 1::2, :, idx:idx+slice_width] - data[integration, ::2, :, idx:idx+slice_width]
+                else:
+                    # Omit the last group if the number of groups is odd
+                    cds = data[integration, 1::2, :, idx:idx+slice_width] - data[integration, ::2, :, idx:idx+slice_width][:-1]
+
+                if integration == 0:
+                    cds_stack = cds
+                else:
+                    cds_stack = np.concatenate((cds_stack, cds), axis=0)
+
+            # Calculate readnoise by taking the clipped stddev through CDS stack
+            clipped = sigma_clip(cds_stack, sigma=3.0, maxiters=3, axis=0)
+            readnoise_slice = np.ma.std(clipped, axis=0)
+
+            # Add the readnoise in this slice to the full readnoise image
+            readnoise[:, idx:idx+slice_width] = readnoise_slice
 
         return readnoise
 
@@ -542,16 +548,23 @@ class Readnoise():
             siaf = Siaf(self.instrument)
             possible_apertures = list(siaf.apertures)
 
+            # Get the minimum groups needed to calculate readnoise for this instrument. MIRI
+            # removes the first five and last group before calculating the readnoise, so needs extra.
+            if instrument == 'miri':
+                min_groups = 8
+            else:
+                min_groups = 2
+
             for aperture in possible_apertures:
 
                 logging.info('\nWorking on aperture {} in {}'.format(aperture, instrument))
                 self.aperture = aperture
 
                 # Locate the record of the most recent MAST search; use this time
-                # (plus a 30 day buffer to catch any missing files from the previous
+                # (plus a buffer to catch any missing files from the previous
                 # run) as the start time in the new MAST search.
                 most_recent_search = self.most_recent_search()
-                self.query_start = most_recent_search - 30
+                self.query_start = most_recent_search - 65
 
                 # Query MAST for new dark files for this instrument/aperture
                 logging.info('\tQuery times: {} {}'.format(self.query_start, self.query_end))
@@ -597,13 +610,14 @@ class Readnoise():
                             logging.info('\t{} does not exist in JWQL filesystem, even though {} does'.format(uncal_filename, filename))
                         else:
                             num_groups = fits.getheader(uncal_filename)['NGROUPS']
-                            if num_groups > 10:  # skip processing if the file doesnt have enough groups to calculate the readnoise
+                            num_ints = fits.getheader(uncal_filename)['NINTS']
+                            if (num_groups >= min_groups) & (num_ints >= 2):  # skip processing if the file doesnt have enough groups/ints to calculate the readnoise
                                 shutil.copy(uncal_filename, self.data_dir)
                                 logging.info('\tCopied {} to {}'.format(uncal_filename, output_filename))
                                 set_permissions(output_filename)
                                 new_files.append(output_filename)
                             else:
-                                logging.info('\tNot enough groups to calculate readnoise in {}'.format(uncal_filename))
+                                logging.info('\tNot enough groups/ints to calculate readnoise in {}'.format(uncal_filename))
                     except FileNotFoundError:
                         logging.info('\t{} does not exist in JWQL filesystem'.format(file_entry['filename']))
 

--- a/jwql/instrument_monitors/common_monitors/readnoise_monitor.py
+++ b/jwql/instrument_monitors/common_monitors/readnoise_monitor.py
@@ -557,7 +557,7 @@ class Readnoise():
                 # (plus a buffer to catch any missing files from the previous
                 # run) as the start time in the new MAST search.
                 most_recent_search = self.most_recent_search()
-                self.query_start = most_recent_search - 65
+                self.query_start = most_recent_search - 70
 
                 # Query MAST for new dark files for this instrument/aperture
                 logging.info('\tQuery times: {} {}'.format(self.query_start, self.query_end))

--- a/jwql/website/apps/jwql/monitor_pages/monitor_bias_bokeh.py
+++ b/jwql/website/apps/jwql/monitor_pages/monitor_bias_bokeh.py
@@ -181,5 +181,11 @@ class BiasMonitor(BokehTemplate):
                 if len(bias_vals) != 0:
                     self.refs['mean_bias_xr_amp{}_{}'.format(amp, kind)].start = expstarts.min() - timedelta(days=3)
                     self.refs['mean_bias_xr_amp{}_{}'.format(amp, kind)].end = expstarts.max() + timedelta(days=3)
-                    self.refs['mean_bias_yr_amp{}_{}'.format(amp, kind)].start = min(x for x in bias_vals if x is not None) - 20
-                    self.refs['mean_bias_yr_amp{}_{}'.format(amp, kind)].end = max(x for x in bias_vals if x is not None) + 20
+                    min_val, max_val = min(x for x in bias_vals if x is not None), max(x for x in bias_vals if x is not None)
+                    if min_val == max_val:
+                        self.refs['mean_bias_yr_amp{}_{}'.format(amp, kind)].start = min_val - 1
+                        self.refs['mean_bias_yr_amp{}_{}'.format(amp, kind)].end = max_val + 1
+                    else:
+                        offset = (max_val - min_val) * .1
+                        self.refs['mean_bias_yr_amp{}_{}'.format(amp, kind)].start = min_val - offset
+                        self.refs['mean_bias_yr_amp{}_{}'.format(amp, kind)].end = max_val + offset

--- a/jwql/website/apps/jwql/monitor_pages/monitor_readnoise_bokeh.py
+++ b/jwql/website/apps/jwql/monitor_pages/monitor_readnoise_bokeh.py
@@ -121,8 +121,14 @@ class ReadnoiseMonitor(BokehTemplate):
             if len(readnoise_vals) != 0:
                 self.refs['mean_readnoise_xr_amp{}'.format(amp)].start = expstarts.min() - timedelta(days=3)
                 self.refs['mean_readnoise_xr_amp{}'.format(amp)].end = expstarts.max() + timedelta(days=3)
-                self.refs['mean_readnoise_yr_amp{}'.format(amp)].start = min(x for x in readnoise_vals if x is not None) - 1
-                self.refs['mean_readnoise_yr_amp{}'.format(amp)].end = max(x for x in readnoise_vals if x is not None) + 1
+                min_val, max_val = min(x for x in readnoise_vals if x is not None), max(x for x in readnoise_vals if x is not None)
+                if min_val == max_val:
+                    self.refs['mean_readnoise_yr_amp{}'.format(amp)].start = min_val - 1
+                    self.refs['mean_readnoise_yr_amp{}'.format(amp)].end = max_val + 1
+                else:
+                    offset = (max_val - min_val) * .1
+                    self.refs['mean_readnoise_yr_amp{}'.format(amp)].start = min_val - offset
+                    self.refs['mean_readnoise_yr_amp{}'.format(amp)].end = max_val + offset
 
     def update_readnoise_diff_plots(self):
         """Updates the readnoise difference image and histogram"""


### PR DESCRIPTION
This PR does the following
- switch to perform the readnoise calculation in smaller slices to reduce memory pressure
- makes the plot limits work better with the ranges in values we're seeing (applied same change to bias monitor too, while I was at it)
- less stringent minimum groups required to calculate readnoise, to maximize the number of data points
- increased the lookback time, so these changes would be applied to all of the new darks we received

The first point is the main one - it addresses the memory issues noted in  https://github.com/spacetelescope/jwql/issues/905 , and (after the jwst pipeline is switched to jwst1.4.3) should also solve https://github.com/spacetelescope/jwql/issues/900.

