### PR TITLE
Updating JWST Pipeline Version Number

### DIFF
--- a/environment_python_3_8.yml
+++ b/environment_python_3_8.yml
@@ -56,11 +56,9 @@ dependencies:
     - asdf==2.11.0
     - astroquery==0.4.5
     - bandit==1.7.4
-    - crds==11.10.0
-    - jwst==1.3.3
+    - jwst==1.4.3
     - pysiaf==0.11.0
     - pysqlite3==0.4.3
-    - stdatamodels==0.2.4
     - stsci_rtd_theme==0.0.2
     - git+https://github.com/spacetelescope/jwst_reffiles
     

--- a/environment_python_3_9.yml
+++ b/environment_python_3_9.yml
@@ -56,11 +56,9 @@ dependencies:
     - asdf==2.8.3
     - astroquery==0.4.5
     - bandit==1.7.1
-    - crds==11.5.2
-    - jwst==1.3.3
+    - jwst==1.4.3
     - pysiaf==0.11.0
     - pysqlite3==0.4.3
-    - stdatamodels==0.2.4
     - stsci_rtd_theme==0.0.2
     - git+https://github.com/spacetelescope/jwst_reffiles
     


### PR DESCRIPTION
A number of issues have turned up because the pipeline version wasn't updated.

- Removed dependencies on `crds` and `stdatamodel`. These are resolved when `jwst` is installed.
- Increased `jwst==1.3.3 ---> 1.4.3` this was done in the `requirement.txt` but neglected in the environment files.