### PR TITLE
Hover over proposal thumbnails

### DIFF
--- a/jwql/website/apps/jwql/static/css/jwql.css
+++ b/jwql/website/apps/jwql/static/css/jwql.css
@@ -373,6 +373,15 @@ li:hover .nav-link, .navbar-brand:hover {
     z-index: 1;
 }
 
+.proposal:hover {
+    cursor: pointer;
+}
+
+.proposal:hover {
+    background-color: #356198;
+    opacity: 0.75;
+}
+
 .proposal-info {
     width: 100%;
     height: 100%;


### PR DESCRIPTION
The image opacity changes when you hover over a thumbnail on the `<instr>/archive/` pages. The image gets slightly lighter, but not so light that the white text with the proposal ID and file information becomes difficult to read.

Closes #562