### PR TITLE
Delete unnecessary files created by dark and bad pixel monitors

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,12 @@
+Unreleased
+==========
+
+Web Application
+~~~~~~~~~~~~~~~
+
+- Dark and Bad Pixel Monitors delete unnecessary outputs to save disk space (#933)
+
+
 1.1.1 (2022-04-05)
 ==================
 

--- a/jwql/instrument_monitors/common_monitors/bad_pixel_monitor.py
+++ b/jwql/instrument_monitors/common_monitors/bad_pixel_monitor.py
@@ -83,6 +83,7 @@ Templates to use: ``FGS_INTFLAT``, ``NIS_LAMP``, ``NRS_LAMP``,
 
 from copy import deepcopy
 import datetime
+from glob import glob
 import logging
 import os
 
@@ -906,6 +907,11 @@ class BadPixels():
                                  min_dark_time, mid_dark_time, max_dark_time, baseline_file)
             else:
                 raise ValueError("Unrecognized type of bad pixel: {}. Cannot update database table.".format(bad_type))
+
+        # Remove raw files, rate files, and pipeline products in order to save disk space
+        files_to_remove = glob(f'{self.data_dir}/*.fits')
+        for filename in files_to_remove:
+            os.remove(filename)
 
     @log_fail
     @log_info

--- a/jwql/instrument_monitors/common_monitors/bad_pixel_monitor.py
+++ b/jwql/instrument_monitors/common_monitors/bad_pixel_monitor.py
@@ -697,7 +697,7 @@ class BadPixels():
             run_field = self.query_table.run_bpix_from_flats
 
         query = session.query(self.query_table).filter(self.query_table.aperture == self.aperture). \
-                              filter(run_field == True)
+            filter(run_field == True)
 
         dates = np.zeros(0)
         if file_type.lower() == 'dark':

--- a/jwql/instrument_monitors/common_monitors/dark_monitor.py
+++ b/jwql/instrument_monitors/common_monitors/dark_monitor.py
@@ -761,8 +761,8 @@ class Dark():
                         # then the monitor will not be run
                         if len(new_filenames) < file_count_threshold:
                             logging.info(("\tFilesystem search for the files identified by MAST has returned {} files. "
-                                         "This is less than the required minimum number of files ({}) necessary to run "
-                                         "the monitor. Quitting.").format(len(new_filenames), file_count_threshold))
+                                          "This is less than the required minimum number of files ({}) necessary to run "
+                                          "the monitor. Quitting.").format(len(new_filenames), file_count_threshold))
                             monitor_run = False
                         else:
                             logging.info(("\tFilesystem search for the files identified by MAST has returned {} files.")
@@ -773,8 +773,8 @@ class Dark():
                             # Set up directories for the copied data
                             ensure_dir_exists(os.path.join(self.output_dir, 'data'))
                             self.data_dir = os.path.join(self.output_dir,
-                                                        'data/{}_{}'.format(self.instrument.lower(),
-                                                                            self.aperture.lower()))
+                                                         'data/{}_{}'.format(self.instrument.lower(),
+                                                                             self.aperture.lower()))
                             ensure_dir_exists(self.data_dir)
 
                             # Copy files from filesystem
@@ -790,19 +790,19 @@ class Dark():
 
                     else:
                         logging.info(('\tDark monitor skipped. MAST query has returned {} new dark files for '
-                                    '{}, {}, {}. {} new files are required to run dark current monitor.')
-                                    .format(len(new_entries), instrument, aperture, self.readpatt, file_count_threshold))
+                                      '{}, {}, {}. {} new files are required to run dark current monitor.')
+                                      .format(len(new_entries), instrument, aperture, self.readpatt, file_count_threshold))
                         monitor_run = False
 
                     # Update the query history
                     new_entry = {'instrument': instrument,
-                                'aperture': aperture,
-                                'readpattern': self.readpatt,
-                                'start_time_mjd': self.query_start,
-                                'end_time_mjd': self.query_end,
-                                'files_found': len(new_entries),
-                                'run_monitor': monitor_run,
-                                'entry_date': datetime.datetime.now()}
+                                 'aperture': aperture,
+                                 'readpattern': self.readpatt,
+                                 'start_time_mjd': self.query_start,
+                                 'end_time_mjd': self.query_end,
+                                 'files_found': len(new_entries),
+                                 'run_monitor': monitor_run,
+                                 'entry_date': datetime.datetime.now()}
                     self.query_table.__table__.insert().execute(new_entry)
                     logging.info('\tUpdated the query history table')
 
@@ -979,7 +979,7 @@ class Dark():
             if len(bin_edges) < 7:
                 logging.info('\tToo few histogram bins in initial fit. Forcing 10 bins.')
                 hist, bin_edges = np.histogram(image[indexes[0], indexes[1]], bins=10,
-                                           range=(lower_bound, upper_bound))
+                                               range=(lower_bound, upper_bound))
 
             bin_centers = (bin_edges[1:] + bin_edges[0: -1]) / 2.
             initial_params = [np.max(hist), amp_mean, amp_stdev]

--- a/jwql/instrument_monitors/common_monitors/dark_monitor.py
+++ b/jwql/instrument_monitors/common_monitors/dark_monitor.py
@@ -56,6 +56,7 @@ Use
 
 from copy import copy, deepcopy
 import datetime
+from glob import glob
 import logging
 import os
 
@@ -584,6 +585,11 @@ class Dark():
         # histogram of the pixels in each amp
         (amp_mean, amp_stdev, gauss_param, gauss_chisquared, double_gauss_params, double_gauss_chisquared,
             histogram, bins) = self.stats_by_amp(slope_image, amp_bounds)
+
+        # Remove the input files in order to save disk space
+        files_to_remove = glob(f'{self.data_dir}/*fits')
+        for filename in files_to_remove:
+            os.remove(filename)
 
         # Construct new entry for dark database table
         source_files = [os.path.basename(item) for item in file_list]


### PR DESCRIPTION
This PR adds code to the dark and bad pixel monitors to delete unnecessary files (the original input files, pipeline products) after the monitor has completed. This will save disk space on the servers.

A further way to save disk space would be to have the monitor create a jpg or png of the main output file (e.g. the mean dark rate image or the file used as the background image in the plot of bad pixels) at runtime. Then that fits file could also be deleted and the jpg/png could be used by the bokeh commands used to create the plots/figures. Currently the bokeh code relies on the fits files being present so that it can open them and display the 2D array as an image.