### PR TITLE
Remove unnecessary output files from bias/readnoise monitors

### DIFF
--- a/jwql/instrument_monitors/common_monitors/bias_monitor.py
+++ b/jwql/instrument_monitors/common_monitors/bias_monitor.py
@@ -382,6 +382,7 @@ class Bias():
                 set_permissions(processed_file)
             except:
                 logging.info('\tPipeline processing failed for {}'.format(filename))
+                os.remove(filename)
                 continue
 
             # Find amplifier boundaries so per-amp statistics can be calculated

--- a/jwql/instrument_monitors/common_monitors/bias_monitor.py
+++ b/jwql/instrument_monitors/common_monitors/bias_monitor.py
@@ -430,6 +430,10 @@ class Bias():
             self.stats_table.__table__.insert().execute(bias_db_entry)
             logging.info('\tNew entry added to bias database table: {}'.format(bias_db_entry))
 
+            # Remove the raw and calibrated files to save memory space
+            os.remove(filename)
+            os.remove(processed_file)
+
     @log_fail
     @log_info
     def run(self):

--- a/jwql/instrument_monitors/common_monitors/readnoise_monitor.py
+++ b/jwql/instrument_monitors/common_monitors/readnoise_monitor.py
@@ -423,6 +423,7 @@ class Readnoise():
                 set_permissions(processed_file)
             except:
                 logging.info('\tPipeline processing failed for {}'.format(filename))
+                os.remove(filename)
                 continue
 
             # Find amplifier boundaries so per-amp statistics can be calculated

--- a/jwql/instrument_monitors/common_monitors/readnoise_monitor.py
+++ b/jwql/instrument_monitors/common_monitors/readnoise_monitor.py
@@ -437,8 +437,8 @@ class Readnoise():
             # Make the readnoise image
             readnoise_outfile = os.path.join(self.data_dir, os.path.basename(processed_file.replace('.fits', '_readnoise.fits')))
             readnoise = self.make_readnoise_image(cal_data)
-            fits.writeto(readnoise_outfile, readnoise, overwrite=True)
-            logging.info('\tReadnoise image saved to {}'.format(readnoise_outfile))
+            #fits.writeto(readnoise_outfile, readnoise, overwrite=True)
+            #logging.info('\tReadnoise image saved to {}'.format(readnoise_outfile))
 
             # Calculate the full image readnoise stats
             clipped = sigma_clip(readnoise, sigma=3.0, maxiters=5)


### PR DESCRIPTION
This PR addresses https://github.com/spacetelescope/jwql/issues/930, to remove fits files from the bias/readnoise monitors that are no longer needed once processing completes, to save memory space on our servers. It also removes the uncal files if pipeline processing fails so they aren't just hanging around taking up space.

The web app only needs the output pngs and database entries to construct the webpages, which is why it's fine to remove these.