### PR TITLE
Remove savefig overwrite call to avoid future deprecation error

### DIFF
--- a/jwql/instrument_monitors/common_monitors/readnoise_monitor.py
+++ b/jwql/instrument_monitors/common_monitors/readnoise_monitor.py
@@ -265,7 +265,7 @@ class Readnoise():
         plt.title('{}'.format(outname))
 
         # Save the figure
-        plt.savefig(output_filename, bbox_inches='tight', dpi=200, overwrite=True)
+        plt.savefig(output_filename, bbox_inches='tight', dpi=200)
         set_permissions(output_filename)
         logging.info('\t{} created'.format(output_filename))
 


### PR DESCRIPTION
This PR addresses https://github.com/spacetelescope/jwql/issues/904 . It simply removes the overwrite call when saving figures in the readnoise monitor to avoid a future deprecation error. This is the only place I see this argument in our code base.