### PR TITLE
Lock python

### DIFF
--- a/jwql/jwql_monitors/create_initial_preview_and_thumbnail_listfiles.py
+++ b/jwql/jwql_monitors/create_initial_preview_and_thumbnail_listfiles.py
@@ -9,11 +9,13 @@ Author:  B. Hilbert
 """
 from glob import glob
 import os
-import re
 
+from jwql.utils.protect_module import lock_module
 from jwql.utils.utils import get_config
 
 
+# Lock module makes create_files() protected code, ensures only one instance of module will run
+@lock_module
 def create_files():
     """Create a new set of listfiles"""
     inst_strings = ['guider', 'nrc', 'miri', 'nis', 'nrs']

--- a/jwql/jwql_monitors/generate_preview_images.py
+++ b/jwql/jwql_monitors/generate_preview_images.py
@@ -38,6 +38,7 @@ from jwql.utils import permissions
 from jwql.utils.constants import IGNORED_SUFFIXES, JWST_INSTRUMENT_NAMES_SHORTHAND, NIRCAM_LONGWAVE_DETECTORS, \
     NIRCAM_SHORTWAVE_DETECTORS, PREVIEW_IMAGE_LISTFILE, THUMBNAIL_LISTFILE
 from jwql.utils.logging_functions import configure_logging, log_info, log_fail
+from jwql.utils.protect_module import lock_module
 from jwql.utils.preview_image import PreviewImage
 from jwql.utils.utils import get_config, filename_parser
 from jwql.utils.monitor_utils import update_monitor_table, initialize_instrument_monitor
@@ -757,11 +758,14 @@ def update_listfile(filename, file_list, filetype):
 
         logging.info(f"{filetype} image listfile {filename} updated with new entries.")
 
-
-if __name__ == '__main__':
-
+@lock_module
+def protected_code():
+    # Protected code ensures only 1 instance of module will run at any given time
     module = os.path.basename(__file__).strip('.py')
     start_time, log_file = initialize_instrument_monitor(module)
 
     generate_preview_images()
     update_monitor_table(module, start_time, log_file)
+
+if __name__ == '__main__':
+    protected_code()

--- a/jwql/jwql_monitors/generate_preview_images.py
+++ b/jwql/jwql_monitors/generate_preview_images.py
@@ -761,7 +761,7 @@ def update_listfile(filename, file_list, filetype):
 
 @lock_module
 def protected_code():
-    # Protected code ensures only 1 instance of module will run at any given time
+    """Protected code ensures only 1 instance of module will run at any given time"""
     module = os.path.basename(__file__).strip('.py')
     start_time, log_file = initialize_instrument_monitor(module)
 

--- a/jwql/jwql_monitors/generate_preview_images.py
+++ b/jwql/jwql_monitors/generate_preview_images.py
@@ -37,7 +37,7 @@ import numpy as np
 from jwql.utils import permissions
 from jwql.utils.constants import IGNORED_SUFFIXES, JWST_INSTRUMENT_NAMES_SHORTHAND, NIRCAM_LONGWAVE_DETECTORS, \
     NIRCAM_SHORTWAVE_DETECTORS, PREVIEW_IMAGE_LISTFILE, THUMBNAIL_LISTFILE
-from jwql.utils.logging_functions import configure_logging, log_info, log_fail
+from jwql.utils.logging_functions import log_info, log_fail
 from jwql.utils.protect_module import lock_module
 from jwql.utils.preview_image import PreviewImage
 from jwql.utils.utils import get_config, filename_parser
@@ -758,6 +758,7 @@ def update_listfile(filename, file_list, filetype):
 
         logging.info(f"{filetype} image listfile {filename} updated with new entries.")
 
+
 @lock_module
 def protected_code():
     # Protected code ensures only 1 instance of module will run at any given time
@@ -766,6 +767,7 @@ def protected_code():
 
     generate_preview_images()
     update_monitor_table(module, start_time, log_file)
+
 
 if __name__ == '__main__':
     protected_code()

--- a/jwql/jwql_monitors/generate_proposal_thumbnails.py
+++ b/jwql/jwql_monitors/generate_proposal_thumbnails.py
@@ -30,9 +30,10 @@ import logging
 import os
 import shutil
 
-from jwql.utils.logging_functions import configure_logging, log_info, log_fail
+from jwql.utils.logging_functions import log_info, log_fail
 from jwql.utils.utils import get_config
 from jwql.utils.monitor_utils import initialize_instrument_monitor, update_monitor_table
+from jwql.utils.protect_module import lock_module
 
 SETTINGS = get_config()
 
@@ -63,10 +64,15 @@ def generate_proposal_thumbnails():
             logging.info('Copied {} to {}'.format(thumbnail, outfile))
 
 
-if __name__ == '__main__':
-
+@lock_module
+def protected_code():
+    # Protected code ensures only 1 instance of module will run at any given time
     module = os.path.basename(__file__).strip('.py')
     start_time, log_file = initialize_instrument_monitor(module)
 
     generate_proposal_thumbnails()
     update_monitor_table(module, start_time, log_file)
+
+
+if __name__ == '__main__':
+    protected_code()

--- a/jwql/jwql_monitors/generate_proposal_thumbnails.py
+++ b/jwql/jwql_monitors/generate_proposal_thumbnails.py
@@ -66,7 +66,7 @@ def generate_proposal_thumbnails():
 
 @lock_module
 def protected_code():
-    # Protected code ensures only 1 instance of module will run at any given time
+    """Protected code ensures only 1 instance of module will run at any given time"""
     module = os.path.basename(__file__).strip('.py')
     start_time, log_file = initialize_instrument_monitor(module)
 

--- a/jwql/jwql_monitors/monitor_cron_jobs.py
+++ b/jwql/jwql_monitors/monitor_cron_jobs.py
@@ -36,11 +36,12 @@ from bokeh.io import save, output_file
 from bokeh.models import ColumnDataSource
 from bokeh.models.widgets import DataTable, DateFormatter, HTMLTemplateFormatter, TableColumn
 
-from jwql.utils.logging_functions import configure_logging, log_info, log_fail
+from jwql.utils.logging_functions import log_info, log_fail
 from jwql.utils.permissions import set_permissions
 from jwql.utils.utils import get_config
 from jwql.utils.monitor_utils import initialize_instrument_monitor, update_monitor_table
 from jwql.utils.utils import ensure_dir_exists
+from jwql.utils.protect_module import lock_module
 
 SETTINGS = get_config()
 
@@ -328,10 +329,14 @@ def success_check(filename):
     return execution
 
 
-if __name__ == '__main__':
-
+@lock_module
+def protected_code():
     module = os.path.basename(__file__).strip('.py')
     start_time, log_file = initialize_instrument_monitor(module)
 
     status()
     update_monitor_table(module, start_time, log_file)
+
+
+if __name__ == '__main__':
+    protected_code()

--- a/jwql/jwql_monitors/monitor_cron_jobs.py
+++ b/jwql/jwql_monitors/monitor_cron_jobs.py
@@ -331,6 +331,7 @@ def success_check(filename):
 
 @lock_module
 def protected_code():
+    """Protected code ensures only 1 instance of module will run at any given time"""
     module = os.path.basename(__file__).strip('.py')
     start_time, log_file = initialize_instrument_monitor(module)
 

--- a/jwql/jwql_monitors/monitor_filesystem.py
+++ b/jwql/jwql_monitors/monitor_filesystem.py
@@ -570,7 +570,7 @@ def update_database(general_results_dict, instrument_results_dict, central_stora
 
 @lock_module
 def protected_code():
-    # Protected code ensures only 1 instance of module will run at any given time
+    """Protected code ensures only 1 instance of module will run at any given time"""
 
     # Configure logging
     module = os.path.basename(__file__).strip('.py')

--- a/jwql/jwql_monitors/monitor_filesystem.py
+++ b/jwql/jwql_monitors/monitor_filesystem.py
@@ -50,12 +50,13 @@ from jwql.database.database_interface import session
 from jwql.database.database_interface import FilesystemGeneral
 from jwql.database.database_interface import FilesystemInstrument
 from jwql.database.database_interface import CentralStore
-from jwql.utils.logging_functions import configure_logging, log_info, log_fail
+from jwql.utils.logging_functions import log_info, log_fail
 from jwql.utils.permissions import set_permissions
 from jwql.utils.constants import FILE_SUFFIX_TYPES, JWST_INSTRUMENT_NAMES, JWST_INSTRUMENT_NAMES_MIXEDCASE
 from jwql.utils.utils import filename_parser
 from jwql.utils.utils import get_config
 from jwql.utils.monitor_utils import initialize_instrument_monitor, update_monitor_table
+from jwql.utils.protect_module import lock_module
 
 SETTINGS = get_config()
 FILESYSTEM = SETTINGS['filesystem']
@@ -567,7 +568,9 @@ def update_database(general_results_dict, instrument_results_dict, central_stora
     session.close()
 
 
-if __name__ == '__main__':
+@lock_module
+def protected_code():
+    # Protected code ensures only 1 instance of module will run at any given time
 
     # Configure logging
     module = os.path.basename(__file__).strip('.py')
@@ -575,3 +578,7 @@ if __name__ == '__main__':
 
     monitor_filesystem()
     update_monitor_table(module, start_time, log_file)
+
+
+if __name__ == '__main__':
+    protected_code()

--- a/jwql/jwql_monitors/monitor_mast.py
+++ b/jwql/jwql_monitors/monitor_mast.py
@@ -27,11 +27,12 @@ from bokeh.io import save, output_file
 import pandas as pd
 
 from jwql.utils.constants import JWST_INSTRUMENT_NAMES, JWST_DATAPRODUCTS
-from jwql.utils.logging_functions import configure_logging, log_info, log_fail
+from jwql.utils.logging_functions import log_info, log_fail
 from jwql.utils.permissions import set_permissions
 from jwql.utils.utils import get_config
 from jwql.utils import monitor_utils
 from jwql.utils.plotting import bar_chart
+from jwql.utils.protect_module import lock_module
 
 
 # Temporary until JWST operations: switch to test string for MAST request URL
@@ -272,7 +273,9 @@ def monitor_mast():
                    caom=True, plot=True)
 
 
-if __name__ == '__main__':
+@lock_module
+def protected_code():
+    # Protected code ensures only 1 instance of module will run at any given time
 
     # Configure logging
     module = os.path.basename(__file__).strip('.py')
@@ -281,3 +284,7 @@ if __name__ == '__main__':
     # Run the monitors
     monitor_mast()
     monitor_utils.update_monitor_table(module, start_time, log_file)
+
+
+if __name__ == '__main__':
+    protected_code()

--- a/jwql/jwql_monitors/monitor_mast.py
+++ b/jwql/jwql_monitors/monitor_mast.py
@@ -275,7 +275,7 @@ def monitor_mast():
 
 @lock_module
 def protected_code():
-    # Protected code ensures only 1 instance of module will run at any given time
+    """Protected code ensures only 1 instance of module will run at any given time"""
 
     # Configure logging
     module = os.path.basename(__file__).strip('.py')

--- a/jwql/tests/test_protect_module.py
+++ b/jwql/tests/test_protect_module.py
@@ -18,8 +18,11 @@ Use
         pytest -s test_protect_module.py
 """
 import os
-from pytest import fixture
+from pytest import fixture, mark
 from jwql.utils.protect_module import lock_module
+
+# Determine if tests are being run on Github Actions
+ON_GITHUB_ACTIONS = '/home/runner' in os.path.expanduser('~') or '/Users/runner' in os.path.expanduser('~')
 
 
 @fixture
@@ -39,6 +42,7 @@ def protected_code_entered():
     return True
 
 
+@mark.skipif(ON_GITHUB_ACTIONS, reason='Requires access to central storage.')
 def test_lock_module_create_destroy_file(module_lock):
     """Test if that wrapper will create and destroy a lock file named by module """
 
@@ -51,7 +55,9 @@ def test_lock_module_create_destroy_file(module_lock):
     assert (file_created and not file_exists) is True
 
 
+@mark.skipif(ON_GITHUB_ACTIONS, reason='Requires access to central storage.')
 def test_lock_module_wont_run_locked(module_lock):
+    """Test if that wrapper will create and destroy a lock file named by module """
     # create locked file in advance of calling protected code
     with open(module_lock, "w"):
         entered_protected_code = protected_code_entered()

--- a/jwql/tests/test_protect_module.py
+++ b/jwql/tests/test_protect_module.py
@@ -21,43 +21,40 @@ import os
 from pytest import fixture
 from jwql.utils.protect_module import lock_module
 
+
 @fixture
 def module_lock():
     module = __file__
     module_lock = module.replace('.py', '.lock')
-    print (f"module_lock fixture is: {module_lock}")
     return module_lock
+
 
 @lock_module
 def protected_code_verify_file_exists_true(module_lock):
-    print("protected_code_verify_file_exists_true CODE ENTERED")
-    #return True
     return os.path.exists(module_lock)
+
 
 @lock_module
 def protected_code_entered():
-    print("protected_code_entered CODE ENTERED")
     return True
+
 
 def test_lock_module_create_destroy_file(module_lock):
     """Test if that wrapper will create and destroy a lock file named by module """
-    
+
     # Ensure lock file does not exist
     if os.path.exists(module_lock):
         os.remove(module_lock)
-    print(f"test_lock_module_create_destroy_file - module_lock is: {module_lock}")
     file_created = protected_code_verify_file_exists_true(module_lock)
     file_exists = os.path.exists(module_lock)
-    print(f"file_created == {file_created}")
-    print(f"file_exists == {file_exists}")
-    #Assert that lock file was created in wrapper, and removed upon exit
-    assert (file_created and not file_exists) == True
+    # Assert that lock file was created in wrapper, and removed upon exit
+    assert (file_created and not file_exists) is True
 
 
 def test_lock_module_wont_run_locked(module_lock):
-    #create locked file in advance of calling protected code
-    with open(module_lock, "w") as lock_file:
+    # create locked file in advance of calling protected code
+    with open(module_lock, "w"):
         entered_protected_code = protected_code_entered()
     os.remove(module_lock)
     # assert that we never entered protected code
-    assert entered_protected_code == None
+    assert entered_protected_code is None

--- a/jwql/tests/test_protect_module.py
+++ b/jwql/tests/test_protect_module.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+
+"""Tests protect_module.py module
+
+Authors
+-------
+
+    - Bradley Sappington
+
+Use
+---
+
+    These tests can be run via the command line (omit the -s to
+    suppress verbose output to stdout):
+
+    ::
+
+        pytest -s test_protect_module.py
+"""
+import os
+from pytest import fixture
+from jwql.utils.protect_module import lock_module
+
+@fixture
+def module_lock():
+    module = __file__
+    module_lock = module.replace('.py', '.lock')
+    print (f"module_lock fixture is: {module_lock}")
+    return module_lock
+
+@lock_module
+def protected_code_verify_file_exists_true(module_lock):
+    print("protected_code_verify_file_exists_true CODE ENTERED")
+    #return True
+    return os.path.exists(module_lock)
+
+@lock_module
+def protected_code_entered():
+    print("protected_code_entered CODE ENTERED")
+    return True
+
+def test_lock_module_create_destroy_file(module_lock):
+    """Test if that wrapper will create and destroy a lock file named by module """
+    
+    # Ensure lock file does not exist
+    if os.path.exists(module_lock):
+        os.remove(module_lock)
+    print(f"test_lock_module_create_destroy_file - module_lock is: {module_lock}")
+    file_created = protected_code_verify_file_exists_true(module_lock)
+    file_exists = os.path.exists(module_lock)
+    print(f"file_created == {file_created}")
+    print(f"file_exists == {file_exists}")
+    #Assert that lock file was created in wrapper, and removed upon exit
+    assert (file_created and not file_exists) == True
+
+
+def test_lock_module_wont_run_locked(module_lock):
+    #create locked file in advance of calling protected code
+    with open(module_lock, "w") as lock_file:
+        entered_protected_code = protected_code_entered()
+    os.remove(module_lock)
+    # assert that we never entered protected code
+    assert entered_protected_code == None

--- a/jwql/utils/protect_module.py
+++ b/jwql/utils/protect_module.py
@@ -31,8 +31,8 @@ Use
         @lock_module
         def protected_code():
             # Protected code ensures only 1 instance of module will run at any given time
-            
-            # Example code normally in __name == '__main__' check 
+
+            # Example code normally in __name == '__main__' check
             initialize_code()
             my_main_function()
             logging_code()
@@ -54,16 +54,17 @@ References
 """
 
 import os
-import inspect 
+import inspect
 from functools import wraps
+
 
 def lock_module(func):
     """Decorator to prevent more than 1 instance of a module.
 
-    This function can be used as a decorator to create lock files on python 
+    This function can be used as a decorator to create lock files on python
     modules where we only want one instance running at any given time.
     More info at top of module
-    
+
     Parameters
     ----------
     func : func
@@ -78,12 +79,12 @@ def lock_module(func):
     @wraps(func)
     def wrapped(*args, **kwargs):
 
-        #Get the module name of the calling method
+        # Get the module name of the calling method
         frame = inspect.stack()[1]
         mod = inspect.getmodule(frame[0])
         module = mod.__file__
 
-        #remove python suffix if it exists, then append to make testing work properly for instances where .py may not exist
+        # remove python suffix if it exists, then append to make testing work properly for instances where .py may not exist
         module_lock = module.replace('.py', '.lock')
 
         if os.path.exists(module_lock):
@@ -101,7 +102,7 @@ def lock_module(func):
                 try:
                     os.remove(module_lock)
                 except Exception as e:
-                    print (e, type(e).__name__, e.args)
-                    print (module_lock + ' delete failed, Please Manually Delete')
+                    print(e, type(e).__name__, e.args)
+                    print(module_lock + ' delete failed, Please Manually Delete')
                     pass
     return wrapped

--- a/jwql/utils/protect_module.py
+++ b/jwql/utils/protect_module.py
@@ -1,0 +1,107 @@
+#! /usr/bin/env python
+
+""" Protect_module wrapper for the ``jwql`` automation platform.
+
+This module provides a decorator to protect against the execution of multiple instances of a module.
+Intended for when only ONE instance of a module should run at any given time.
+Using this decorator, When a module is run, a Lock file is written.  The Lock file is removed upon completion of the module.
+If there is already a lock file created for that module, the decorator will exit before running module specific code.
+
+The file will also contain the process id for reference, in case a lock file exists and
+the user does not think it should (i.e. module exited unexpectedly without proper closure)
+
+This decorator is designed for use with JWQL Monitors and Generate functions.
+It should decorate a function called "protected_code" which contains the main functionality where locking is required.
+
+
+Authors
+-------
+
+    - Bradley Sappington
+
+Use
+---
+
+    To protect a module to ensure it is not run multiple times
+    ::
+
+        import os
+        from jwql.utils.protect_module import lock_module
+
+        @lock_module
+        def protected_code():
+            # Protected code ensures only 1 instance of module will run at any given time
+            
+            # Example code normally in __name == '__main__' check 
+            initialize_code()
+            my_main_function()
+            logging_code()
+            ...
+
+        if __name__ == '__main__':
+            protected_code()
+
+
+Dependencies
+------------
+
+    None
+
+References
+----------
+
+    None
+"""
+
+import os
+import inspect 
+from functools import wraps
+
+def lock_module(func):
+    """Decorator to prevent more than 1 instance of a module.
+
+    This function can be used as a decorator to create lock files on python 
+    modules where we only want one instance running at any given time.
+    More info at top of module
+    
+    Parameters
+    ----------
+    func : func
+        The function to decorate.
+
+    Returns
+    -------
+    wrapped : func
+        The wrapped function.
+    """
+
+    @wraps(func)
+    def wrapped(*args, **kwargs):
+
+        #Get the module name of the calling method
+        frame = inspect.stack()[1]
+        mod = inspect.getmodule(frame[0])
+        module = mod.__file__
+
+        #remove python suffix if it exists, then append to make testing work properly for instances where .py may not exist
+        module_lock = module.replace('.py', '.lock')
+
+        if os.path.exists(module_lock):
+            indent = " " * 4
+            print(indent + "ERROR!! Instance of protected module already running for:")
+            print(indent + module)
+            print(indent + f"Check PID in {module_lock} and verify process is still running")
+            print(indent + "If logged PID is not currently running, delete lock file and run again")
+        else:
+            try:
+                with open(module_lock, "w") as lock_file:
+                    lock_file.write(f"Process Id = {os.getpid()}\n")
+                return func(*args, **kwargs)
+            finally:
+                try:
+                    os.remove(module_lock)
+                except Exception as e:
+                    print (e, type(e).__name__, e.args)
+                    print (module_lock + ' delete failed, Please Manually Delete')
+                    pass
+    return wrapped


### PR DESCRIPTION
Create Wrapper to institute code protection when a module should only have one instance running at any given time.
This was created for and added into the generate_preview_images, generate_thumbnails, and all jwql monitors.