### PR TITLE
 Fix bad thumbnails

### DIFF
--- a/jwql/jwql_monitors/generate_preview_images.py
+++ b/jwql/jwql_monitors/generate_preview_images.py
@@ -672,6 +672,10 @@ def process_program(program):
 
     # remove specific "ignored" suffix files (currently "original" and "stream")
     filenames = [filename for filename in filenames if os.path.splitext(filename.split('_')[-1])[0] not in IGNORED_SUFFIXES]
+
+    # Remove guiding files, as these are not currently visible in JWQL anyway
+    filenames = [filename for filename in filenames if 'guider_mode' not in filename_parser(filename)]
+
     logging.info('Found {} filenames'.format(len(filenames)))
     logging.info('')
 

--- a/jwql/utils/preview_image.py
+++ b/jwql/utils/preview_image.py
@@ -302,9 +302,9 @@ class PreviewImage():
             if thumbnail:
                 self.fig, ax = plt.subplots(figsize=(3, 3))
                 cax = ax.imshow(shiftdata,
-                                      norm=colors.LogNorm(vmin=shiftmin,
-                                                          vmax=shiftmax),
-                                      cmap=self.cmap)
+                                norm=colors.LogNorm(vmin=shiftmin,
+                                                    vmax=shiftmax),
+                                cmap=self.cmap)
                 # Invert y axis
                 plt.gca().invert_yaxis()
 

--- a/jwql/utils/preview_image.py
+++ b/jwql/utils/preview_image.py
@@ -167,6 +167,11 @@ class PreviewImage():
         """
         nelem = np.sum(pixmap)
         numclip = np.int(clipperc * nelem)
+
+        # Ignore any pixels that are NaN
+        finite = np.isfinite(data)
+        pixmap = pixmap & finite
+
         sorted = np.sort(data[pixmap], axis=None)
         minval = sorted[numclip]
         maxval = sorted[-numclip - 1]
@@ -295,20 +300,21 @@ class PreviewImage():
 
             # If making a thumbnail, make a figure with no axes
             if thumbnail:
-                fig = plt.imshow(shiftdata,
-                                 norm=colors.LogNorm(vmin=shiftmin,
-                                                     vmax=shiftmax),
-                                 cmap=self.cmap)
+                self.fig, ax = plt.subplots(figsize=(3, 3))
+                cax = ax.imshow(shiftdata,
+                                      norm=colors.LogNorm(vmin=shiftmin,
+                                                          vmax=shiftmax),
+                                      cmap=self.cmap)
                 # Invert y axis
                 plt.gca().invert_yaxis()
 
                 plt.axis('off')
-                fig.axes.get_xaxis().set_visible(False)
-                fig.axes.get_yaxis().set_visible(False)
+                cax.axes.get_xaxis().set_visible(False)
+                cax.axes.get_yaxis().set_visible(False)
 
             # If preview image, add axes and colorbars
             else:
-                fig, ax = plt.subplots(figsize=(xsize, ysize))
+                self.fig, ax = plt.subplots(figsize=(xsize, ysize))
                 cax = ax.imshow(shiftdata,
                                 norm=colors.LogNorm(vmin=shiftmin,
                                                     vmax=shiftmax),
@@ -335,7 +341,7 @@ class PreviewImage():
                     dig = 2
                 format_string = "%.{}f".format(dig)
                 tlabelstr = [format_string % number for number in tlabelflt]
-                cbar = fig.colorbar(cax, ticks=tickvals)
+                cbar = self.fig.colorbar(cax, ticks=tickvals)
 
                 # This seems to correctly remove the ticks and labels we want to remove. It gives a warning that
                 # it doesn't work on log scales, which we don't care about. So let's ignore that warning.
@@ -355,8 +361,11 @@ class PreviewImage():
                 plt.rcParams.update({'xtick.labelsize': maxsize * 5. / 4})
 
         elif scale == 'linear':
-            fig, ax = plt.subplots(figsize=(xsize, ysize))
+            self.fig, ax = plt.subplots(figsize=(xsize, ysize))
             cax = ax.imshow(image, clim=(min_value, max_value), cmap=self.cmap)
+
+            # Invert y axis
+            plt.gca().invert_yaxis()
 
             if not thumbnail:
                 cbar = fig.colorbar(cax)
@@ -414,7 +423,7 @@ class PreviewImage():
             self.make_figure(frame, i, minval, maxval, self.scaling.lower(),
                              maxsize=max_img_size, thumbnail=False)
             self.save_image(outfile, thumbnail=False)
-            plt.close()
+            plt.close(self.fig)
             self.preview_images.append(outfile)
 
             # Create thumbnail image matplotlib object, only for the
@@ -428,7 +437,7 @@ class PreviewImage():
                 self.make_figure(frame, i, minval, maxval, self.scaling.lower(),
                                  maxsize=max_img_size, thumbnail=True)
                 self.save_image(outfile, thumbnail=True)
-                plt.close()
+                plt.close(self.fig)
                 self.thumbnail_images.append(outfile)
 
     def save_image(self, fname, thumbnail=False):
@@ -448,7 +457,6 @@ class PreviewImage():
             True if saving a thumbnail image, false for the full
             preview image.
         """
-
         plt.savefig(fname, bbox_inches='tight', pad_inches=0)
         permissions.set_permissions(fname)
 


### PR DESCRIPTION
This PR makes some tweaks to the preview image generator in an effort to finally fix the bad thumbnail images that have been plaguing us forever. 

Previously, the thumbnail images were created using matplotlib's imshow() function. This function creates an AxesImage object. However, preview images are generated by first creating a matplotlib Figure object, and then populating the axes of that object with an AxesImage object via imshow(). It turns out that `plt.close` only closes Figure objects. This means that thumbnail images were not being closed at the end of the preview image generation process, and this must have been leading to multiple images open at the same time, resulting in bad thumbnail images.

This PR changes the thumbnail creation to be like that of the preview images. We first create a Figure object and then populate that using imshow. Local testing on several programs showed no bad thumbnails while using this. We should try a larger scale test on the server, but it looks promising that this PR will put an end to our bad thumbnail images.

I also fixed a small bug that was preventing some thumbnails from being created, where NaN values in the data were causing bad min/max values for the display. 

Resolves #958 