### PR TITLE
Allow proposal thumbnails to come from dark thumbnails

### DIFF
--- a/jwql/jwql_monitors/generate_proposal_thumbnails.py
+++ b/jwql/jwql_monitors/generate_proposal_thumbnails.py
@@ -48,14 +48,17 @@ def generate_proposal_thumbnails():
 
     for proposal_dir in proposal_dirs:
         rate_thumbnails = glob.glob(os.path.join(proposal_dir, '*rate*.thumb'))
+        dark_thumbnails = glob.glob(os.path.join(proposal_dir, '*dark*.thumb'))
         uncal_thumbnails = glob.glob(os.path.join(proposal_dir, '*uncal*.thumb'))
         if rate_thumbnails:
             thumbnail = rate_thumbnails[0]
+        elif dark_thumbnails:
+            thumbnail = dark_thumbnails[0]
         elif uncal_thumbnails:
             thumbnail = uncal_thumbnails[0]
         else:
             thumbnail = None
-            logging.info('No uncal or rate files found for {}.  No thumbnail generated.'.format(proposal_dir))
+            logging.info('No uncal, dark,  or rate files found for {}.  No thumbnail generated.'.format(proposal_dir))
 
         if thumbnail:
             proposal = os.path.basename(thumbnail)[0:7]

--- a/jwql/utils/preview_image.py
+++ b/jwql/utils/preview_image.py
@@ -217,6 +217,15 @@ class PreviewImage():
                 if 'PIXELDQ' in extnames:
                     dq = hdulist['PIXELDQ'].data
                     dq = (dq & dqflags.pixel['NON_SCIENCE'] == 0)
+
+                    # Case where all pixels are flagged as NON_SCIENCE
+                    # This shouldn't happen, but preview_image did crash
+                    # at one point saying that there were no good pixels to
+                    # work with.
+                    if not np.any(dq):
+                        logging.warning('All pixels flagged as NON_SCIENCE. Using all pixels to determine scaling.')
+                        yd, xd = data.shape[-2:]
+                        dq = np.ones((yd, xd), dtype="bool")
                 else:
                     yd, xd = data.shape[-2:]
                     dq = np.ones((yd, xd), dtype="bool")

--- a/jwql/utils/preview_image.py
+++ b/jwql/utils/preview_image.py
@@ -229,15 +229,6 @@ class PreviewImage():
                 if 'PIXELDQ' in extnames:
                     dq = hdulist['PIXELDQ'].data
                     dq = (dq & dqflags.pixel['NON_SCIENCE'] == 0)
-
-                    # Case where all pixels are flagged as NON_SCIENCE
-                    # This shouldn't happen, but preview_image did crash
-                    # at one point saying that there were no good pixels to
-                    # work with.
-                    if not np.any(dq):
-                        logging.warning('All pixels flagged as NON_SCIENCE. Using all pixels to determine scaling.')
-                        yd, xd = data.shape[-2:]
-                        dq = np.ones((yd, xd), dtype="bool")
                 else:
                     yd, xd = data.shape[-2:]
                     dq = np.ones((yd, xd), dtype="bool")

--- a/jwql/utils/preview_image.py
+++ b/jwql/utils/preview_image.py
@@ -170,6 +170,13 @@ class PreviewImage():
 
         # Ignore any pixels that are NaN
         finite = np.isfinite(data)
+
+        # If all non-science pixels are NaN then we're sunk. Scale
+        # from 0 to 1.
+        if not np.any(finite):
+            logging.info('No pixels with finite signal. Scaling from 0 to 1')
+            return (0., 1.)
+
         pixmap = pixmap & finite
 
         sorted = np.sort(data[pixmap], axis=None)


### PR DESCRIPTION
This PR adds code to allow proposal-level thumbnails to be created from dark file thumbnails. Currently only rate or uncal thumbnails will be copied over to become proposal level thumbnails. But with #997 we are now making thumbnails only for rate.fits and dark.fits files. So for proposals that contain only dark.fits data, we need to be able to copy one of the resulting thumbnails over to be the proposal level thumbnail.