### PR TITLE
Fix clipping logic in preview image scaling

### DIFF
--- a/jwql/jwql_monitors/generate_preview_images.py
+++ b/jwql/jwql_monitors/generate_preview_images.py
@@ -673,8 +673,8 @@ def process_program(program):
     logging.info('Processing {}'.format(program))
 
     # Gather files to process
-    filenames = glob.glob(os.path.join(SETTINGS['filesystem'], 'public', program, '*/*.fits'))
-    filenames.extend(glob.glob(os.path.join(SETTINGS['filesystem'], 'proprietary', program, '*/*.fits')))
+    filenames = glob.glob(os.path.join(SETTINGS['filesystem'], 'public', program, 'jw*/*.fits'))
+    filenames.extend(glob.glob(os.path.join(SETTINGS['filesystem'], 'proprietary', program, 'jw*/*.fits')))
     filenames = list(set(filenames))
 
     # remove specific "ignored" suffix files (currently "original" and "stream")

--- a/jwql/utils/preview_image.py
+++ b/jwql/utils/preview_image.py
@@ -422,8 +422,7 @@ class PreviewImage():
             frame = diff_img[i, :, :]
 
             # Find signal limits for the display
-            minval, maxval = self.find_limits(frame, self.dq,
-                                              self.clip_percent)
+            minval, maxval = self.find_limits(frame)
 
             # Create preview image matplotlib object
             indir, infile = os.path.split(self.file)

--- a/jwql/utils/preview_image.py
+++ b/jwql/utils/preview_image.py
@@ -143,7 +143,7 @@ class PreviewImage():
         """
         return data[:, -1, :, :] - data[:, 0, :, :]
 
-    def find_limits(self, data, pixmap, clipperc):
+    def find_limits(self, data):
         """
         Find the minimum and maximum signal levels after clipping the
         top and bottom ``clipperc`` of the pixels.
@@ -152,36 +152,33 @@ class PreviewImage():
         ----------
         data : obj
             2D numpy ndarray of floats
-        pixmap : obj
-            2D numpy ndarray boolean array of science pixel locations
-            (``True`` for science pixels, ``False`` for non-science
-            pixels)
-        clipperc : float
-            Fraction of top and bottom signal levels to clip (e.g. 0.01
-            means to clip brightest and dimmest 1% of pixels)
 
         Returns
         -------
         results : tuple
             Tuple of floats, minimum and maximum signal levels
         """
-        nelem = np.sum(pixmap)
-        numclip = np.int32(clipperc * nelem)
-
         # Ignore any pixels that are NaN
         finite = np.isfinite(data)
 
+        # Combine maps of science pixels and finite pixels
+        pixmap = self.dq & finite
+
         # If all non-science pixels are NaN then we're sunk. Scale
         # from 0 to 1.
-        if not np.any(finite):
+        if not np.any(pixmap):
             logging.info('No pixels with finite signal. Scaling from 0 to 1')
             return (0., 1.)
 
-        pixmap = pixmap & finite
+        sorted_pix = np.sort(data[pixmap], axis=None)
 
-        sorted = np.sort(data[pixmap], axis=None)
-        minval = sorted[numclip]
-        maxval = sorted[-numclip - 1]
+        # Determine how many pixels to clip off of the high and low ends
+        nelem = np.sum(pixmap)
+        numclip = np.int32(self.clip_percent * nelem)
+
+        # Determine min and max scaling levels
+        minval = sorted_pix[numclip]
+        maxval = sorted_pix[-numclip - 1]
         return (minval, maxval)
 
     def get_data(self, filename, ext):


### PR DESCRIPTION
Resolves #1009 

This PR fixes a flaw in the logic of the pixel clipping when determining scaling limits for preview images. Previously the number of pixels to be clipped was the user-input percentage of the total number of non-science pixels. With this change, it is now the user-input percentage of the number of non-science pixels with finite signal. 