### PR TITLE
Raise the upper limit on number of returned Mast entries

### DIFF
--- a/jwql/jwql_monitors/monitor_mast.py
+++ b/jwql/jwql_monitors/monitor_mast.py
@@ -26,7 +26,7 @@ from bokeh.embed import components
 from bokeh.io import save, output_file
 import pandas as pd
 
-from jwql.utils.constants import JWST_INSTRUMENT_NAMES, JWST_DATAPRODUCTS
+from jwql.utils.constants import JWST_INSTRUMENT_NAMES, JWST_DATAPRODUCTS, MAST_QUERY_LIMIT
 from jwql.utils.logging_functions import log_info, log_fail
 from jwql.utils.permissions import set_permissions
 from jwql.utils.utils import get_config
@@ -39,6 +39,10 @@ from jwql.utils.protect_module import lock_module
 ON_GITHUB_ACTIONS = '/home/runner' in os.path.expanduser('~') or '/Users/runner' in os.path.expanduser('~')
 if not ON_GITHUB_ACTIONS:
     Mast._portal_api_connection.MAST_REQUEST_URL = get_config()['mast_request_url']
+
+# Increase the limit on the number of entries that can be returned by
+# a MAST query.
+Mast._portal_api_connection.PAGESIZE = MAST_QUERY_LIMIT
 
 
 def instrument_inventory(instrument, dataproduct=JWST_DATAPRODUCTS,

--- a/jwql/utils/constants.py
+++ b/jwql/utils/constants.py
@@ -294,7 +294,7 @@ JWST_MAST_SERVICES = ['Mast.Jwst.Filtered.{}'.format(value.title()) for value in
                       JWST_INSTRUMENT_NAMES]
 
 # Maximum number of records returned by MAST for a single query
-MAST_QUERY_LIMIT = 50000
+MAST_QUERY_LIMIT = 500000
 
 # Available monitor names and their location for each JWST instrument
 MONITORS = {

--- a/jwql/utils/monitor_utils.py
+++ b/jwql/utils/monitor_utils.py
@@ -23,9 +23,14 @@ from astroquery.mast import Mast, Observations
 
 from jwql.database.database_interface import Monitor
 from jwql.jwql_monitors import monitor_mast
-from jwql.utils.constants import ASIC_TEMPLATES, JWST_DATAPRODUCTS
+from jwql.utils.constants import ASIC_TEMPLATES, JWST_DATAPRODUCTS, MAST_QUERY_LIMIT
 from jwql.utils.logging_functions import configure_logging, get_log_status
 from jwql.utils.utils import filename_parser
+
+
+# Increase the limit on the number of entries that can be returned by
+# a MAST query.
+Mast._portal_api_connection.PAGESIZE = MAST_QUERY_LIMIT
 
 
 def exclude_asic_tuning(mast_results):

--- a/jwql/website/apps/jwql/data_containers.py
+++ b/jwql/website/apps/jwql/data_containers.py
@@ -49,7 +49,7 @@ from jwql.edb.engineering_database import get_mnemonic, get_mnemonic_info, mnemo
 from jwql.instrument_monitors.miri_monitors.data_trending import dashboard as miri_dash
 from jwql.instrument_monitors.nirspec_monitors.data_trending import dashboard as nirspec_dash
 from jwql.utils.utils import check_config_for_key, ensure_dir_exists, filesystem_path, filename_parser, get_config
-from jwql.utils.constants import MONITORS, PREVIEW_IMAGE_LISTFILE, THUMBNAIL_LISTFILE
+from jwql.utils.constants import MAST_QUERY_LIMIT, MONITORS, PREVIEW_IMAGE_LISTFILE, THUMBNAIL_LISTFILE
 from jwql.utils.constants import IGNORED_SUFFIXES, INSTRUMENT_SERVICE_MATCH, JWST_INSTRUMENT_NAMES_MIXEDCASE
 from jwql.utils.constants import JWST_INSTRUMENT_NAMES_SHORTHAND, SUFFIXES_TO_ADD_ASSOCIATION, SUFFIXES_WITH_AVERAGED_INTS
 from jwql.utils.preview_image import PreviewImage
@@ -58,6 +58,9 @@ from jwql.utils.utils import get_rootnames_for_instrument_proposal
 from .forms import InstrumentAnomalySubmitForm
 from astroquery.mast import Mast
 
+# Increase the limit on the number of entries that can be returned by
+# a MAST query.
+Mast._portal_api_connection.PAGESIZE = MAST_QUERY_LIMIT
 
 # astroquery.mast import that depends on value of auth_mast
 # this import has to be made before any other import of astroquery.mast
@@ -87,7 +90,6 @@ if not ON_GITHUB_ACTIONS and not ON_READTHEDOCS:
 PACKAGE_DIR = os.path.dirname(__location__.split('website')[0])
 REPO_DIR = os.path.split(PACKAGE_DIR)[0]
 
-# Temporary until JWST operations: switch to test string for MAST request URL
 if not ON_GITHUB_ACTIONS:
     Mast._portal_api_connection.MAST_REQUEST_URL = get_config()['mast_request_url']
 


### PR DESCRIPTION
By default, querying Mast through astroquery will return only 50,000 entries. Any query that hits this limit will take several minutes to complete, and will return only 50,000 entries regardless of how many entries actually match the search criteria. This PR raises that limit to be 500,000. At the moment, the only time we were running into the 50,000 limit was when querying for all filenames for PID 1187. This is an early WFSS program, where the pipeline was extracting a spectrum for ~all sources in each exposure. This was leading to separate cal.fits and i2d.fits files for each source, which caused the number of files for a given observation to be ~15,000-20,000. When we then queried the filenames for all observations, the result was over the 50,000 limit. This update should take care of that situation. At last check, there were no other programs where this was a problem. The pipeline has also changed its default behavior to only extract the brightest 100 sources from each exposure, so this shouldn't be a problem for future programs either.

This method of increasing the Mast limit was suggested by @tomdonaldson 