### PR TITLE
Select anomaly name formatting

### DIFF
--- a/jwql/utils/constants.py
+++ b/jwql/utils/constants.py
@@ -28,7 +28,6 @@ References
 """
 
 import inflection
-from jwql.utils.utils import query_unformat
 
 # Each amplifier is represented by 2 tuples, the first for x coordinates
 # and the second for y coordinates. Within each tuple are value for
@@ -88,14 +87,14 @@ special_cases = ['Dominant_MSA_Leakage','MRS_Glow','MRS_Zipper','LRS_Contaminati
 
 # Defines the possible anomalies to flag through the web app
 ANOMALY_CHOICES = [(anomaly, inflection.titleize(anomaly)) if anomaly not in special_cases
-                        else (anomaly, query_unformat(anomaly))
+                        else (anomaly, anomaly.replace('_',' '))
                         for anomaly in ANOMALIES_PER_INSTRUMENT]
 
 ANOMALY_CHOICES_FGS = [(anomaly, inflection.titleize(anomaly)) for anomaly in ANOMALIES_PER_INSTRUMENT
                        if 'fgs' in ANOMALIES_PER_INSTRUMENT[anomaly]]
 
 ANOMALY_CHOICES_MIRI = [(anomaly, inflection.titleize(anomaly)) if anomaly not in special_cases
-                        else (anomaly, query_unformat(anomaly))
+                        else (anomaly, anomaly.replace('_',' '))
                         for anomaly in ANOMALIES_PER_INSTRUMENT
                         if 'miri' in ANOMALIES_PER_INSTRUMENT[anomaly]]
 
@@ -106,7 +105,7 @@ ANOMALY_CHOICES_NIRISS = [(anomaly, inflection.titleize(anomaly)) for anomaly in
                           if 'niriss' in ANOMALIES_PER_INSTRUMENT[anomaly]]
 
 ANOMALY_CHOICES_NIRSPEC = [(anomaly, inflection.titleize(anomaly)) if anomaly not in special_cases
-                            else (anomaly, query_unformat(anomaly))
+                            else (anomaly, anomaly.replace('_',' '))
                             for anomaly in ANOMALIES_PER_INSTRUMENT
                             if 'nirspec' in ANOMALIES_PER_INSTRUMENT[anomaly]]
 

--- a/jwql/utils/constants.py
+++ b/jwql/utils/constants.py
@@ -10,6 +10,7 @@ Authors
     - Teagan King
     - Mike Engesser
     - Maria Pena-Guerrero
+    - Rachel Cooper
 
 Use
 ---
@@ -27,6 +28,7 @@ References
 """
 
 import inflection
+from jwql.utils.utils import query_unformat
 
 # Each amplifier is represented by 2 tuples, the first for x coordinates
 # and the second for y coordinates. Within each tuple are value for
@@ -69,10 +71,10 @@ ANOMALIES_PER_INSTRUMENT = {
     # instrument-specific anomalies:
     'column_pull_up': ['miri'],
     'column_pull_down': ['miri'],
-    'dominant_msa_leakage': ['nirspec'],
+    'Dominant_MSA_Leakage': ['nirspec'],
     'dragons_breath': ['nircam'],
-    'MRS_glow': ['miri'],
-    'MRS_zipper': ['miri'],
+    'MRS_Glow': ['miri'],
+    'MRS_Zipper': ['miri'],
     'internal_reflection': ['miri'],
     'optical_short': ['nirspec'],  # Only for MOS observations
     'row_pull_up': ['miri'],
@@ -81,16 +83,20 @@ ANOMALIES_PER_INSTRUMENT = {
     'tree_rings': ['miri'],
     # additional anomalies:
     'other': ['fgs', 'miri', 'nircam', 'niriss', 'nirspec']}
+# anomalies that shouldn't be 'titleized'
+special_cases = ['Dominant_MSA_Leakage','MRS_Glow','MRS_Zipper','LRS_Contamination'] 
 
 # Defines the possible anomalies to flag through the web app
-ANOMALY_CHOICES = [(anomaly, inflection.titleize(anomaly)) if anomaly != "dominant_msa_leakage"
-                   else (anomaly, "Dominant MSA Leakage")
-                   for anomaly in ANOMALIES_PER_INSTRUMENT]
+ANOMALY_CHOICES = [(anomaly, inflection.titleize(anomaly)) if anomaly not in special_cases
+                        else (anomaly, query_unformat(anomaly))
+                        for anomaly in ANOMALIES_PER_INSTRUMENT]
 
 ANOMALY_CHOICES_FGS = [(anomaly, inflection.titleize(anomaly)) for anomaly in ANOMALIES_PER_INSTRUMENT
                        if 'fgs' in ANOMALIES_PER_INSTRUMENT[anomaly]]
 
-ANOMALY_CHOICES_MIRI = [(anomaly, inflection.titleize(anomaly)) for anomaly in ANOMALIES_PER_INSTRUMENT
+ANOMALY_CHOICES_MIRI = [(anomaly, inflection.titleize(anomaly)) if anomaly not in special_cases
+                        else (anomaly, query_unformat(anomaly))
+                        for anomaly in ANOMALIES_PER_INSTRUMENT
                         if 'miri' in ANOMALIES_PER_INSTRUMENT[anomaly]]
 
 ANOMALY_CHOICES_NIRCAM = [(anomaly, inflection.titleize(anomaly)) for anomaly in ANOMALIES_PER_INSTRUMENT
@@ -99,10 +105,10 @@ ANOMALY_CHOICES_NIRCAM = [(anomaly, inflection.titleize(anomaly)) for anomaly in
 ANOMALY_CHOICES_NIRISS = [(anomaly, inflection.titleize(anomaly)) for anomaly in ANOMALIES_PER_INSTRUMENT
                           if 'niriss' in ANOMALIES_PER_INSTRUMENT[anomaly]]
 
-ANOMALY_CHOICES_NIRSPEC = [(anomaly, inflection.titleize(anomaly)) if anomaly != "dominant_msa_leakage"
-                           else (anomaly, "Dominant MSA Leakage")
-                           for anomaly in ANOMALIES_PER_INSTRUMENT
-                           if 'nirspec' in ANOMALIES_PER_INSTRUMENT[anomaly]]
+ANOMALY_CHOICES_NIRSPEC = [(anomaly, inflection.titleize(anomaly)) if anomaly not in special_cases
+                            else (anomaly, query_unformat(anomaly))
+                            for anomaly in ANOMALIES_PER_INSTRUMENT
+                            if 'nirspec' in ANOMALIES_PER_INSTRUMENT[anomaly]]
 
 ANOMALY_CHOICES_PER_INSTRUMENT = {'fgs': ANOMALY_CHOICES_FGS,
                                   'miri': ANOMALY_CHOICES_MIRI,


### PR DESCRIPTION
Fixes #1018 by reformatting a few of the anomaly names to the desired case and treating them differently when the names are created for the checkboxes (don't use `inflection.titleize`, just replace underscores with spaces). 

This requires some changes to the column names in the database. @BradleySappington made these on the dev database but @mfixstsci and/or @bhilbert4 should be aware that this will need to be done on the prod DB too before this change will work correctly. 
The changes are:

- 'dominant_msa_leakage' --> 'Dominant_MSA_Leakage'
- 'MRS_glow' --> 'MRS_Glow'
- 'MRS_zipper' --> 'MRS_Zipper'
('LRS_Contamination' was already capitalized correctly)


<img width="387" alt="Screen Shot 2022-10-11 at 11 12 04 AM" src="https://user-images.githubusercontent.com/57679854/195199708-35428fb0-c41c-4e12-b815-458225ed1ecc.png">
