### PR TITLE
Proposal thumbnail search includes only proposal subdirectories

### DIFF
--- a/jwql/jwql_monitors/generate_proposal_thumbnails.py
+++ b/jwql/jwql_monitors/generate_proposal_thumbnails.py
@@ -44,7 +44,7 @@ def generate_proposal_thumbnails():
     """The main function of the ``generate_proposal_thumbnails`` module.
     See module docstring for further details."""
 
-    proposal_dirs = glob.glob(os.path.join(SETTINGS['thumbnail_filesystem'], '*'))
+    proposal_dirs = glob.glob(os.path.join(SETTINGS['thumbnail_filesystem'], 'jw*'))
 
     for proposal_dir in proposal_dirs:
         rate_thumbnails = glob.glob(os.path.join(proposal_dir, '*rate*.thumb'))


### PR DESCRIPTION
When creating proposal-level thumbnails, generate_proposal_thumbnails.py globs over the thumbnail system directory. However, it was searching for everything in this directory using a simple '*'. This PR updates the search to look only for 'jw*' entries, so that only the subdirectories containing the thumbnails are found. Logs from previous runs show that it was finding the text files in the same directory. This wasn't causing any real problem, since the next step is to search for files within each of the glob results, but it was leading to confusing log entries that seemed to indicate it was having trouble with the thumbnail list files.