### PR TITLE
Cr database bigint

### DIFF
--- a/jwql/database/database_interface.py
+++ b/jwql/database/database_interface.py
@@ -63,6 +63,7 @@ import os
 import socket
 import pandas as pd
 
+from sqlalchemy import BigInteger
 from sqlalchemy import Boolean
 from sqlalchemy import Column
 from sqlalchemy import create_engine
@@ -288,6 +289,7 @@ def get_monitor_columns(data_dict, table_name):
 
     # Define column types
     data_type_dict = {'integer': Integer(),
+                      'bigint': BigInteger(),
                       'string': String(),
                       'float': Float(precision=32),
                       'decimal': Float(precision='13,8'),

--- a/jwql/database/monitor_table_definitions/fgs/fgs_cosmic_ray_stats.txt
+++ b/jwql/database/monitor_table_definitions/fgs/fgs_cosmic_ray_stats.txt
@@ -5,4 +5,4 @@ OBS_END_TIME, datetime
 JUMP_COUNT, integer
 JUMP_RATE, float
 MAGNITUDE, integer_array_1d
-OUTLIERS, integer_array_1d
+OUTLIERS, bigint_array_1d

--- a/jwql/database/monitor_table_definitions/miri/miri_cosmic_ray_stats.txt
+++ b/jwql/database/monitor_table_definitions/miri/miri_cosmic_ray_stats.txt
@@ -5,4 +5,4 @@ OBS_END_TIME, datetime
 JUMP_COUNT, integer
 JUMP_RATE, float
 MAGNITUDE, integer_array_1d
-OUTLIERS, integer_array_1d
+OUTLIERS, bigint_array_1d

--- a/jwql/database/monitor_table_definitions/nircam/nircam_cosmic_ray_stats.txt
+++ b/jwql/database/monitor_table_definitions/nircam/nircam_cosmic_ray_stats.txt
@@ -4,5 +4,5 @@ OBS_START_TIME, datetime
 OBS_END_TIME, datetime
 JUMP_COUNT, integer
 JUMP_RATE, float
-MAGNITUDE, float_array_1d
-OUTLIERS, integer_array_1d
+MAGNITUDE, integer_array_1d
+OUTLIERS, bigint_array_1d

--- a/jwql/database/monitor_table_definitions/niriss/niriss_cosmic_ray_stats.txt
+++ b/jwql/database/monitor_table_definitions/niriss/niriss_cosmic_ray_stats.txt
@@ -5,4 +5,4 @@ OBS_END_TIME, datetime
 JUMP_COUNT, integer
 JUMP_RATE, float
 MAGNITUDE, integer_array_1d
-OUTLIERS, integer_array_1d
+OUTLIERS, bigint_array_1d

--- a/jwql/database/monitor_table_definitions/nirspec/nirspec_cosmic_ray_stats.txt
+++ b/jwql/database/monitor_table_definitions/nirspec/nirspec_cosmic_ray_stats.txt
@@ -5,4 +5,4 @@ OBS_END_TIME, datetime
 JUMP_COUNT, integer
 JUMP_RATE, float
 MAGNITUDE, integer_array_1d
-OUTLIERS, integer_array_1d
+OUTLIERS, bigint_array_1d


### PR DESCRIPTION
Currently the cosmic ray monitor database stores cosmic ray magnitudes as follows:

- A histogram covering -65535 to +65535, showing the number of cosmic rays found at each magnitude
- An integer array of outliers (cosmic rays with magnitudes larger than the histogram boundaries)

However, apparently some cosmic rays have magnitudes that are too large to fit into a 32-big signed integer (i.e. magnitude > 2 billion), so trying to store them generates "integer out of range" errors. This fixes that issue.

*NOTE* that the cosmic ray databases on production will need to be reset after this PR is approved, because the database definition has changed from array-of-integer to array-of-bigint

*NOTE* that, prior to this, the database_interface.py file didn't import the BigInteger definition from SQLAlchemy, so it had to be added to the import statements, and to the column mappings.