### PR TITLE
Allow thumbnail files with multiple substrings to be kept

### DIFF
--- a/jwql/utils/utils.py
+++ b/jwql/utils/utils.py
@@ -599,7 +599,7 @@ def delete_non_rate_thumbnails(extensions=['_rate_', '_dark']):
     Parameters
     ----------
     extension : list
-        If a thumbnail filename contains tany of these strings, it will not be deleted
+        If a thumbnail filename contains any of these strings, it will not be deleted
     """
     base_dir = get_config()["thumbnail_filesystem"]
     dir_list = sorted(glob.glob(os.path.join(base_dir, 'jw*')))

--- a/jwql/utils/utils.py
+++ b/jwql/utils/utils.py
@@ -591,25 +591,24 @@ def check_config_for_key(key):
         raise ValueError(msg)
 
 
-def delete_non_rate_thumbnails(extension='_rate_'):
-    """We now create thumbnails using only rate.fits files. This script will go
-    through all the thumbnail directories and delete all thumbnails that do not
-    contain the given extension.
+def delete_non_rate_thumbnails(extensions=['_rate_', '_dark']):
+    """This script will go through all the thumbnail directories and delete all
+    thumbnails that do not contain the given extensions. We currently create thumbnails
+    using only rate.fits and dark.fits files, so the default is to keep only those.
 
     Parameters
     ----------
-    extension : str
-        If a thumbnail filename contains this string, it will not be deleted
+    extension : list
+        If a thumbnail filename contains tany of these strings, it will not be deleted
     """
     base_dir = get_config()["thumbnail_filesystem"]
-    dir_list = sorted(glob.glob('jw*'))
+    dir_list = sorted(glob.glob(os.path.join(base_dir, 'jw*')))
 
     for dirname in dir_list:
-        fulldir = os.path.join(base_dir, dirname)
-        fulldir_files = glob.glob(os.path.join(fulldir, '*.thumb'))
-        files_to_delete = [f for f in fulldir_files if extension not in f]
-        for file in files_to_delete:
-            os.remove(file)
+        files = glob.glob(os.path.join(dirname, '*.thumb'))
+        for file in files:
+            if not any([x in file for x in extensions]):
+                os.remove(file)
 
 
 def query_format(string):


### PR DESCRIPTION
This makes a modification to the function introduced by #1061. With this update, the function will delete all thumbnails whose names do not contain any of a list of substrings. Previously only a single substring was allowed.

Now we can keep thumbnails for "rate" and "dark" files. The thumbnails from the dark files is our one exception to the rule of making thumbnails only for rate files. That's because dark files don't get processed through the pipeline far enough to create rate files.