### PR TITLE
Fixed cosmic ray monitor chunk iteration

### DIFF
--- a/jwql/instrument_monitors/common_monitors/cosmic_ray_monitor.py
+++ b/jwql/instrument_monitors/common_monitors/cosmic_ray_monitor.py
@@ -615,7 +615,7 @@ class CosmicRay:
                     input_files.append(file_name)
                     output_files[file_name] = existing_files[file_name]
 
-            for file_name in file_chunk:
+            for file_name in input_files:
 
                 head = fits.getheader(file_name)
                 self.nints = head['NINTS']
@@ -705,10 +705,10 @@ class CosmicRay:
                     logging.error("Could not insert entry into database. \n")
                     logging.error(e)
 
-                if len(no_coord_files) > 0:
-                    logging.error("{} files had no jump co-ordinates".format(len(no_coord_files)))
-                    for file_name in no_coord_files:
-                        logging.error("\t{} had no jump co-ordinates".format(file_name))
+            if len(no_coord_files) > 0:
+                logging.error("{} files had no jump co-ordinates".format(len(no_coord_files)))
+                for file_name in no_coord_files:
+                    logging.error("\t{} had no jump co-ordinates".format(file_name))
 
 
     def pull_filenames(self, file_info):


### PR DESCRIPTION
This fixes the cosmic ray iteration by iterating through the list of files that were just calibrated, rather than the original list, after calibration has happened.