### PR TITLE
Update Common Monitor Scripts

### DIFF
--- a/jwql/instrument_monitors/common_monitors/bias_monitor.py
+++ b/jwql/instrument_monitors/common_monitors/bias_monitor.py
@@ -372,13 +372,19 @@ class Bias():
 
         for filename in file_list:
             logging.info('\tWorking on file: {}'.format(filename))
+            
+            if filename not in outputs:
+                processed_file = filename.replace("uncal_0thgroup", "refpix")
+                if not os.path.isfile(processed_file):
+                    logging.warning("Pipeline was unable to process {}".format(filename))
+                    logging.warning("File will be skipped.")
+                    continue
+            else:
+                processed_file = outputs[filename]
 
             # Get relevant header info for this file
             self.read_pattern = fits.getheader(filename, 0)['READPATT']
             self.expstart = '{}T{}'.format(fits.getheader(filename, 0)['DATE-OBS'], fits.getheader(filename, 0)['TIME-OBS'])
-
-            # Run the file through the necessary pipeline steps
-            processed_file = outputs[filename]
 
             # Find amplifier boundaries so per-amp statistics can be calculated
             _, amp_bounds = instrument_properties.amplifier_info(processed_file, omit_reference_pixels=True)

--- a/jwql/instrument_monitors/common_monitors/cosmic_ray_monitor.py
+++ b/jwql/instrument_monitors/common_monitors/cosmic_ray_monitor.py
@@ -615,13 +615,26 @@ class CosmicRay:
                     input_files.append(file_name)
                     output_files[file_name] = existing_files[file_name]
 
-            for file_name in file_chunk:
+            for file_name in input_files:
 
                 head = fits.getheader(file_name)
                 self.nints = head['NINTS']
 
                 dir_name = '_'.join(os.path.basename(file_name).split('_')[:2])  # file_name[51:76]
                 self.obs_dir = os.path.join(self.data_dir, dir_name)
+                
+                if file_name not in obs_files:
+                    head = fits.getheader(file_name)
+                    nints = head['NINTS']
+                    out_exts = ["jump", "0_ramp_fit"]
+                    if nints > 1:
+                        out_exts[-1] = "1_ramp_fit"
+                    for ext in out_exts:
+                        ext_file = os.path.basename(file_name).replace("uncal", "ext")
+                        if not os.path.isfile(os.path.join(self.obs_dir, ext_file)):
+                            logging.warning("\tOutput {} missing".format(ext_file))
+                            logging.warning("\tSkipping {}".format(os.path.basename(file_name)))
+                            continue
 
                 obs_files = output_files[file_name]
 
@@ -705,10 +718,10 @@ class CosmicRay:
                     logging.error("Could not insert entry into database. \n")
                     logging.error(e)
 
-                if len(no_coord_files) > 0:
-                    logging.error("{} files had no jump co-ordinates".format(len(no_coord_files)))
-                    for file_name in no_coord_files:
-                        logging.error("\t{} had no jump co-ordinates".format(file_name))
+            if len(no_coord_files) > 0:
+                logging.error("{} files had no jump co-ordinates".format(len(no_coord_files)))
+                for file_name in no_coord_files:
+                    logging.error("\t{} had no jump co-ordinates".format(file_name))
 
 
     def pull_filenames(self, file_info):


### PR DESCRIPTION
This updates the common instrument monitor scripts (bad pixel, bias, cosmic ray, dark, read noise) to be more tolerant of some issues that can occur when processing files to generate references:

- Some files may not be processed because they have >1000 groups
- Some files may fail to process for unrelated reasons
- Some files may already have calibrated versions available locally, and so may not need to be calibrated again

In general, these monitor versions retain the current scripts, with the following changes:

- files that fail to calibrate are removed from the list that will be added to the database (or used to create a reference file)
- If calibrated data already exists locally, then the file will not be sent as a pipeline task
- If the monitor has a threshold number of files to produce output, then the threshold value is checked both before pipeline tasks start and after failed calibrations have been removed.