### PR TITLE
Add missing shebang line to archive_database_update

### DIFF
--- a/jwql/website/apps/jwql/archive_database_update.py
+++ b/jwql/website/apps/jwql/archive_database_update.py
@@ -1,3 +1,5 @@
+#! /usr/bin env python
+
 """Script that can be used to query MAST and return basic info
 about all proposals. This information is used to help populate
 the instrument archive pages


### PR DESCRIPTION
I think this missing line is what was keeping the archive_database_update.py cronjob from running.