### PR TITLE
Exposure page: Default to show rate img, keep order of radio buttons constant

### DIFF
--- a/jwql/utils/constants.py
+++ b/jwql/utils/constants.py
@@ -184,6 +184,11 @@ EXPTYPES = {"nircam": {"imaging": "NRC_IMAGE", "ts_imaging": "NRC_TSIMAGE",
                        "pom": "NIS_IMAGE", "wfss": "NIS_WFSS"},
             "fgs": {"imaging": "FGS_IMAGE"}}
 
+EXPOSURE_PAGE_SUFFIX_ORDER = ['uncal', 'dark', 'trapsfilled', 'ramp', 'rate', 'rateints', 'fitopt', 'cal', 'calints',
+                              'msa', 'crf', 'crfints', 'bsub', 'bsubints', 'i2d', 's2d', 's3d', 'x1d', 'x1dints',
+                              'cat', 'segm', 'c1d', 'psfstack', 'psfalign', 'psfsub', 'amiavg', 'aminorm', 'ami',
+                              'psf-amiavg', 'phot', 'whtlt', 'wfscmb']
+
 # Filename Component Lengths
 FILE_AC_CAR_ID_LEN = 4
 FILE_AC_O_ID_LEN = 3

--- a/jwql/website/apps/jwql/templates/view_image.html
+++ b/jwql/website/apps/jwql/templates/view_image.html
@@ -67,7 +67,7 @@
                         {% if index != 0 %}
                             <a role="button" class="btn btn-primary my-2" type="submit" href="{{ base_url }}/{{ inst }}/{{ file_root_list[obsnum][index-1] }}/" style="float: left;">< Previous</a>
                         {% endif %}
-        
+
                         {% if index != file_root_list[obsnum]|length - 1 %}
                             <a role="button" class="btn btn-primary my-2" type="submit" href="{{ base_url }}/{{ inst }}/{{ file_root_list[obsnum][index+1] }}/" style="float: right;">Next ></a>
                         {% endif %}
@@ -115,12 +115,12 @@
             <script>update_viewed_button(false)</script>
         {% endif %}
         <!-- Determine which filetype should be shown on load -->
-        {% if 'cal' in suffixes %}
-            <script>change_filetype('cal', '{{file_root}}', '{{num_ints}}', "{{available_ints}}", "{{total_ints}}", '{{inst}}');</script>
-        {% elif 'rate' in suffixes %}
+        {% if 'rate' in suffixes %}
             <script>change_filetype('rate', '{{file_root}}', '{{num_ints}}', "{{available_ints}}", "{{total_ints}}", '{{inst}}');</script>
-        {% elif 'uncal' in suffixes %}
-            <script>change_filetype('uncal', '{{file_root}}', '{{num_ints}}', "{{available_ints}}", "{{total_ints}}", '{{inst}}');</script>
+        {% elif 'dark' in suffixes %}
+            <script>change_filetype('dark', '{{file_root}}', '{{num_ints}}', "{{available_ints}}", "{{total_ints}}", '{{inst}}');</script>
+        {% elif 'rateints' in suffixes %}
+            <script>change_filetype('rateints', '{{file_root}}', '{{num_ints}}', "{{available_ints}}", "{{total_ints}}", '{{inst}}');</script>
         {% elif suffixes|length == 1 %}
             <script>change_filetype('{{suffixes.0}}', '{{file_root}}', '{{num_ints}}', "{{available_ints}}", "{{total_ints}}", '{{inst}}');</script>
         {% else %}

--- a/jwql/website/apps/jwql/templates/view_image.html
+++ b/jwql/website/apps/jwql/templates/view_image.html
@@ -119,7 +119,7 @@
             <script>change_filetype('rate', '{{file_root}}', '{{num_ints}}', "{{available_ints}}", "{{total_ints}}", '{{inst}}');</script>
         {% elif 'dark' in suffixes %}
             <script>change_filetype('dark', '{{file_root}}', '{{num_ints}}', "{{available_ints}}", "{{total_ints}}", '{{inst}}');</script>
-        {% elif 'rateints' in suffixes %}
+        {% elif 'uncal' in suffixes %}
             <script>change_filetype('uncal', '{{file_root}}', '{{num_ints}}', "{{available_ints}}", "{{total_ints}}", '{{inst}}');</script>
         {% elif suffixes|length == 1 %}
             <script>change_filetype('{{suffixes.0}}', '{{file_root}}', '{{num_ints}}', "{{available_ints}}", "{{total_ints}}", '{{inst}}');</script>

--- a/jwql/website/apps/jwql/templates/view_image.html
+++ b/jwql/website/apps/jwql/templates/view_image.html
@@ -120,7 +120,7 @@
         {% elif 'dark' in suffixes %}
             <script>change_filetype('dark', '{{file_root}}', '{{num_ints}}', "{{available_ints}}", "{{total_ints}}", '{{inst}}');</script>
         {% elif 'rateints' in suffixes %}
-            <script>change_filetype('rateints', '{{file_root}}', '{{num_ints}}', "{{available_ints}}", "{{total_ints}}", '{{inst}}');</script>
+            <script>change_filetype('uncal', '{{file_root}}', '{{num_ints}}', "{{available_ints}}", "{{total_ints}}", '{{inst}}');</script>
         {% elif suffixes|length == 1 %}
             <script>change_filetype('{{suffixes.0}}', '{{file_root}}', '{{num_ints}}', "{{available_ints}}", "{{total_ints}}", '{{inst}}');</script>
         {% else %}

--- a/jwql/website/apps/jwql/views.py
+++ b/jwql/website/apps/jwql/views.py
@@ -42,6 +42,7 @@ Dependencies
 """
 
 from collections import defaultdict
+from copy import deepcopy
 import csv
 import os
 

--- a/jwql/website/apps/jwql/views.py
+++ b/jwql/website/apps/jwql/views.py
@@ -957,8 +957,8 @@ def view_image(request, inst, file_root, rewrite=False):
                 file_entries = list(files_arr[idxs])
                 suffixes.extend(suff_entries)
                 all_files.extend(file_entries)
-                untracked_suffixes = np.delete(untracked_suffixes, idx)
-                untracked_files = np.delete(untracked_files, idx)
+                untracked_suffixes = np.delete(untracked_suffixes, idxs)
+                untracked_files = np.delete(untracked_files, idxs)
 
     # If the data contain any suffixes that are not in the list that specifies the order
     # to use, make a note in the log (so that they can be added to EXPOSURE_PAGE_SUFFIX_ORDER)

--- a/jwql/website/apps/jwql/views.py
+++ b/jwql/website/apps/jwql/views.py
@@ -53,7 +53,7 @@ from django.shortcuts import redirect, render
 from jwql.database.database_interface import load_connection
 from jwql.utils import anomaly_query_config
 from jwql.utils.interactive_preview_image import InteractivePreviewImg
-from jwql.utils.constants import JWST_INSTRUMENT_NAMES_MIXEDCASE, MONITORS, URL_DICT, THUMBNAIL_FILTER_LOOK
+from jwql.utils.constants import EXPOSURE_PAGE_SUFFIX_ORDER, JWST_INSTRUMENT_NAMES_MIXEDCASE, MONITORS, URL_DICT, THUMBNAIL_FILTER_LOOK
 from jwql.utils.utils import filename_parser, get_base_url, get_config, get_rootnames_for_instrument_proposal, query_unformat
 
 from .data_containers import build_table
@@ -924,6 +924,32 @@ def view_image(request, inst, file_root, rewrite=False):
     template = 'view_image.html'
     image_info = get_image_info(file_root, rewrite)
 
+    # Put suffixes in a consistent order. Check if any of the
+    # suffixes are not in the list that specifies order.
+    # Reorder the list of filenames to match the reordered list
+    # of suffixes.
+    suffixes = []
+    all_files = []
+    untracked_suffixes = deepcopy(image_info['suffixes'])
+    untracked_files = deepcopy(image_info['all_files'])
+    for poss_suffix in EXPOSURE_PAGE_SUFFIX_ORDER:
+        if poss_suffix in image_info['suffixes']:
+            suffixes.append(poss_suffix)
+            loc = image_info['suffixes'].index(poss_suffix)
+
+            all_files.append(image_info['all_files'][loc])
+            untracked_suffixes.remove(poss_suffix)
+            untracked_files.remove(image_info['all_files'][loc])
+
+    # If the data contain any suffixes that are not in the list that specifies the order
+    # to use, make a note in the log and add them to the end of the suffixes list.
+    if len(untracked_suffixes) > 0:
+        logging.warning((f'For {inst}, {file_root}, the following suffixes are present in the data, '
+                         f'but not in EXPOSURE_PAGE_SUFFIX_ORDER in constants.py: {untracked_suffixes} '
+                         'Please add them, so that they will appear in a consistent order on the webpage.'))
+        suffixes.extend(untracked_suffixes)
+        all_files.extend(untracked_files)
+
     form = get_anomaly_form(request, inst, file_root)
 
     prop_id = file_root[2:7]
@@ -954,8 +980,8 @@ def view_image(request, inst, file_root, rewrite=False):
                'obsnum': file_root[7:10],
                'file_root': file_root,
                'jpg_files': image_info['all_jpegs'],
-               'fits_files': image_info['all_files'],
-               'suffixes': image_info['suffixes'],
+               'fits_files': all_files,
+               'suffixes': suffixes,
                'num_ints': image_info['num_ints'],
                'available_ints': image_info['available_ints'],
                'total_ints': image_info['total_ints'],

--- a/jwql/website/apps/jwql/views.py
+++ b/jwql/website/apps/jwql/views.py
@@ -960,8 +960,8 @@ def view_image(request, inst, file_root, rewrite=False):
 
                 untracked_splits = np.array([ele.split('_')[-1] for ele in untracked_suffixes])
                 untracked_idxs = np.where(untracked_splits == poss_suffix)[0]
-                untracked_suffixes = np.delete(untracked_suffixes, untracked_idxs)
-                untracked_files = np.delete(untracked_files, untracked_idxs)
+                untracked_suffixes = list(np.delete(untracked_suffixes, untracked_idxs))
+                untracked_files = list(np.delete(untracked_files, untracked_idxs))
 
     # If the data contain any suffixes that are not in the list that specifies the order
     # to use, make a note in the log (so that they can be added to EXPOSURE_PAGE_SUFFIX_ORDER)

--- a/jwql/website/apps/jwql/views.py
+++ b/jwql/website/apps/jwql/views.py
@@ -957,8 +957,11 @@ def view_image(request, inst, file_root, rewrite=False):
                 file_entries = list(files_arr[idxs])
                 suffixes.extend(suff_entries)
                 all_files.extend(file_entries)
-                untracked_suffixes = np.delete(untracked_suffixes, idxs)
-                untracked_files = np.delete(untracked_files, idxs)
+
+                untracked_splits = np.array([ele.split('_')[-1] for ele in untracked_suffixes])
+                untracked_idxs = np.where(untracked_splits == poss_suffix)[0]
+                untracked_suffixes = np.delete(untracked_suffixes, untracked_idxs)
+                untracked_files = np.delete(untracked_files, untracked_idxs)
 
     # If the data contain any suffixes that are not in the list that specifies the order
     # to use, make a note in the log (so that they can be added to EXPOSURE_PAGE_SUFFIX_ORDER)

--- a/jwql/website/apps/jwql/views.py
+++ b/jwql/website/apps/jwql/views.py
@@ -957,8 +957,8 @@ def view_image(request, inst, file_root, rewrite=False):
                 file_entries = list(files_arr[idxs])
                 suffixes.extend(suff_entries)
                 all_files.extend(file_entries)
-                untracked_suffixes = np.remove(untracked_suffixes, idx)
-                untracked_files = np.remove(untracked_files, idx)
+                untracked_suffixes = np.delete(untracked_suffixes, idx)
+                untracked_files = np.delete(untracked_files, idx)
 
     # If the data contain any suffixes that are not in the list that specifies the order
     # to use, make a note in the log (so that they can be added to EXPOSURE_PAGE_SUFFIX_ORDER)

--- a/jwql/website/apps/jwql/views.py
+++ b/jwql/website/apps/jwql/views.py
@@ -51,6 +51,7 @@ from bokeh.layouts import layout
 from bokeh.embed import components
 from django.http import HttpResponse, JsonResponse
 from django.shortcuts import redirect, render
+import numpy as np
 
 from jwql.database.database_interface import load_connection
 from jwql.utils import anomaly_query_config, monitor_utils


### PR DESCRIPTION
Small adjustments such that the rate image is shown by default when clicking on the page for a given exposure. If there is n rate image, then it looks for a dark suffix. 

There are also changes such that we try to keep the order of the radio buttons that list the available suffixes as consistent as possible, with the only changes coming from which suffixes are present.