### PR TITLE
Clarify reset_database.py statement

### DIFF
--- a/jwql/database/reset_database.py
+++ b/jwql/database/reset_database.py
@@ -76,8 +76,8 @@ if __name__ == '__main__':
         sys.stderr.write(msg)
         sys.exit(1)
 
-    msg = 'About to reset instruments: {} and monitors: {} tables for database instance {}. Do you wish to proceed? (y/N)'
-    response = input(msg.format(monitor, instrument, connection_string))
+    msg = 'About to reset instruments: [{}] and monitors: [{}] tables for database instance {}. Do you wish to proceed? (y/N)'
+    response = input(msg.format(instrument, monitor, connection_string))
 
     if response.lower() != 'y':
         print("Did not enter y/Y. Stopping.")


### PR DESCRIPTION
Just a small change to the message printed to the screen when asking the user to confirm the database reset. The instrument name and monitor name were being printed in the wrong order, which made the message confusing. I also enclosed the values in brackets, just to separate them from the rest of the text a bit more.

@mfixstsci this is ready for review.