### PR TITLE
added scattered light, light saber anomalies for niriss

### DIFF
--- a/jwql/utils/constants.py
+++ b/jwql/utils/constants.py
@@ -80,6 +80,8 @@ ANOMALIES_PER_INSTRUMENT = {
     'row_pull_down': ['miri'],
     'LRS_Contamination': ['miri'],
     'tree_rings': ['miri'],
+    'scattered_light': ['niriss'],
+    'light_saber': ['niriss'],
     # additional anomalies:
     'other': ['fgs', 'miri', 'nircam', 'niriss', 'nirspec']}
 # anomalies that shouldn't be 'titleized'


### PR DESCRIPTION
Addresses issue #1128, adding NIRISS-specific anomalies to constants.py 

Requires NIRISS anomaly database reset.