### PR TITLE
Add more details to EDB documentation

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -17,4 +17,6 @@ sphinx:
 # Optionally declare the Python requirements required to build your docs
 python:
    install:
+    - method: pip
+    path: .
    - requirements: rtd_requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -19,4 +19,4 @@ python:
    install:
     - method: pip
     path: .
-   - requirements: rtd_requirements.txt
+    - requirements: rtd_requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -17,6 +17,6 @@ sphinx:
 # Optionally declare the Python requirements required to build your docs
 python:
    install:
-    - method: pip
-    path: .
-    - requirements: rtd_requirements.txt
+      - method: pip
+        path: .
+        extra_args: -r rtd_requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,12 +5,13 @@
 version: 2
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-20.04
+  os: ubuntu-22.04
   tools:
     python: "3.9"
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
    configuration: docs/source/conf.py
+   fail_on_warning: true
 # If using Sphinx, optionally build your docs in additional formats such as PDF
 # formats:
 #    - pdf
@@ -18,4 +19,5 @@ sphinx:
 python:
    install:
       - requirements: rtd_requirements.txt
-      - path: .
+      - method: pip
+        path: .

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,7 +11,7 @@ build:
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
    configuration: docs/source/conf.py
-   fail_on_warning: true
+   fail_on_warning: false
 # If using Sphinx, optionally build your docs in additional formats such as PDF
 # formats:
 #    - pdf

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -17,6 +17,5 @@ sphinx:
 # Optionally declare the Python requirements required to build your docs
 python:
    install:
-      - method: pip
-        path: .
-        extra_args: -r rtd_requirements.txt
+      - requirements: rtd_requirements.txt
+      - path: .

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -82,7 +82,7 @@ release = jwql.__version__
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # This is a fix for warnings because of sphinx-autodoc interaction for classes,
 # however it removes method table from the docs.

--- a/jwql/edb/engineering_database.py
+++ b/jwql/edb/engineering_database.py
@@ -405,8 +405,6 @@ class EdbMnemonic:
         return_fig : bool
             If True, return the plot as a bokeh Figure object
 
-        Parameters
-        ----------
         show_plot : boolean
             A switch to show the plot in the browser or not.
 

--- a/jwql/edb/engineering_database.py
+++ b/jwql/edb/engineering_database.py
@@ -363,8 +363,8 @@ class EdbMnemonic:
         nominal (expected) value, as well as yellow and red background regions to denote values that
         may be unexpected.
 
-        Paramters
-        ---------
+        Parameters
+        ----------
         show_plot : bool
             If True, show plot on screen rather than returning div and script
 
@@ -750,8 +750,8 @@ class EdbMnemonic:
         may be unexpected. Also add a plot of the mean value over time and in a second figure, a plot of
         the devaition from the mean.
 
-        Paramters
-        ---------
+        Parameters
+        ----------
         show_plot : bool
             If True, show plot on screen rather than returning div and script
 
@@ -1250,8 +1250,8 @@ def create_time_offset(dt_obj, epoch):
     """Subtract input epoch from a datetime object and return the
     residual number of seconds
 
-    Paramters
-    ---------
+    Parameters
+    ----------
     dt_obj : datetime.datetime
         Original datetiem object
 

--- a/jwql/instrument_monitors/common_monitors/edb_telemetry_monitor.py
+++ b/jwql/instrument_monitors/common_monitors/edb_telemetry_monitor.py
@@ -21,12 +21,12 @@ Statistics
 After filtering the data, the monitor calcualtes statistics. The monitor supports several different types
 averaging. These include:
 
-1. **daily_means** - This is designed for mnemonics whose values do not change much over the course of a
+1. **daily\_means** - This is designed for mnemonics whose values do not change much over the course of a
 day. In this case, mnemonic data is retrieved over a small amount of time each day (e.g. 12:00 - 12:15).
 From these data, a daily mean is calculated. For all other types of telemetry, the EDB queries span
 the full day.
 
-2. **block_means** - These are mnemonics where the user wishes to see mean values associated with each
+2. **block\_means** - These are mnemonics where the user wishes to see mean values associated with each
 block of entries in the retrieved and filtered data. For example, you want to examine a voltage at times
 when some other current is less than 0.25A. The script will read in all telemetry data, and filter out
 data points for times where the current did not meet the criteria. It will then calculate the mean of
@@ -34,15 +34,15 @@ each remaining block of continuous good data. So if the data were good from 2:00
 3:00, and good again from 3:00-4:00, then the monitor will calculate a mean value for the 2:00-2:30
 period, and a mean from the 3:00-4:00 period.
 
-3. **time_interval** - Mnemonics in this category have their data retrieved and filtered, and then averaged
+3. **time\_interval** - Mnemonics in this category have their data retrieved and filtered, and then averaged
 over the requested time interval. For example, if the user sets a time interval of 5 minutes, then the
 monitor caculates the mean value within each 5-minute block of the total time range of the data, and plots
 the average values.
 
-4. **every_change** - This is the most complex case. Mnemonics in this category have their data filtered
-and organized based on the value of a secondary mnemonic. For example, the IMIR_HK_GW14_POS_RATIO returns
+4. **every\_change** - This is the most complex case. Mnemonics in this category have their data filtered
+and organized based on the value of a secondary mnemonic. For example, the IMIR\_HK\_GW14\_POS\_RATIO returns
 a measure of the position of MIRI's grating wheel. We can plot this position as a function of the commanded
-location of the grating wheel, which is provided by IMIR_HK_GW14_CUR_POS. In this case, the monitor will
+location of the grating wheel, which is provided by IMIR\_HK\_GW14\_CUR\_POS. In this case, the monitor will
 loop over the commanded positions and for each, gather the measured position information. The measured
 positions associated with each commanded position will then be plotted separately. Note that this use
 of "every change" is separate from the idea of every-change telemetry, in which telemetry points are
@@ -52,15 +52,15 @@ change-only telemetry data, but this should be largely invisible to the EDB Tele
 5. **all** - In this case, no averaging is done. (Although filtering is still done) All filtered data
 are kept as they are retrived from the EDB, and plotted without any modification.
 
-6. **all+daily_means** - This is a combination of the "all" and "daily_means" cases above. All data points
+6. **all+daily\_means** - This is a combination of the "all" and "daily\_means" cases above. All data points
 are retrieved from the EDB and optionally filtered by dependencies. Then daily means are calculated.
 Both the full set of data and the daily means are plotted, along with deviations from the mean.
 
-7. **all+block_means** - This is a combination of the "all" and "block_means" cases above. All data points
+7. **all+block\_means** - This is a combination of the "all" and "block\_means" cases above. All data points
 are retrieved from the EDB and optionally filtered by dependencies. Then means for each block of good data
 are calculated. Both the full set of data and the means are plotted, along with deviations from the mean.
 
-8. **all+time_interval** - This is a combination of the "all" and "time_interval" cases above. All data points
+8. **all+time\_interval** - This is a combination of the "all" and "time\_interval" cases above. All data points
 are retrieved from the EDB and optionally filtered by dependencies. Then means are calculated for each block
 of time lasting the duration of the time interval. Both the full set of data and the means are plotted, along
 with deviations from the mean.
@@ -69,30 +69,34 @@ JSON file format
 ----------------
 
 The type of data averaging is at the top level of the JSON file. Values must match the 8 types described above.
-Each mnemonic's entry has several pieces of information:
+The entry for each mnemonic has several pieces of information, described below.
 
-* **"name"**: Name of the mnemonic as it appears in the EDB.
-* **"database_id"**: Optional name to use in the plot title for this mnemonic. Any averaged data saved to the JWQL database will be saved under this name if it is present.
-* **"description"**: Summary describing the data contained in the mnemonic. Placed in the plot title.
-* **"dependency"**: This is a list of mnemonics and conditions that will be used to filter the data
-* **"plot_data"**: Description of how the data are to be plotted. There are two options: "nominal", in which case the mnemonic data are plotted as-is, and "*<mnem>" where <mnem> is the name of another mnemonic. In this case, the data for this second mnemonic are retrieved using the same dependencies as the primary mnemonic. The primary mnemonic and this second mnemonic are then multiplied together and plotted. This option was designed around plotting power as the product of current and voltage.
+- **name**: Name of the mnemonic as it appears in the EDB.
+- **database\_id** Optional name to use in the plot title for this mnemonic. Any averaged data saved to the JWQL database will be saved under this name if it is present.
+- **description**: Summary describing the data contained in the mnemonic. Placed in the plot title.
+- **dependency**: This is a list of mnemonics and conditions that will be used to filter the data
+- **plot\_data**: Description of how the data are to be plotted. There are two options: "nominal", in which case
+  the mnemonic data are plotted as-is, and "*<mnem>" where <mnem> is the name of another mnemonic. In this case, the
+  data for this second mnemonic are retrieved using the same dependencies as the primary mnemonic. The primary mnemonic
+  and this second mnemonic are then multiplied together and plotted. This option was designed around plotting power as
+  the product of current and voltage.
 
-A further option for the **"plot_data"** field is the addition of a comma-separated list of statistics to be overplotted.
+A further option for the **"plot\_data"** field is the addition of a comma-separated list of statistics to be overplotted.
 Options are: "mean", "median", "max", and "min". Note that this is a little confusing, because in many cases the menmonic's
 data will already contain the median value of the data (and the original data as returned from the EDB will not be
-available). The monitor realized this though, so if you specify "mean" for a mnemonic in the "daily_mean" list, it will simply
+available). The monitor realized this though, so if you specify "mean" for a mnemonic in the "daily\_mean" list, it will simply
 plot the same data twice, on top of itself.
 
-As an example, in order to plot the daily mean and maximum values of the product of SE_ZIMIRICEA and SE_ZBUSVLT, the plot_data
-entry would be: "*SE_ZBUSVLT,max". If you also wanted to plot the minimum daily value, the entry would be: "*SE_ZBUSVLT,max,min".
-And similarly, to plot SE_ZIMIRICEA on its own (not as a product), the plot_data entries shown above would become: "nominal,max"
+As an example, in order to plot the daily mean and maximum values of the product of SE\_ZIMIRICEA and SE\_ZBUSVLT, the plot\_data
+entry would be: "*SE\_ZBUSVLT,max". If you also wanted to plot the minimum daily value, the entry would be: "*SE\_ZBUSVLT,max,min".
+And similarly, to plot SE\_ZIMIRICEA on its own (not as a product), the plot\_data entries shown above would become: "nominal,max"
 and "nominal,max,min".
 
-* **"nominal_value"**: Optional. The "expected" value for this mnemonic. If provided, a horizontal dashed line will be added at this value.
-* **"yellow_limits"**: Optional. This is a list of two values that describe the lower and upper limits of the expected range of the mnemonic's value. If these are present, a green background is added to the plot at values between these limits. Outside of these limits, the background is yellow.
-* **"red_limits"**: Optional. Similar to yellow_limits above. In this case the lower and upper limits represent the thresholds outside of which there may be a problem. In this case, the background of the plot outside of these values is red.
-* **"plot_category"**: This is the name of the tab on the website into which this plot should be placed.
-* **"mean_time_block"**: Optional. This is only used for ``time_interval`` mnemonics. It describes the length of time over which to bin and average the data. The value consists of a number and a unit of time: e.g. "15_minutes"
+* **nominal_value**: Optional. The "expected" value for this mnemonic. If provided, a horizontal dashed line will be added at this value.
+* **yellow_limits**: Optional. This is a list of two values that describe the lower and upper limits of the expected range of the mnemonic's value. If these are present, a green background is added to the plot at values between these limits. Outside of these limits, the background is yellow.
+* **red_limits**: Optional. Similar to yellow_limits above. In this case the lower and upper limits represent the thresholds outside of which there may be a problem. In this case, the background of the plot outside of these values is red.
+* **plot_category**: This is the name of the tab on the website into which this plot should be placed.
+* **mean_time_block**: Optional. This is only used for ``time_interval`` mnemonics. It describes the length of time over which to bin and average the data. The value consists of a number and a unit of time: e.g. "15_minutes"
 
 Below we present details on how to construct json entries for these specific cases.
 

--- a/jwql/instrument_monitors/common_monitors/edb_telemetry_monitor.py
+++ b/jwql/instrument_monitors/common_monitors/edb_telemetry_monitor.py
@@ -1,6 +1,9 @@
 #! /usr/bin/env python
 
-"""Engineering Database Mnemonics Trending Monitor (EDB Trending Monitor)
+"""
+######################################################################
+Engineering Database Mnemonics Trending Monitor (EDB Trending Monitor)
+######################################################################
 
 This module contains code for the Engineering Database Telemetry monitor. For a given mnemonic,
 this monitor retrieves telemetry data from the EDB, filters the data based on optional conditions,
@@ -12,28 +15,31 @@ on the values of the mnemonic's own data (e.g. keep only entries where the volta
 filtering based on the values of dependency mnemonics. For example, keep data for mnemonic A only
 when mnemonic B is > 0.25V and mnemonic C is less than 38K.
 
+Statistics
+----------
+
 After filtering the data, the monitor calcualtes statistics. The monitor supports several different types
 averaging. These include:
 
-1. "daily_means" - This is designed for mnemonics whose values do not change much over the course of a
+1. **daily_means** - This is designed for mnemonics whose values do not change much over the course of a
 day. In this case, mnemonic data is retrieved over a small amount of time each day (e.g. 12:00 - 12:15).
 From these data, a daily mean is calculated. For all other types of telemetry, the EDB queries span
 the full day.
 
-2. "block_means" - These are mnemonics where the user wishes to see mean values associated with each
+2. **block_means** - These are mnemonics where the user wishes to see mean values associated with each
 block of entries in the retrieved and filtered data. For example, you want to examine a voltage at times
 when some other current is less than 0.25A. The script will read in all telemetry data, and filter out
 data points for times where the current did not meet the criteria. It will then calculate the mean of
 each remaining block of continuous good data. So if the data were good from 2:00 to 2:30, then bad until
-3:00, and good again from 3:00 - 4:00, then the monitor will calculate a mean value for the 2:00-2:30
+3:00, and good again from 3:00-4:00, then the monitor will calculate a mean value for the 2:00-2:30
 period, and a mean from the 3:00-4:00 period.
 
-3. "time_interval" - Mnemonics in this category have their data retrieved and filtered, and then averaged
+3. **time_interval** - Mnemonics in this category have their data retrieved and filtered, and then averaged
 over the requested time interval. For example, if the user sets a time interval of 5 minutes, then the
 monitor caculates the mean value within each 5-minute block of the total time range of the data, and plots
 the average values.
 
-4. "every_change" - This is the most complex case. Mnemonics in this category have their data filtered
+4. **every_change** - This is the most complex case. Mnemonics in this category have their data filtered
 and organized based on the value of a secondary mnemonic. For example, the IMIR_HK_GW14_POS_RATIO returns
 a measure of the position of MIRI's grating wheel. We can plot this position as a function of the commanded
 location of the grating wheel, which is provided by IMIR_HK_GW14_CUR_POS. In this case, the monitor will
@@ -43,24 +49,56 @@ of "every change" is separate from the idea of every-change telemetry, in which 
 only generated at times when the telemetry value changes. Some of the mnemonics in the EDB do contain
 change-only telemetry data, but this should be largely invisible to the EDB Telemetry Monitor user.
 
-5. "all" - In this case, no averaging is done. (Although filtering is still done) All filtered data
+5. **all** - In this case, no averaging is done. (Although filtering is still done) All filtered data
 are kept as they are retrived from the EDB, and plotted without any modification.
 
-6. "all+daily_means" - This is a combination of the "all" and "daily_means" cases above. All data points
+6. **all+daily_means** - This is a combination of the "all" and "daily_means" cases above. All data points
 are retrieved from the EDB and optionally filtered by dependencies. Then daily means are calculated.
 Both the full set of data and the daily means are plotted, along with deviations from the mean.
 
-7. "all+block_means" - This is a combination of the "all" and "block_means" cases above. All data points
+7. **all+block_means** - This is a combination of the "all" and "block_means" cases above. All data points
 are retrieved from the EDB and optionally filtered by dependencies. Then means for each block of good data
 are calculated. Both the full set of data and the means are plotted, along with deviations from the mean.
 
-8. "all+time_interval" - This is a combination of the "all" and "time_interval" cases above. All data points
+8. **all+time_interval** - This is a combination of the "all" and "time_interval" cases above. All data points
 are retrieved from the EDB and optionally filtered by dependencies. Then means are calculated for each block
 of time lasting the duration of the time interval. Both the full set of data and the means are plotted, along
 with deviations from the mean.
 
+JSON file format
+----------------
 
-Here is an example of two daily_mean telemetry entries in the json file. In both, SE_ZIMIRICEA values are retrieved.
+The type of data averaging is at the top level of the JSON file. Values must match the 8 types described above.
+Each mnemonic's entry has several pieces of information:
+
+* **"name"**: Name of the mnemonic as it appears in the EDB.
+* **"database_id"**: Optional name to use in the plot title for this mnemonic. Any averaged data saved to the JWQL database will be saved under this name if it is present.
+* **"description"**: Summary describing the data contained in the mnemonic. Placed in the plot title.
+* **"dependency"**: This is a list of mnemonics and conditions that will be used to filter the data
+* **"plot_data"**: Description of how the data are to be plotted. There are two options: "nominal", in which case the mnemonic data are plotted as-is, and "*<mnem>" where <mnem> is the name of another mnemonic. In this case, the data for this second mnemonic are retrieved using the same dependencies as the primary mnemonic. The primary mnemonic and this second mnemonic are then multiplied together and plotted. This option was designed around plotting power as the product of current and voltage.
+
+A further option for the **"plot_data"** field is the addition of a comma-separated list of statistics to be overplotted.
+Options are: "mean", "median", "max", and "min". Note that this is a little confusing, because in many cases the menmonic's
+data will already contain the median value of the data (and the original data as returned from the EDB will not be
+available). The monitor realized this though, so if you specify "mean" for a mnemonic in the "daily_mean" list, it will simply
+plot the same data twice, on top of itself.
+
+As an example, in order to plot the daily mean and maximum values of the product of SE_ZIMIRICEA and SE_ZBUSVLT, the plot_data
+entry would be: "*SE_ZBUSVLT,max". If you also wanted to plot the minimum daily value, the entry would be: "*SE_ZBUSVLT,max,min".
+And similarly, to plot SE_ZIMIRICEA on its own (not as a product), the plot_data entries shown above would become: "nominal,max"
+and "nominal,max,min".
+
+* **"nominal_value"**: Optional. The "expected" value for this mnemonic. If provided, a horizontal dashed line will be added at this value.
+* **"yellow_limits"**: Optional. This is a list of two values that describe the lower and upper limits of the expected range of the mnemonic's value. If these are present, a green background is added to the plot at values between these limits. Outside of these limits, the background is yellow.
+* **"red_limits"**: Optional. Similar to yellow_limits above. In this case the lower and upper limits represent the thresholds outside of which there may be a problem. In this case, the background of the plot outside of these values is red.
+* **"plot_category"**: This is the name of the tab on the website into which this plot should be placed.
+* **"mean_time_block"**: Optional. This is only used for ``time_interval`` mnemonics. It describes the length of time over which to bin and average the data. The value consists of a number and a unit of time: e.g. "15_minutes"
+
+Below we present details on how to construct json entries for these specific cases.
+
+"daily_means" entries
+=====================
+Here is an example of two **daily_mean** telemetry entries in the json file. In both, SE_ZIMIRICEA values are retrieved.
 For the first plot, data are only kept for the times where the following dependencies are true:
 
 1. SE_ZIMIRICEA is > 0.2 A
@@ -69,52 +107,103 @@ For the first plot, data are only kept for the times where the following depende
 4. IMIR_HK_IFU_CAL_LOOP is OFF
 5. IMIR_HK_POM_LOOP is OFF
 
-For the second plot, data are kept for the times where IMIR_HK_ICE_SEC_VOLT1 is > 25 V. Note that the "database_id"
-entry is used to differentiate the plots of these two cases, as well as the entries in the JWQLDB.
+For the second plot, data are kept for the times where:
 
-{
-    "daily_means": [
+1. IMIR_HK_ICE_SEC_VOLT1 is > 25 V
+
+Note that the "database_id" entry is used to differentiate the plot labels of these two cases, as well as their entries in the JWQLDB.
+In both cases, the data are plotted as the product of SE_ZIMIRICEA and SE_ZBUSVLT. In the second case, the maximum daily value is also
+plotted. Both plots are placed in the ``power`` tab on the webpage.
+
+.. code-block:: json
+
+    {
+        "daily_means": [
+            {
+                "name": "SE_ZIMIRICEA",
+                "database_id": "SE_ZIMIRICEA_NO_OPS",
+                "description": "ICE drive current (no ops)",
+                "dependency": [
+                    {
+                        "name": "SE_ZIMIRICEA",
+                        "relation": ">",
+                        "threshold": 0.2
+                    },
+                    {
+                        "name": "IMIR_HK_ICE_SEC_VOLT1",
+                        "relation": "<",
+                        "threshold": 1
+                    },
+                    {
+                        "name": "IMIR_HK_IMG_CAL_LOOP",
+                        "relation": "=",
+                        "threshold": "OFF"
+                    },
+                    {
+                        "name": "IMIR_HK_IFU_CAL_LOOP",
+                        "relation": "=",
+                        "threshold": "OFF"
+                    },
+                    {
+                        "name": "IMIR_HK_POM_LOOP",
+                        "relation": "=",
+                        "threshold": "OFF"
+                    }
+                ],
+                "plot_data": "*SE_ZBUSVLT",
+                "nominal_value": 7.57,
+                "yellow_limits": [7.0, 8.13],
+                "plot_category": "power"
+            },
+            {
+                "name": "SE_ZIMIRICEA",
+                "database_id": "SE_ZIMIRICEA_OPS",
+                "description": "ICE drive current (ops)",
+                "dependency": [
+                    {
+                        "name": "IMIR_HK_ICE_SEC_VOLT1",
+                        "relation": ">",
+                        "threshold": 25
+                    }
+                ],
+                "plot_data": "*SE_ZBUSVLT,max",
+                "nominal_value": 11.13,
+                "yellow_limits": [10.23, 12.02],
+                "plot_category": "power"
+            }
+        ]
+    }
+
+
+For a case with no dependencies, the "dependencies" keyword can be left empty:
+
+.. code-block:: json
+
+    {
+        "name": "INRC_ICE_DC_VOL_P5_DIG",
+        "description": "ICE HK +5V voltage for digital electronics",
+        "dependency": [],
+        "plot_data": "nominal",
+        "yellow_limits": [4.99, 5.04],
+        "red_limits": [4.5, 5.5],
+        "plot_category": "ice_voltage"
+    }
+
+
+"block_means" entries
+=====================
+In the example shown below, we want to plot IMIR_HK_ICE_SEC_VOLT1 at times when it has values higher
+than 25V. In this case, the EDB monitor will find times when the voltage is under the 25V limit. These
+times will separate the blocks of time when the voltage does meet the threshold value. It then calculates
+and plots the median voltage within each of these blocks.
+
+.. code-block:: json
+
+    "block_means":[
         {
-            "name": "SE_ZIMIRICEA",
-            "database_id": "SE_ZIMIRICEA_NO_OPS",
-            "description": "ICE drive current (no ops)",
-            "dependency": [
-                {
-                    "name": "SE_ZIMIRICEA",
-                    "relation": ">",
-                    "threshold": 0.2
-                },
-                {
-                    "name": "IMIR_HK_ICE_SEC_VOLT1",
-                    "relation": "<",
-                    "threshold": 1
-                },
-                {
-                    "name": "IMIR_HK_IMG_CAL_LOOP",
-                    "relation": "=",
-                    "threshold": "OFF"
-                },
-                {
-                    "name": "IMIR_HK_IFU_CAL_LOOP",
-                    "relation": "=",
-                    "threshold": "OFF"
-                },
-                {
-                    "name": "IMIR_HK_POM_LOOP",
-                    "relation": "=",
-                    "threshold": "OFF"
-                }
-            ],
-            "plot_data": "*SE_ZBUSVLT",
-            "nominal_value": 7.57,
-            "yellow_limits": [7.0, 8.13],
-            "plot_category": "power",
-            "query_duration": "15 minutes"
-        },
-        {
-            "name": "SE_ZIMIRICEA",
-            "database_id": "SE_ZIMIRICEA_OPS",
-            "description": "ICE drive current (ops)",
+            "name": "IMIR_HK_ICE_SEC_VOLT1",
+            "database_id": "IMIR_HK_ICE_SEC_VOLT1_OPS",
+            "description": "ICE Secondary Voltage (HV) 1",
             "dependency": [
                 {
                     "name": "IMIR_HK_ICE_SEC_VOLT1",
@@ -122,42 +211,77 @@ entry is used to differentiate the plots of these two cases, as well as the entr
                     "threshold": 25
                 }
             ],
-            "plot_data": "*SE_ZBUSVLT",
-            "nominal_value": 11.13,
-            "yellow_limits": [10.23, 12.02],
-            "plot_category": "power",
-            "query_duration": "15 minutes"
+            "plot_data": "nominal",
+            "nominal_value": 39.24,
+            "yellow_limits": [39.14, 39.34],
+            "plot_category": "ICE_voltage"
         }
-    ]
-}
 
-Also note the plotting-related entries. In this case, the filtered SE_ZIMIRICEA data
-will be plotted as the product of SE_ZIMIRICEA*SE_ZBUSVLT. In addition, the plot will
-contain a "nominal_value". This is a horizontal line indicating the expected location
-of the data. In addition, the json entry defines yellow and red limits for the plot.
-These limits define background colors that are added to the plots. Areas of the plot
-below the lower yellow limit, and those greater than the larger yellow limit, will be
-colored yellow. Areas below the lower red limit, and those greater than the upper red
-limit, will be colored red. In the case where yellow and/or red areas are added, the
-central area of the plot will have a green background. These colors, as well as the
-nomincal_value line, are meant to help the user analyze the plot and see data that may
-be uncharacteristic or outside of desired limits.
+"time_interval" entries
+=======================
 
-For a case with no dependencies, the "dependencies" keyword can be left empty:
+For mnemonics to be averaged over some time period, use the "mean_time_block" entry.
+The value of mean_time_block should be a number followed by an underscore and a unit
+of time. Currently, the unit must contain one of "min", "sec", "hour", or "day". The
+monitor looks for one of these strings within the mean_time_block entry, meaning that
+"second", "seconds", "minutes", "minute", "hours", "days", etc are all valid entries.
 
+In the example below, the EDB monitor will bin the SE_ZINRCICE1 data into 5 minute blocks,
+and calculate and plot the mean of each block.
+
+.. code-block:: json
+
+    "time_interval": [
         {
-            "name": "INRC_ICE_DC_VOL_P5_DIG",
-            "description": "ICE HK +5V voltage for digital electronics",
+            "name": "SE_ZINRCICE1",
+            "description": "ICE1 current",
+            "mean_time_block": "5_min",
             "dependency": [],
             "plot_data": "nominal",
-            "yellow_limits": [4.99, 5.04],
-            "red_limits": [4.5, 5.5],
-            "plot_category": "ice_voltage"
+            "yellow_limits": [0.36, 0.8],
+            "red_limits": [0, 1.367],
+            "plot_category": "box_current"
         }
+    ]
 
+"every_change" entries
+======================
 
-For the case where no averaging is to be done, place the entries under the top-level
-"all" entry.
+This is a complex case and at the moment is customized for the MIRI filter wheel position
+mnemonics such as IMIR_HK_FW_POS_RATIO. In this case, the EDB monitor will retrieve data for
+the filter wheel position, which is a float at each time. It will also retrive the commmanded
+position of the filter wheel, which is a string at each time (e.g. OPEN, CLOSED). It then divides
+the filter wheel postiion data into groups based on the value of the commanded position (i.e. group
+together all of the postion data when the commanded position is OPEN). It then computes the median
+value of the filter position within each continuous block of time where the commanded position is
+constant. This median value is then normalized by the expected location value (retrieved from
+constants.py). One line is plotted for each commanded position.
+
+.. code-block:: json
+
+    "every_change": [
+        {
+            "name": "IMIR_HK_FW_POS_RATIO",
+            "description": "FW normalized position sensor voltage ratio",
+            "dependency": [
+                {
+                    "name": "IMIR_HK_FW_CUR_POS",
+                    "relation": "none",
+                    "threshold": 0
+                }
+            ],
+            "plot_data": "nominal",
+            "yellow_limits": [-1.6, 1.6],
+            "plot_category": "Position_sensors"
+        }
+    ]
+
+"all" entries
+=============
+In this case, no grouping or averaging of data from the EDB are done. Data are retrieved from the EDB,
+filtered by any dependencies, and plotted.
+
+.. code-block:: json
 
     "all": [
         {
@@ -178,25 +302,23 @@ For the case where no averaging is to be done, place the entries under the top-l
             "red_limits": [0, 1.372],
             "plot_category": "box_current"
         }
-
-For mnemonics to be averaged over some time period, use the "mean_time_block" entry.
-The value of mean_time_block should be a number followed by an underscore and a unit
-of time. Currently, the unit must contain one of "min", "sec", "hour", or "day". The
-monitor looks for one of these strings within the mean_time_block entry, meaning that
-"second", "seconds", "minutes", "minute", "hours", "days", etc are all valid entries.
-
-"time_interval": [
-        {
-            "name": "SE_ZINRCICE1",
-            "description": "ICE1 current",
-            "mean_time_block": "5_min",
-            "dependency": [],
-            "plot_data": "nominal",
-            "yellow_limits": [0.36, 0.8],
-            "red_limits": [0, 1.367],
-            "plot_category": "box_current"
-        }
     ]
+
+"all+daily_means" entries
+=========================
+This is a combination of the "daily_means" and "all" cases above.
+
+"all+block_means" entries
+=========================
+This is a combination of the "all" and "block_means" cases above.
+
+"all+time_interval" entries
+===========================
+This is a combination of the "all" and "time_interval" cases above.
+
+
+Summary of the EDB monitor operation
+------------------------------------
 
 The monitor is set up to find the total span of time over which the plots are requested
 (with the default being contolled by the value in jwql.utils.constants). It loops over
@@ -227,9 +349,10 @@ done asynchronously, which means that the EDB Telemetry Monitor web page shoudl 
 Author
 ------
     - Bryan Hilbert
+
 Use
 ---
-    This module can be used from the command line as such:
+    This module can be called from the command line like this:
 
     ::
 

--- a/jwql/tests/test_permissions.py
+++ b/jwql/tests/test_permissions.py
@@ -43,7 +43,7 @@ def test_directory(test_dir=TEST_DIRECTORY):
         Path to directory used for testing
 
     Yields
-    -------
+    ------
     test_dir : str
         Path to directory used for testing
     """
@@ -85,7 +85,7 @@ def test_file(test_dir=TEST_DIRECTORY):
         Path to directory used for testing
 
     Yields
-    -------
+    ------
     filename : str
         Path of file used for testing
     """

--- a/jwql/tests/test_preview_image.py
+++ b/jwql/tests/test_preview_image.py
@@ -94,7 +94,7 @@ def test_directory(test_dir=TEST_DIRECTORY):
         Path to directory used for testing
 
     Yields
-    -------
+    ------
     test_dir : str
         Path to directory used for testing
 

--- a/jwql/website/apps/jwql/views.py
+++ b/jwql/website/apps/jwql/views.py
@@ -74,7 +74,8 @@ from .data_containers import thumbnails_ajax
 from .data_containers import thumbnails_query_ajax
 from .forms import AnomalyQueryForm
 from .forms import FileSearchForm
-from .models import Observation, Proposal, RootFileInfo
+if not os.environ.get("READTHEDOCS"):
+    from .models import Observation, Proposal, RootFileInfo
 from astropy.io import fits
 
 

--- a/jwql/website/jwql_proj/settings.py
+++ b/jwql/website/jwql_proj/settings.py
@@ -34,7 +34,8 @@ from django.contrib.messages import constants as messages
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = get_config()['django_secret_key']
+if not os.environ.get("READTHEDOCS"):
+    SECRET_KEY = get_config()['django_secret_key']
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 # pyproject.toml
 [build-system]
 requires = ["setuptools<=65.5.0",
+		    "numpy",
 			"wheel",
 			"setuptools_scm"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+# pyproject.toml
+[build-system]
+requires = ["setuptools<=65.5.0",
+			"wheel",
+			"setuptools_scm"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 # pyproject.toml
 [build-system]
 requires = ["setuptools<=65.5.0",
-		    "numpy",
+			"numpy",
 			"wheel",
 			"setuptools_scm"]

--- a/rtd_requirements.txt
+++ b/rtd_requirements.txt
@@ -1,3 +1,4 @@
+bokeh==2.4.3
 cython==0.29.28
 django==3.1.7
 docutils==0.18.1

--- a/rtd_requirements.txt
+++ b/rtd_requirements.txt
@@ -1,9 +1,9 @@
 cython==0.29.28
-django==3.2.5
+django==4.1
 docutils==0.18.1
 flake8==4.0.1
 jwst==1.4.3
-jwql==1.0.0
+jwql==1.1.1
 pygments==2.11.2
 pytest==7.0.1
 sphinx>=2

--- a/rtd_requirements.txt
+++ b/rtd_requirements.txt
@@ -1,5 +1,6 @@
 sphinx_automodapi==0.14.1
 bokeh==2.4.3
+celery==4.4.0
 cython==0.29.28
 django==3.1.7
 docutils==0.18.1

--- a/rtd_requirements.txt
+++ b/rtd_requirements.txt
@@ -4,7 +4,6 @@ django==3.1.7
 docutils==0.18.1
 flake8==4.0.1
 jwst==1.4.3
-jwql==1.1.1
 pygments==2.11.2
 pytest==7.0.1
 sphinx>=2

--- a/rtd_requirements.txt
+++ b/rtd_requirements.txt
@@ -1,3 +1,4 @@
+sphinx_automodapi==0.14.1
 bokeh==2.4.3
 cython==0.29.28
 django==3.1.7

--- a/rtd_requirements.txt
+++ b/rtd_requirements.txt
@@ -1,5 +1,5 @@
 cython==0.29.28
-django==4.1
+django==3.1.7
 docutils==0.18.1
 flake8==4.0.1
 jwst==1.4.3

--- a/rtd_requirements.txt
+++ b/rtd_requirements.txt
@@ -7,6 +7,7 @@ flake8==4.0.1
 jwst==1.4.3
 pygments==2.11.2
 pytest==7.0.1
+redis
 sphinx>=2
 stsci_rtd_theme==0.0.2
 tomli==2.0.1

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ REQUIRES = [
     'astropy>=3.2.1',
     'astroquery>=0.3.9',
     'bandit',
-    'bokeh',
+    'bokeh==2.4.3',
     'codecov',
     'crds',
     'cryptography',


### PR DESCRIPTION
Flesh out the documentation on the EDB monitor a bit, in order to explain the format and use of the JSON file that goes into specifying which mnemonics to monitor.

Resolves #1101 
