### PR TITLE
Add missing monitor_pages import

### DIFF
--- a/jwql/website/apps/jwql/bokeh_containers.py
+++ b/jwql/website/apps/jwql/bokeh_containers.py
@@ -29,6 +29,7 @@ from bokeh.plotting import figure, output_file
 import numpy as np
 import pysiaf
 
+from jwql.website.apps.jwql import monitor_pages
 from jwql.website.apps.jwql.monitor_pages.monitor_dark_bokeh import DarkMonitorPlots
 from jwql.utils.constants import BAD_PIXEL_TYPES, FULL_FRAME_APERTURES
 from jwql.utils.utils import get_config


### PR DESCRIPTION
As part of recent changes to the dark monitor, the import statement for monitor_pages was modified. This ended up breaking the other monitors that still need monitor_pages imported. This PR returns the import statement so that the other monitors work.