### PR TITLE
Fix failing RTD builds

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,6 +8,9 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.9"
+  jobs:
+    post_create_environment:
+      - pip install . --no-deps
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
    configuration: docs/source/conf.py
@@ -16,8 +19,3 @@ sphinx:
 # formats:
 #    - pdf
 # Optionally declare the Python requirements required to build your docs
-python:
-   install:
-      - requirements: rtd_requirements.txt
-      - method: pip
-        path: .

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,6 +8,9 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.9"
+  jobs:
+    post_create_environment:
+      - pip install . --no-deps
 
 conda:
   environment: environment_python_3_8.yml

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,6 +14,7 @@ build:
       - pip install sphinx_automodapi
       - pip install stsci_rtd_theme
       - pip install pyvo
+      - pip install jsonschema
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
    configuration: docs/source/conf.py

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,7 +11,7 @@ build:
   jobs:
     post_create_environment:
       - pip install . --no-deps
-      - pip install sqlalchemy==1.49.3
+      - pip install sqlalchemy==1.4.43
 
 #conda:
 #  environment: environment_python_3_8.yml

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,6 +11,8 @@ build:
   jobs:
     post_create_environment:
       - pip install . --no-deps
+      - pip install sphinx_automodapi
+      - pip install stsci_rtd_theme
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
    configuration: docs/source/conf.py

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,9 +9,11 @@ build:
   tools:
     python: "3.9"
   jobs:
-    post_create_environment:
-      - pip install . --no-deps
+    post_install:
       - pip install sqlalchemy==1.4.43
+#    post_create_environment:
+#      - pip install . --no-deps
+#      - pip install sqlalchemy==1.4.43
 
 #conda:
 #  environment: environment_python_3_8.yml

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,6 +9,9 @@ build:
   tools:
     python: "3.9"
 
+conda:
+  environment: environment_python_3_8.yml
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
    configuration: docs/source/conf.py

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,6 +13,7 @@ build:
       - pip install . --no-deps
       - pip install sphinx_automodapi
       - pip install stsci_rtd_theme
+      - pip install pyvo
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
    configuration: docs/source/conf.py

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,6 +15,7 @@ build:
       - pip install stsci_rtd_theme
       - pip install pyvo
       - pip install jsonschema
+      - pip install inflection
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
    configuration: docs/source/conf.py

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,8 +12,8 @@ build:
     post_create_environment:
       - pip install . --no-deps
 
-conda:
-  environment: environment_python_3_8.yml
+#conda:
+#  environment: environment_python_3_8.yml
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
@@ -23,8 +23,8 @@ sphinx:
 # formats:
 #    - pdf
 # Optionally declare the Python requirements required to build your docs
-#python:
-#   install:
-#      - requirements: rtd_requirements.txt
-#      - method: pip
-#        path: .
+python:
+   install:
+      - requirements: rtd_requirements.txt
+      - method: pip
+        path: .

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,6 +4,11 @@
 # Required
 version: 2
 # Set the version of Python and other tools you might need
+# Explicit sqlalchemy install using post_install in order to get around the RTD
+# command pip install --upgrade --upgrade-strategy eager
+# This command upgrades all packages listed in rtd_reuirements.txt. This was causing
+# a problem when upgrading to sqlalchemy >=2.0, which has large changes from versions
+# <2.0, and was causing jwql to crash.
 build:
   os: ubuntu-22.04
   tools:
@@ -11,12 +16,6 @@ build:
   jobs:
     post_install:
       - pip install sqlalchemy==1.4.43
-#    post_create_environment:
-#      - pip install . --no-deps
-#      - pip install sqlalchemy==1.4.43
-
-#conda:
-#  environment: environment_python_3_8.yml
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,14 +8,7 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.9"
-  jobs:
-    post_create_environment:
-      - pip install . --no-deps
-      - pip install sphinx_automodapi
-      - pip install stsci_rtd_theme
-      - pip install pyvo
-      - pip install jsonschema
-      - pip install inflection
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
    configuration: docs/source/conf.py
@@ -24,3 +17,8 @@ sphinx:
 # formats:
 #    - pdf
 # Optionally declare the Python requirements required to build your docs
+#python:
+#   install:
+#      - requirements: rtd_requirements.txt
+#      - method: pip
+#        path: .

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,6 +11,7 @@ build:
   jobs:
     post_create_environment:
       - pip install . --no-deps
+      - pip install sqlalchemy==1.49.3
 
 #conda:
 #  environment: environment_python_3_8.yml

--- a/environment_python_3_8.yml
+++ b/environment_python_3_8.yml
@@ -50,7 +50,6 @@ dependencies:
   - setuptools=65.5.0
   - sphinx=5.0.2
   - sphinx_rtd_theme=0.4.3
-  - sqlalchemy=1.4.39
   - twine=3.7.1
   - vine=1.3.0
   - wtforms=2.3.3
@@ -64,6 +63,7 @@ dependencies:
     - pyvo==1.4
     - redis
     - selenium==4.8.0
+    - sqlalchemy=1.4.39
     - stsci_rtd_theme==1.0.0
     - stcal==1.2.1
     - git+https://github.com/spacetelescope/jwst_reffiles

--- a/environment_python_3_8.yml
+++ b/environment_python_3_8.yml
@@ -63,7 +63,7 @@ dependencies:
     - pyvo==1.4
     - redis
     - selenium==4.8.0
-    - sqlalchemy=1.4.39
+    - sqlalchemy==1.4.39
     - stsci_rtd_theme==1.0.0
     - stcal==1.2.1
     - git+https://github.com/spacetelescope/jwst_reffiles

--- a/rtd_requirements.txt
+++ b/rtd_requirements.txt
@@ -10,6 +10,7 @@ pygments==2.11.2
 pytest==7.0.1
 redis
 sphinx>=2
+sqlalchemy==1.4.39
 stsci_rtd_theme==0.0.2
 tomli==2.0.1
 git+https://github.com/spacetelescope/jwst_reffiles

--- a/rtd_requirements.txt
+++ b/rtd_requirements.txt
@@ -10,7 +10,6 @@ pygments==2.11.2
 pytest==7.0.1
 redis
 sphinx>=2
-sqlalchemy==1.4.39
 stsci_rtd_theme==0.0.2
 tomli==2.0.1
 git+https://github.com/spacetelescope/jwst_reffiles


### PR DESCRIPTION
RTD builds are failing silently. It appears that in version >= 2.0 of sqlalchemy, create_engine() no longer accepts `encoding` as a keyword. This is causing a lot of import errors when RTD is trying to build the JWQL docs.

First attempt at a fix:  pin sqlalchemy in rtd_requirements to match the version in our env files.

Resolves #1169 



