### PR TITLE
Re-add missing sqlalchemy to env file

### DIFF
--- a/environment_python_3_8.yml
+++ b/environment_python_3_8.yml
@@ -50,6 +50,7 @@ dependencies:
   - setuptools=65.5.0
   - sphinx=5.0.2
   - sphinx_rtd_theme=0.4.3
+  - sqlalchemy=1.4.39
   - twine=3.7.1
   - vine=1.3.0
   - wtforms=2.3.3


### PR DESCRIPTION
Oops. In #1170 I forgot to put sqlalchemy back into the 3.8 environment file. This PR does that.

@mfixstsci ready for review. Sorry about the oversight.