### PR TITLE
Create archive page asynchronously

### DIFF
--- a/jwql/website/apps/jwql/archive_database_update.py
+++ b/jwql/website/apps/jwql/archive_database_update.py
@@ -44,6 +44,7 @@ from jwql.utils.logging_functions import log_info, log_fail  # noqa
 from jwql.utils.monitor_utils import initialize_instrument_monitor  # noqa
 from jwql.utils.constants import MAST_QUERY_LIMIT  # noqa
 from jwql.utils.utils import filename_parser, filesystem_path, get_config  # noqa
+from jwql.website.apps.jwql.data_containers import create_archived_proposals_context  # noqa
 from jwql.website.apps.jwql.data_containers import get_instrument_proposals, get_filenames_by_instrument  # noqa
 from jwql.website.apps.jwql.data_containers import get_proposal_info, mast_query_filenames_by_instrument  # noqa
 
@@ -313,3 +314,4 @@ if __name__ == '__main__':
     instruments = ['nircam', 'miri', 'nirspec', 'niriss', 'fgs']
     for instrument in instruments:
         get_updates(instrument)
+        create_archived_proposals_context(instrument)

--- a/jwql/website/apps/jwql/data_containers.py
+++ b/jwql/website/apps/jwql/data_containers.py
@@ -27,6 +27,7 @@ Use
 import copy
 from collections import OrderedDict
 import glob
+import json
 from operator import getitem
 import os
 import re
@@ -53,6 +54,7 @@ from jwql.utils.constants import MAST_QUERY_LIMIT, MONITORS, PREVIEW_IMAGE_LISTF
 from jwql.utils.constants import IGNORED_SUFFIXES, INSTRUMENT_SERVICE_MATCH, JWST_INSTRUMENT_NAMES_MIXEDCASE, JWST_INSTRUMENT_NAMES
 from jwql.utils.constants import SUFFIXES_TO_ADD_ASSOCIATION, SUFFIXES_WITH_AVERAGED_INTS, QUERY_CONFIG_KEYS, QUERY_CONFIG_TEMPLATE
 from jwql.utils.credentials import get_mast_token
+from jwql.utils.permissions import set_permissions
 from jwql.utils.utils import get_rootnames_for_instrument_proposal
 from .forms import InstrumentAnomalySubmitForm
 from astroquery.mast import Mast
@@ -79,7 +81,7 @@ if not ON_GITHUB_ACTIONS and not ON_READTHEDOCS:
     setup()
 
     from .forms import MnemonicSearchForm, MnemonicQueryForm, MnemonicExplorationForm
-    from jwql.website.apps.jwql.models import RootFileInfo
+    from jwql.website.apps.jwql.models import Observation, Proposal, RootFileInfo
     check_config_for_key('auth_mast')
     configs = get_config()
     auth_mast = configs['auth_mast']
@@ -93,6 +95,7 @@ if not ON_GITHUB_ACTIONS and not ON_READTHEDOCS:
     FILESYSTEM_DIR = configs['filesystem']
     PREVIEW_IMAGE_FILESYSTEM = configs['preview_image_filesystem']
     THUMBNAIL_FILESYSTEM = configs['thumbnail_filesystem']
+    OUTPUT_DIR = configs['outputs']
 
 PACKAGE_DIR = os.path.dirname(__location__.split('website')[0])
 REPO_DIR = os.path.split(PACKAGE_DIR)[0]
@@ -145,6 +148,100 @@ def build_table(tablename):
 
     session.close()
     return table_meta_data
+
+
+def create_archived_proposals_context(inst):
+    """Generate and save a json file containing the information needed
+    to create an instrument's archive page.
+
+    Parameters
+    ----------
+    inst : str
+        Name of JWST instrument
+    """
+    # Ensure the instrument is correctly capitalized
+    inst = JWST_INSTRUMENT_NAMES_MIXEDCASE[inst.lower()]
+
+    # Get a list of Observation entries for the given instrument
+    all_entries = Observation.objects.filter(proposal__archive__instrument=inst)
+
+    # Get a list of proposal numbers.
+    prop_objects = Proposal.objects.filter(archive__instrument=inst)
+    proposal_nums = [entry.prop_id for entry in prop_objects]
+
+    # Put proposals into descending order
+    proposal_nums.sort(reverse=True)
+
+    # Total number of proposals for the instrument
+    num_proposals = len(proposal_nums)
+
+    thumbnail_paths = []
+    min_obsnums = []
+    total_files = []
+    proposal_viewed = []
+    proposal_exp_types = []
+    thumb_exp_types = []
+    proposal_obs_times = []
+    thumb_obs_time = []
+
+    # Get a set of all exposure types used in the observations associated with this proposal
+    exp_types = [exposure_type for observation in all_entries for exposure_type in observation.exptypes.split(',')]
+    exp_types = sorted(list(set(exp_types)))
+
+    # The naming conventions for dropdown_menus are tightly coupled with the code, this should be changed down the line.
+    dropdown_menus = {'look': THUMBNAIL_FILTER_LOOK,
+                      'exp_type': exp_types}
+    thumbnails_dict = {}
+
+    for proposal_num in proposal_nums:
+        # For each proposal number, get all entries
+        prop_entries = all_entries.filter(proposal__prop_id=proposal_num)
+
+        # All entries will have the same thumbnail_path, so just grab the first
+        thumbnail_paths.append(prop_entries[0].proposal.thumbnail_path)
+
+        # Extract the observation numbers from each entry and find the minimum
+        prop_obsnums = [entry.obsnum for entry in prop_entries]
+        min_obsnums.append(min(prop_obsnums))
+
+        # Sum the file count from all observations to get the total file count for
+        # the proposal
+        prop_filecount = [entry.number_of_files for entry in prop_entries]
+        total_files.append(sum(prop_filecount))
+
+        # In order to know if a proposal contains all observations that are entirely viewed, check for at least one existing viewed=False in RootFileInfo
+        unviewed_root_file_infos = RootFileInfo.objects.filter(instrument=inst, proposal=proposal_num, viewed=False)
+        proposal_viewed.append("Viewed" if unviewed_root_file_infos.count() == 0 else "New")
+
+        # Store comma separated list of exp_types associated with each proposal
+        proposal_exp_types = [exposure_type for observation in prop_entries for exposure_type in observation.exptypes.split(',')]
+        proposal_exp_types = list(set(proposal_exp_types))
+        thumb_exp_types.append(','.join(proposal_exp_types))
+
+        # Get Most recent observation start time
+        proposal_obs_times = [observation.obsstart for observation in prop_entries]
+        thumb_obs_time.append(max(proposal_obs_times))
+
+    thumbnails_dict['proposals'] = proposal_nums
+    thumbnails_dict['thumbnail_paths'] = thumbnail_paths
+    thumbnails_dict['num_files'] = total_files
+    thumbnails_dict['viewed'] = proposal_viewed
+    thumbnails_dict['exp_types'] = thumb_exp_types
+    thumbnails_dict['obs_time'] = thumb_obs_time
+
+    context = {'inst': inst,
+               'num_proposals': num_proposals,
+               'min_obsnum': min_obsnums,
+               'thumbnails': thumbnails_dict,
+               'dropdown_menus': dropdown_menus}
+
+    json_object = json.dumps(context, indent = 4)
+
+    # Writing to json file
+    outfilename = os.path.join(OUTPUT_DIR, 'archive_page', f'{inst}_archive_context.json')
+    with open(outfilename, "w") as outfile:
+        outfile.write(json_object)
+    set_permissions(outfilename)
 
 
 def get_acknowledgements():
@@ -1004,7 +1101,7 @@ def get_thumbnails_all_instruments(parameters):
     ----------
     parameters: dict of type QUERY_CONFIG_TEMPLATE
         A dictionary containing keys of QUERY_CONFIG_KEYS, some of which are dictionaries:
- 
+
 
     Returns
     -------
@@ -1057,7 +1154,7 @@ def get_thumbnails_all_instruments(parameters):
         # Get list of all thumbnails
         thumb_inventory = os.path.join(f"{THUMBNAIL_FILESYSTEM}", f"{THUMBNAIL_LISTFILE}_{inst.lower()}.txt")
         thumbnail_inst_list = retrieve_filelist(thumb_inventory)
-        
+
         # Get subset of thumbnail images that match the filenames
         thumbnails_inst_subset = [os.path.basename(item) for item in thumbnail_inst_list if
                                   os.path.basename(item).split('_integ')[0] in inst_filenames]
@@ -1152,8 +1249,8 @@ def get_thumbnails_by_proposal(proposal):
 
 def get_thumbnail_by_rootname(rootname):
     """Return the most appropriate existing thumbnail basename available in the filesystem for the given ``rootname``.
-    We generate thumbnails only for 'rate' and 'dark' files. 
-    Check if these files exist in the thumbnail filesystem. 
+    We generate thumbnails only for 'rate' and 'dark' files.
+    Check if these files exist in the thumbnail filesystem.
     In the case where neither rate nor dark thumbnails are present, revert to 'none'
 
     Parameters

--- a/jwql/website/apps/jwql/views.py
+++ b/jwql/website/apps/jwql/views.py
@@ -333,7 +333,7 @@ def archived_proposals_ajax(request, inst):
         Outgoing response sent to the webpage
     """
     # Read in the json file created by data_containers.create_archived_proposals_context
-    # as use as the context
+    # and use as the context
     output_dir = get_config()['outputs']
     context_file = os.path.join(output_dir, 'archive_page', f'{inst}_archive_context.json')
 

--- a/jwql/website/apps/jwql/views.py
+++ b/jwql/website/apps/jwql/views.py
@@ -44,6 +44,7 @@ Dependencies
 from collections import defaultdict
 from copy import deepcopy
 import csv
+import json
 import glob
 import logging
 import os
@@ -181,12 +182,12 @@ def api_landing(request):
 def save_page_navigation_data_ajax(request):
     """
     Takes a bracketless string of rootnames and expstarts, and saves it as a session dictionary
-    
+
     Parameters
     ----------
     request: HttpRequest object
         Incoming request from the webpage
-    
+
 
     Returns
     -------
@@ -202,7 +203,7 @@ def save_page_navigation_data_ajax(request):
         request.session['navigation_data'] = rootname_expstarts
     context = {'item': request.session['navigation_data']}
     return JsonResponse(context, json_dumps_params={'indent': 2})
-    
+
 
 def archive_date_range(request, inst):
     """Generate the page for date range images
@@ -268,7 +269,7 @@ def archive_date_range_ajax(request, inst, start_date, stop_date):
     end_after_start = Observation.objects.filter(proposal__archive__instrument=inst, obsend__gte=inclusive_start_time.mjd)
     all_entries_ending_in_range = end_after_start.filter(obsend__lt=exclusive_stop_time.mjd)
 
-    # Get a queryset of all observations SPANNING (starting before and ending after) our date range.  Bump our window out a few days to catch hypothetical 
+    # Get a queryset of all observations SPANNING (starting before and ending after) our date range.  Bump our window out a few days to catch hypothetical
     # observations that last over 24 hours.  The larger the window the more time the query takes so keeping it tight.
     two_days_before_start_time = Time(start_date) - (2 * u.day)
     two_days_after_end_time = Time(stop_date) + (3 * u.day)
@@ -278,13 +279,13 @@ def archive_date_range_ajax(request, inst, start_date, stop_date):
     obs_beginning = [observation for observation in all_entries_beginning_in_range]
     obs_ending = [observation for observation in all_entries_ending_in_range]
     obs_spanning = [observation for observation in all_entries_spanning_range]
-    
+
     # Create a single list of all pertinent observations
     all_observations = list(set(obs_beginning + obs_ending + obs_spanning))
     # Get all thumbnails that occurred within the time frame for these observations
     data = thumbnails_date_range_ajax(inst, all_observations, inclusive_start_time.mjd, exclusive_stop_time.mjd)
     data['thumbnail_sort'] = request.session.get("image_sort", "Recent")
-    
+
     # Create Dictionary of Rootnames with expstart
     save_page_navigation_data(request, data)
     return JsonResponse(data, json_dumps_params={'indent': 2})
@@ -331,81 +332,13 @@ def archived_proposals_ajax(request, inst):
     JsonResponse object
         Outgoing response sent to the webpage
     """
-    # Ensure the instrument is correctly capitalized
-    inst = JWST_INSTRUMENT_NAMES_MIXEDCASE[inst.lower()]
+    # Read in the json file created by data_containers.create_archived_proposals_context
+    # as use as the context
+    output_dir = get_config()['outputs']
+    context_file = os.path.join(output_dir, 'archive_page', f'{inst}_archive_context.json')
 
-    # Get a list of Observation entries for the given instrument
-    all_entries = Observation.objects.filter(proposal__archive__instrument=inst)
-
-    # Get a list of proposal numbers.
-    prop_objects = Proposal.objects.filter(archive__instrument=inst)
-    proposal_nums = [entry.prop_id for entry in prop_objects]
-
-    # Put proposals into descending order
-    proposal_nums.sort(reverse=True)
-
-    # Total number of proposals for the instrument
-    num_proposals = len(proposal_nums)
-
-    thumbnail_paths = []
-    min_obsnums = []
-    total_files = []
-    proposal_viewed = []
-    proposal_exp_types = []
-    thumb_exp_types = []
-    proposal_obs_times = []
-    thumb_obs_time = []
-
-    # Get a set of all exposure types used in the observations associated with this proposal
-    exp_types = [exposure_type for observation in all_entries for exposure_type in observation.exptypes.split(',')]
-    exp_types = sorted(list(set(exp_types)))
-
-    # The naming conventions for dropdown_menus are tightly coupled with the code, this should be changed down the line.
-    dropdown_menus = {'look': THUMBNAIL_FILTER_LOOK,
-                      'exp_type': exp_types}
-    thumbnails_dict = {}
-
-    for proposal_num in proposal_nums:
-        # For each proposal number, get all entries
-        prop_entries = all_entries.filter(proposal__prop_id=proposal_num)
-
-        # All entries will have the same thumbnail_path, so just grab the first
-        thumbnail_paths.append(prop_entries[0].proposal.thumbnail_path)
-
-        # Extract the observation numbers from each entry and find the minimum
-        prop_obsnums = [entry.obsnum for entry in prop_entries]
-        min_obsnums.append(min(prop_obsnums))
-
-        # Sum the file count from all observations to get the total file count for
-        # the proposal
-        prop_filecount = [entry.number_of_files for entry in prop_entries]
-        total_files.append(sum(prop_filecount))
-
-        # In order to know if a proposal contains all observations that are entirely viewed, check for at least one existing viewed=False in RootFileInfo
-        unviewed_root_file_infos = RootFileInfo.objects.filter(instrument=inst, proposal=proposal_num, viewed=False)
-        proposal_viewed.append("Viewed" if unviewed_root_file_infos.count() == 0 else "New")
-
-        # Store comma separated list of exp_types associated with each proposal
-        proposal_exp_types = [exposure_type for observation in prop_entries for exposure_type in observation.exptypes.split(',')]
-        proposal_exp_types = list(set(proposal_exp_types))
-        thumb_exp_types.append(','.join(proposal_exp_types))
-
-        # Get Most recent observation start time
-        proposal_obs_times = [observation.obsstart for observation in prop_entries]
-        thumb_obs_time.append(max(proposal_obs_times))
-
-    thumbnails_dict['proposals'] = proposal_nums
-    thumbnails_dict['thumbnail_paths'] = thumbnail_paths
-    thumbnails_dict['num_files'] = total_files
-    thumbnails_dict['viewed'] = proposal_viewed
-    thumbnails_dict['exp_types'] = thumb_exp_types
-    thumbnails_dict['obs_time'] = thumb_obs_time
-
-    context = {'inst': inst,
-               'num_proposals': num_proposals,
-               'min_obsnum': min_obsnums,
-               'thumbnails': thumbnails_dict,
-               'dropdown_menus': dropdown_menus}
+    with open(context_file, 'r') as obj:
+        context = json.load(obj)
 
     return JsonResponse(context, json_dumps_params={'indent': 2})
 
@@ -518,7 +451,7 @@ def archive_thumbnails_query_ajax(request):
 
     # when parameters only contains nirspec as instrument, thumbnails still end up being all niriss data
     thumbnails = get_thumbnails_all_instruments(parameters)
-    
+
     data = thumbnails_query_ajax(thumbnails)
     data['thumbnail_sort'] = request.session.get("image_sort", "Ascending")
     save_page_navigation_data(request, data)
@@ -827,7 +760,7 @@ def query_submit(request):
     HttpResponse object
         Outgoing response sent to the webpage
     """
-    
+
     template = 'query_submit.html'
     sort_type = request.session.get('image_sort', 'Ascending')
     context = {'inst': '',
@@ -1048,9 +981,9 @@ def explore_image_ajax(request, inst, file_root, filetype, scaling="log", low_li
 def save_page_navigation_data(request, data):
     """
     It saves the data from the current page in the session so that the user can navigate to the next or
-    previous page.  Our current sort options are Ascending/Descending, and Recent/Oldest so we need to 
+    previous page.  Our current sort options are Ascending/Descending, and Recent/Oldest so we need to
     preserve 'rootname' and 'expstart'.
-    
+
     Parameters
     ----------
     request: HttpRequest object


### PR DESCRIPTION
Rather than querying the database and constructing the context for an instrument's archive page at the time of the request, do that work asynchronously, and save the results in a json file. Then when there is a request for the page, read in the json file and create the page.