### PR TITLE
Catch missing obs in navigation data

### DIFF
--- a/jwql/website/apps/jwql/templates/thumbnails_per_obs.html
+++ b/jwql/website/apps/jwql/templates/thumbnails_per_obs.html
@@ -75,13 +75,15 @@
 
         <div class="previous-next-buttons">
             <span class="step-links">
-                {% set index = obs_list.index(obs) %}
-                {% if index != 0 %}
-                    <a role="button" class="btn btn-primary my-2" type="submit" href="{{ base_url }}/{{ inst }}/archive/{{ prop }}/obs{{ obs_list[index-1] }}/" style="float: left;">< Previous</a>
-                {% endif %}
+                {% if obs in obs_list %}
+                    {% set index = obs_list.index(obs) %}
+                    {% if index != 0 %}
+                        <a role="button" class="btn btn-primary my-2" type="submit" href="{{ base_url }}/{{ inst }}/archive/{{ prop }}/obs{{ obs_list[index-1] }}/" style="float: left;">< Previous</a>
+                    {% endif %}
 
-                {% if obs_list.index(obs) != obs_list|length - 1 %}
-                    <a role="button" class="btn btn-primary my-2" type="submit" href="{{ base_url }}/{{ inst }}/archive/{{ prop }}/obs{{ obs_list[index+1] }}/" style="float: right;">Next ></a>
+                    {% if obs_list.index(obs) != obs_list|length - 1 %}
+                        <a role="button" class="btn btn-primary my-2" type="submit" href="{{ base_url }}/{{ inst }}/archive/{{ prop }}/obs{{ obs_list[index+1] }}/" style="float: right;">Next ></a>
+                    {% endif %}
                 {% endif %}
             </span>
         </div>


### PR DESCRIPTION
Minor fix to the thumbnails_per_obs template to catch mismatch between the obs_list generated from navigation data and the currently displayed observation.