### PR TITLE
Make pyvo searches robust against updated instrument names

### DIFF
--- a/jwql/utils/utils.py
+++ b/jwql/utils/utils.py
@@ -561,8 +561,8 @@ def get_rootnames_for_instrument_proposal(instrument, proposal):
     rootnames : list
         List of rootnames for the given instrument and proposal number
     """
-    tap_service = vo.dal.TAPService("http://vao.stsci.edu/caomtap/tapservice.aspx")
-    tap_results = tap_service.search(f"select observationID from dbo.CaomObservation where collection='JWST' and maxLevel=2 and insName like '{instrument.lower()}' and prpID='{int(proposal)}'")
+    tap_service = vo.dal.TAPService("https://vao.stsci.edu/caomtap/tapservice.aspx")
+    tap_results = tap_service.search(f"select observationID from dbo.CaomObservation where collection='JWST' and maxLevel=2 and insName like '{instrument.lower()}%' and prpID='{int(proposal)}'")
     prop_table = tap_results.to_table()
     rootnames = prop_table['observationID'].data
     return rootnames.compressed()

--- a/jwql/website/apps/jwql/data_containers.py
+++ b/jwql/website/apps/jwql/data_containers.py
@@ -958,8 +958,8 @@ def get_instrument_proposals(instrument):
     inst_proposals : list
         List of proposals for the given instrument
     """
-    tap_service = vo.dal.TAPService("http://vao.stsci.edu/caomtap/tapservice.aspx")
-    tap_results = tap_service.search(f"select distinct proposal_id from dbo.ObsPointing where obs_collection='JWST' and calib_level>0 and instrument_name like '{instrument.lower()}'")
+    tap_service = vo.dal.TAPService("https://vao.stsci.edu/caomtap/tapservice.aspx")
+    tap_results = tap_service.search(f"select distinct proposal_id from dbo.ObsPointing where obs_collection='JWST' and calib_level>0 and instrument_name like '{instrument.lower()}%'")
     prop_table = tap_results.to_table()
     proposals = prop_table['proposal_id'].data
     inst_proposals = sorted(proposals.compressed(), reverse=True)
@@ -1086,7 +1086,7 @@ def get_rootnames_for_proposal(proposal):
     rootnames : list
         List of rootnames for the given instrument and proposal number
     """
-    tap_service = vo.dal.TAPService("http://vao.stsci.edu/caomtap/tapservice.aspx")
+    tap_service = vo.dal.TAPService("https://vao.stsci.edu/caomtap/tapservice.aspx")
     tap_results = tap_service.search(f"select observationID from dbo.CaomObservation where collection='JWST' and maxLevel=2 and prpID='{int(proposal)}'")
     prop_table = tap_results.to_table()
     rootnames = prop_table['observationID'].data


### PR DESCRIPTION
Resolves #1208 

MAST has updated the values that are present in the "instrument" column of the CAOM database such that they are no longer e.g. "MIRI", but instead e.g. "MIRI/IMAGE" or "MIRI/LRS". This doesn't affect the Mast.Jwst.Filtered services that JWQL uses for most queries, but it does affect all of the pyvo queries that we make. This PR updates those pyvo queries to add a wildcard after the instrument name, so that we will get back results for all modes of a given instrument. Without this, our queries currently do not return recent data, since those have been switched to the new instrument/mode value, and as data are slowly reprocessed in MAST with the new values, the size of our query results would get smaller and smaller. The pyvo queries are used primarily to get a list of program numbers per instrument, as well as a list of rootnames for a given instrument and program. The missing results here were causing new data not to be displayed on observation level pages.