### PR TITLE
Update preview image generator to handle new NaN pixels

### DIFF
--- a/jwql/utils/preview_image.py
+++ b/jwql/utils/preview_image.py
@@ -765,6 +765,16 @@ def expand_for_i2d(array, xdim, ydim):
 
 def nan_to_zero(image):
     """Set any pixels with a value of NaN to zero
+
+    Parameters
+    ----------
+    image : numpy.ndarray
+        Array from which NaNs will be removed
+
+    Returns
+    -------
+    image : numpy.ndarray
+        Input array with NaNs changed to zero
     """
     nan = np.isnan(image)
     image[nan] = 0

--- a/jwql/utils/preview_image.py
+++ b/jwql/utils/preview_image.py
@@ -576,6 +576,11 @@ class PreviewImage():
             # Find signal limits for the display
             minval, maxval = self.find_limits(frame)
 
+            # Set NaN values to zero, so that those pixels
+            # do not appear as big white splotches in the jpgs
+            # after matplotlib downsamples/averages
+            frame = nan_to_zero(frame)
+
             # Create preview image matplotlib object
             indir, infile = os.path.split(self.file)
             suffix = '_integ{}.{}'.format(i, self.output_format)
@@ -757,3 +762,10 @@ def expand_for_i2d(array, xdim, ydim):
         return new_array_x
     else:
         return array
+
+def nan_to_zero(image):
+    """Set any pixels with a value of NaN to zero
+    """
+    nan = np.isnan(image)
+    image[nan] = 0
+    return image


### PR DESCRIPTION
Resolves #1207 

A recent change in the cal pipeline now has pixels for which no slope is computed being set to NaN in the slope image. Previously these pixels had been set to zero. Setting these pixels to NaN means matplotlib now shows them as white in the preview images rather than black. This, combined with the way that matplotlib averages pixels together when producing the preview image/thumbnail jpgs was resulting in preview images that were full of white splotches. This PR updates the preview image generator such that NaN pixels are set to zero prior to creating jpgs. This means these pixels are back to being shown as black, and the matplotlib averaging seems not to creates big splotches when working with them.