### PR TITLE
[WIP] Updates and Fixes to EDB Monitor

### DIFF
--- a/jwql/instrument_monitors/common_monitors/edb_telemetry_monitor.py
+++ b/jwql/instrument_monitors/common_monitors/edb_telemetry_monitor.py
@@ -1410,9 +1410,9 @@ class EdbMnemonicMonitor():
                         multiday_every_change_data.extend(mnemonic_info.every_change_values)
                 else:
                     multiday_median_times.extend(mnemonic_info.data["dates"].data)
-                    multiday_mean_vals.extend(mnemonic_info.data["euvalues"].data)
+                    multiday_mean_vals.extend(mnemonic_info.mean))
                     multiday_stdev_vals.extend(mnemonic_info.stdev)
-                    multiday_median_vals.extend(mnemonic_info.median)
+                    multiday_median_vals.extend(mnemonic_info.data["euvalues"].data)
                     multiday_max_vals.extend(mnemonic_info.max)
                     multiday_min_vals.extend(mnemonic_info.min)
 

--- a/jwql/instrument_monitors/common_monitors/edb_telemetry_monitor.py
+++ b/jwql/instrument_monitors/common_monitors/edb_telemetry_monitor.py
@@ -1410,7 +1410,7 @@ class EdbMnemonicMonitor():
                         multiday_every_change_data.extend(mnemonic_info.every_change_values)
                 else:
                     multiday_median_times.extend(mnemonic_info.data["dates"].data)
-                    multiday_mean_vals.extend(mnemonic_info.mean))
+                    multiday_mean_vals.extend(mnemonic_info.mean)
                     multiday_stdev_vals.extend(mnemonic_info.stdev)
                     multiday_median_vals.extend(mnemonic_info.data["euvalues"].data)
                     multiday_max_vals.extend(mnemonic_info.max)


### PR DESCRIPTION
When the EDB Monitor attempts to plot every data point returned from the mnemonic, we are currently running into a column mismatch error from astropy. This is because the median time values do not match the length of the median eu_values obtained from the mnemonic. Here is a quick fix that assigns the proper data to the `multiday_table`.