### PR TITLE
WIP: More instrument info on thumbnail hover-over

### DIFF
--- a/jwql/website/apps/jwql/data_containers.py
+++ b/jwql/website/apps/jwql/data_containers.py
@@ -1634,6 +1634,7 @@ def thumbnails_ajax(inst, proposal, obs_num=None):
         data_dict['file_data'][rootname]["viewed"] = viewed
         data_dict['file_data'][rootname]["exp_type"] = exp_type
         data_dict['file_data'][rootname]['thumbnail'] = get_thumbnail_by_rootname(rootname)
+        data_dict['file_data'][rootname]['obs_visit'] = filename_dict['observation']+'/'+filename_dict['visit']
 
         try:
             data_dict['file_data'][rootname]['expstart'] = exp_start
@@ -1677,15 +1678,16 @@ def thumbnails_ajax(inst, proposal, obs_num=None):
             except KeyError: # only MRS mode has band kwd?
                 continue
 
-        # for keyword in moreinfo:
-        #     data_dict['file_data'][rootname][keyword] = moreinfo[keyword]
-
-        # if they both exist, replace 'filter' and 'pupil' with 'filter/pupil'
+        # combine optical elements keywords to save space
         if ('filter' in data_dict['file_data'][rootname].keys()) & ('pupil' in data_dict['file_data'][rootname].keys()):
             filt_pup = data_dict['file_data'][rootname]['filter'] + '/' + data_dict['file_data'][rootname]['pupil']
             data_dict['file_data'][rootname]['filterpupil'] = filt_pup
-            del data_dict['file_data'][rootname]['filter']
-            del data_dict['file_data'][rootname]['pupil']
+        if ('filter' in data_dict['file_data'][rootname].keys()) & ('grating' in data_dict['file_data'][rootname].keys()):
+            filt_grat = data_dict['file_data'][rootname]['filter'] + '/' + data_dict['file_data'][rootname]['grating']
+            data_dict['file_data'][rootname]['filtergrating'] = filt_grat
+        if ('filter' in data_dict['file_data'][rootname].keys()) & ('band' in data_dict['file_data'][rootname].keys()):
+            filt_band = data_dict['file_data'][rootname]['filter'] + '/' + data_dict['file_data'][rootname]['band']
+            data_dict['file_data'][rootname]['filterband'] = filt_band
 
     # Extract information for sorting with dropdown menus
     # (Don't include the proposal as a sorting parameter if the proposal has already been specified)

--- a/jwql/website/apps/jwql/data_containers.py
+++ b/jwql/website/apps/jwql/data_containers.py
@@ -1624,6 +1624,8 @@ def thumbnails_ajax(inst, proposal, obs_num=None):
 
             viewed = THUMBNAIL_FILTER_LOOK[0]
 
+        exp_num = filename_dict['exposure_id']#.lstrip('0')
+
         # Add data to dictionary
         data_dict['file_data'][rootname] = {}
         data_dict['file_data'][rootname]['filename_dict'] = filename_dict
@@ -1635,6 +1637,7 @@ def thumbnails_ajax(inst, proposal, obs_num=None):
         try:
             data_dict['file_data'][rootname]['expstart'] = exp_start
             data_dict['file_data'][rootname]['expstart_iso'] = Time(exp_start, format='mjd').iso.split('.')[0]
+            data_dict['file_data'][rootname]['exp_num'] = exp_num
         except (ValueError, TypeError) as e:
             logging.warning("Unable to populate exp_start info for {}".format(rootname))
             logging.warning(e)

--- a/jwql/website/apps/jwql/data_containers.py
+++ b/jwql/website/apps/jwql/data_containers.py
@@ -1671,7 +1671,7 @@ def thumbnails_ajax(inst, proposal, obs_num=None):
             data_dict['file_data'][rootname]['pupil'] = root_file_info.pupil
         if inst == 'MIRI':
             data_dict['file_data'][rootname]['filter'] = root_file_info.filter
-            data_dict['file_data'][rootname]['pupil'] = root_file_info.pupil
+            data_dict['file_data'][rootname]['ngrp_nint'] = str(header['NGROUPS'])+'/'+str(header['NINTS'])
             try:
                 data_dict['file_data'][rootname]['band'] = header['BAND']
             except KeyError: # only MRS mode has band kwd?

--- a/jwql/website/apps/jwql/static/css/jwql.css
+++ b/jwql/website/apps/jwql/static/css/jwql.css
@@ -474,7 +474,7 @@
   
   .thumbnail {
       width: 8rem;
-      height: 12rem;
+      height: 8rem;
       text-align: center;
       position: relative;
       display: inline-block;
@@ -485,7 +485,7 @@
   .thumbnail-color-fill {
       display: none;
       width: 100%;
-      height: 100%;
+      height: 105%;
       background-color: #356198;
       opacity: 0.5;
       position: absolute;

--- a/jwql/website/apps/jwql/static/css/jwql.css
+++ b/jwql/website/apps/jwql/static/css/jwql.css
@@ -474,7 +474,7 @@
   
   .thumbnail {
       width: 8rem;
-      height: 8rem;
+      height: 12rem;
       text-align: center;
       position: relative;
       display: inline-block;
@@ -487,7 +487,7 @@
       width: 100%;
       height: 100%;
       background-color: #356198;
-      opacity: 0.3;
+      opacity: 0.5;
       position: absolute;
       top: 0%;
       left: 0%;
@@ -526,7 +526,7 @@
       text-align: left;
       color: white;
       z-index: 2;
-      font-size: 0.75rem;
+      font-size: 0.65rem;
   }
   
   .thumbnail-staff {
@@ -536,6 +536,15 @@
       position: relative;
       display: inline-block;
       margin: 0.1rem;
+  }
+
+  .thumbinfo-key {
+      float: left;
+      font-weight: bolder;
+  }
+
+    .thumbinfo-val {
+      float: right;
   }
   
   

--- a/jwql/website/apps/jwql/static/css/jwql.css
+++ b/jwql/website/apps/jwql/static/css/jwql.css
@@ -485,7 +485,7 @@
   .thumbnail-color-fill {
       display: none;
       width: 100%;
-      height: 105%;
+      height: 110%;
       background-color: #356198;
       opacity: 0.5;
       position: absolute;

--- a/jwql/website/apps/jwql/static/js/jwql.js
+++ b/jwql/website/apps/jwql/static/js/jwql.js
@@ -934,7 +934,7 @@ function update_thumbnail_array(data) {
         if (filename_dict.instrument=="nirspec"){
             content += '<span class="thumbinfo-key">Filter: </span>' + '<span class="thumbinfo-val">'+ file.filter+ '</span><br>';
             content += '<span class="thumbinfo-key">Grating: </span>' + '<span class="thumbinfo-val">'+ file.grating+ '</span><br>';
-            content += '<span class="thumbinfo-key">Patt_Num: </span>' + '<span class="thumbinfo-val">'+ file.pattnum+ '</span><br>';
+            content += '<span class="thumbinfo-key">Patt_Num: </span>' + '<span class="thumbinfo-val">'+ file.patt_num+ '</span><br>';
             content += '<span class="thumbinfo-key">Lamp: </span>' + '<span class="thumbinfo-val">'+ file.lamp+ '</span><br>';
             content += '<span class="thumbinfo-key">Opmode: </span>' + '<span class="thumbinfo-val">'+ file.opmode+ '</span><br>';
         }
@@ -946,10 +946,12 @@ function update_thumbnail_array(data) {
         }
         if (filename_dict.instrument=="miri"){
             content += '<span class="thumbinfo-key">Filter: </span>'+ '<span class="thumbinfo-val">'+ file.filter + '</span><br>';
-        }
-        if (exp_type=="miri_mrs"){
-            content += '<span class="thumbinfo-key">Band: </span>'+ '<span class="thumbinfo-val">'+ file.band + '</span><br>';
+            content += '<span class="thumbinfo-key">Ngrp/Nint: </span>'+ '<span class="thumbinfo-val">'+ file.ngrp_nint + '</span><br>';
+            if (exp_type=="mir_mrs"){
+                content += '<span class="thumbinfo-key">Band: </span>'+ '<span class="thumbinfo-val">'+ file.band + '</span><br>';
             }
+        }
+        
         content += '</div></a></div>';
 
         // Add the content to the div

--- a/jwql/website/apps/jwql/static/js/jwql.js
+++ b/jwql/website/apps/jwql/static/js/jwql.js
@@ -924,32 +924,34 @@ function update_thumbnail_array(data) {
         content += '<div class="thumbnail-color-fill" ></div>';
         content += '<div class="thumbnail-info">';
         content += '<span class="thumbinfo-key">Proposal: </span>' + '<span class="thumbinfo-val">'+ filename_dict.program_id + '</span><br>';
-        content += '<span class="thumbinfo-key">Observation: </span>' + '<span class="thumbinfo-val">'+ filename_dict.observation + '</span><br>';
-        content += '<span class="thumbinfo-key">Visit: </span>' + '<span class="thumbinfo-val">'+ filename_dict.visit + '</span><br>';
+        content += '<span class="thumbinfo-key">Obs/Visit: </span>' + '<span class="thumbinfo-val">'+ file.obs_visit + '</span><br>';
         content += '<span class="thumbinfo-key">Detector: </span>' + '<span class="thumbinfo-val">'+ filename_dict.detector + '</span><br>';
         content += '<span class="thumbinfo-key">Start: </span>' + '<span class="thumbinfo-val">'+ file.expstart_str + '</span><br>';
         content += '<span class="thumbinfo-key">Exp_Num: </span>' + '<span class="thumbinfo-val">'+ file.exp_num + '</span><br>';
 
         // Additional keywords to be displayed for each instrument
         if (filename_dict.instrument=="nirspec"){
-            content += '<span class="thumbinfo-key">Filter: </span>' + '<span class="thumbinfo-val">'+ file.filter+ '</span><br>';
-            content += '<span class="thumbinfo-key">Grating: </span>' + '<span class="thumbinfo-val">'+ file.grating+ '</span><br>';
+            content += '<span class="thumbinfo-key">Optics: </span>' + '<span class="thumbinfo-val">'+ file.filtergrating+ '</span><br>';
             content += '<span class="thumbinfo-key">Patt_Num: </span>' + '<span class="thumbinfo-val">'+ file.patt_num+ '</span><br>';
-            content += '<span class="thumbinfo-key">Lamp: </span>' + '<span class="thumbinfo-val">'+ file.lamp+ '</span><br>';
+            if (file.lamp !== "NONE"){
+                content += '<span class="thumbinfo-key">Lamp: </span>' + '<span class="thumbinfo-val">'+ file.lamp+ '</span><br>';
+            }
             content += '<span class="thumbinfo-key">Opmode: </span>' + '<span class="thumbinfo-val">'+ file.opmode+ '</span><br>';
         }
         if (filename_dict.instrument=="nircam"){
-            content += '<span class="thumbinfo-key">Filter/Pupil: </span>' + '<span class="thumbinfo-val">'+ file.filterpupil + '</span><br>';   
+            content += '<span class="thumbinfo-key">Optics: </span>' + '<span class="thumbinfo-val">'+ file.filterpupil + '</span><br>';   
         }
         if (filename_dict.instrument=="niriss"){
-            content += '<span class="thumbinfo-key">Filter/Pupil: </span>' + '<span class="thumbinfo-val">'+ file.filterpupil + '</span><br>';   
+            content += '<span class="thumbinfo-key">Optics: </span>' + '<span class="thumbinfo-val">'+ file.filterpupil + '</span><br>';   
         }
         if (filename_dict.instrument=="miri"){
-            content += '<span class="thumbinfo-key">Filter: </span>'+ '<span class="thumbinfo-val">'+ file.filter + '</span><br>';
-            content += '<span class="thumbinfo-key">Ngrp/Nint: </span>'+ '<span class="thumbinfo-val">'+ file.ngrp_nint + '</span><br>';
-            if (exp_type=="mir_mrs"){
-                content += '<span class="thumbinfo-key">Band: </span>'+ '<span class="thumbinfo-val">'+ file.band + '</span><br>';
+            if ('band' in file) {
+                content += '<span class="thumbinfo-key">Optics: </span>'+ '<span class="thumbinfo-val">'+ file.filterband + '</span><br>';
             }
+            else {
+                content += '<span class="thumbinfo-key">Filter: </span>'+ '<span class="thumbinfo-val">'+ file.filter + '</span><br>';
+            }
+            content += '<span class="thumbinfo-key">Ngrp/Nint: </span>'+ '<span class="thumbinfo-val">'+ file.ngrp_nint + '</span><br>';
         }
         
         content += '</div></a></div>';

--- a/jwql/website/apps/jwql/static/js/jwql.js
+++ b/jwql/website/apps/jwql/static/js/jwql.js
@@ -945,8 +945,8 @@ function update_thumbnail_array(data) {
             content += '<span class="thumbinfo-key">Optics: </span>' + '<span class="thumbinfo-val">'+ file.filterpupil + '</span><br>';   
         }
         if (filename_dict.instrument=="miri"){
-            if ('band' in file) {
-                content += '<span class="thumbinfo-key">Optics: </span>'+ '<span class="thumbinfo-val">'+ file.filterband + '</span><br>';
+            if ('channelband' in file) {
+                content += '<span class="thumbinfo-key">Optics: </span>'+ '<span class="thumbinfo-val">'+ file.channelband + '</span><br>';
             }
             else {
                 content += '<span class="thumbinfo-key">Filter: </span>'+ '<span class="thumbinfo-val">'+ file.filter + '</span><br>';

--- a/jwql/website/apps/jwql/static/js/jwql.js
+++ b/jwql/website/apps/jwql/static/js/jwql.js
@@ -923,12 +923,33 @@ function update_thumbnail_array(data) {
         content += '<span class="helper"></span><img id="thumbnail' + i + '" onerror="image_error(this);">';
         content += '<div class="thumbnail-color-fill" ></div>';
         content += '<div class="thumbnail-info">';
-        content += 'Proposal: ' + filename_dict.program_id + '<br>';
-        content += 'Observation: ' + filename_dict.observation + '<br>';
-        content += 'Visit: ' + filename_dict.visit + '<br>';
-        content += 'Detector: ' + filename_dict.detector + '<br>';
-        content += 'Exp_Start: ' + file.expstart_iso + '<br>';
-        content += 'Exp_Num: ' + file.exp_num + '<br>';
+        content += '<span class="thumbinfo-key">Proposal: </span>' + '<span class="thumbinfo-val">'+ filename_dict.program_id + '</span><br>';
+        content += '<span class="thumbinfo-key">Observation: </span>' + '<span class="thumbinfo-val">'+ filename_dict.observation + '</span><br>';
+        content += '<span class="thumbinfo-key">Visit: </span>' + '<span class="thumbinfo-val">'+ filename_dict.visit + '</span><br>';
+        content += '<span class="thumbinfo-key">Detector: </span>' + '<span class="thumbinfo-val">'+ filename_dict.detector + '</span><br>';
+        content += '<span class="thumbinfo-key">Start: </span>' + '<span class="thumbinfo-val">'+ file.expstart_str + '</span><br>';
+        content += '<span class="thumbinfo-key">Exp_Num: </span>' + '<span class="thumbinfo-val">'+ file.exp_num + '</span><br>';
+
+        // Additional keywords to be displayed for each instrument
+        if (filename_dict.instrument=="nirspec"){
+            content += '<span class="thumbinfo-key">Filter: </span>' + '<span class="thumbinfo-val">'+ file.filter+ '</span><br>';
+            content += '<span class="thumbinfo-key">Grating: </span>' + '<span class="thumbinfo-val">'+ file.grating+ '</span><br>';
+            content += '<span class="thumbinfo-key">Patt_Num: </span>' + '<span class="thumbinfo-val">'+ file.pattnum+ '</span><br>';
+            content += '<span class="thumbinfo-key">Lamp: </span>' + '<span class="thumbinfo-val">'+ file.lamp+ '</span><br>';
+            content += '<span class="thumbinfo-key">Opmode: </span>' + '<span class="thumbinfo-val">'+ file.opmode+ '</span><br>';
+        }
+        if (filename_dict.instrument=="nircam"){
+            content += '<span class="thumbinfo-key">Filter/Pupil: </span>' + '<span class="thumbinfo-val">'+ file.filterpupil + '</span><br>';   
+        }
+        if (filename_dict.instrument=="niriss"){
+            content += '<span class="thumbinfo-key">Filter/Pupil: </span>' + '<span class="thumbinfo-val">'+ file.filterpupil + '</span><br>';   
+        }
+        if (filename_dict.instrument=="miri"){
+            content += '<span class="thumbinfo-key">Filter: </span>'+ '<span class="thumbinfo-val">'+ file.filter + '</span><br>';
+        }
+        if (exp_type=="miri_mrs"){
+            content += '<span class="thumbinfo-key">Band: </span>'+ '<span class="thumbinfo-val">'+ file.band + '</span><br>';
+            }
         content += '</div></a></div>';
 
         // Add the content to the div

--- a/jwql/website/apps/jwql/static/js/jwql.js
+++ b/jwql/website/apps/jwql/static/js/jwql.js
@@ -928,6 +928,7 @@ function update_thumbnail_array(data) {
         content += 'Visit: ' + filename_dict.visit + '<br>';
         content += 'Detector: ' + filename_dict.detector + '<br>';
         content += 'Exp_Start: ' + file.expstart_iso + '<br>';
+        content += 'Exp_Num: ' + file.exp_num + '<br>';
         content += '</div></a></div>';
 
         // Add the content to the div


### PR DESCRIPTION
Additional keywords have been added to the info displayed when mousing over thumbnails on the archive images pages as requested by the instrument teams. They are:
NIRCam:
- optics (filter/pupil)
NIRISS:
- optics (filter/pupil)
NIRSpec:
- optics (filter/grating)
- patt_num
- lamp (when not None)
- opmode
MIRI:
- optics (channel/band or filter as appropriate)
- ngrps/nints

Other keywords have been combined or reformatted to save space ("obs/visit", "start"). Formatting adjustments such as left/right justification of keys/values have also been applied via CSS class.