### PR TITLE
Nest the if statements to protect against empty file list

### DIFF
--- a/jwql/website/apps/jwql/monitor_pages/monitor_bias_bokeh.py
+++ b/jwql/website/apps/jwql/monitor_pages/monitor_bias_bokeh.py
@@ -616,22 +616,28 @@ class ZerothGroupImage():
     def create_figure(self):
         """Create the Bokeh figure
         """
-        if len(self.data['cal_image']) > 0 and os.path.isfile(self.data['cal_image'].iloc[0]):
-            image = read_png(self.data['cal_image'].iloc[0])
+        if len(self.data['cal_image']) > 0:
+            if os.path.isfile(self.data['cal_image'].iloc[0]):
+                image = read_png(self.data['cal_image'].iloc[0])
 
-            datestr = self.data['expstart_str'].iloc[0]
+                datestr = self.data['expstart_str'].iloc[0]
 
-            # Display the 32-bit RGBA image
-            ydim, xdim = image.shape
-            dim = max(xdim, ydim)
-            self.figure = figure(title=f'Calibrated Zeroth Group of Most Recent Dark: {datestr}', x_range=(0, xdim), y_range=(0, ydim),
-                                 tools='pan,box_zoom,reset,wheel_zoom,save')
-            self.figure.image_rgba(image=[image], x=0, y=0, dw=xdim, dh=ydim)
-            self.figure.xaxis.visible = False
-            self.figure.yaxis.visible = False
+                # Display the 32-bit RGBA image
+                ydim, xdim = image.shape
+                dim = max(xdim, ydim)
+                self.figure = figure(title=f'Calibrated Zeroth Group of Most Recent Dark: {datestr}', x_range=(0, xdim), y_range=(0, ydim),
+                                     tools='pan,box_zoom,reset,wheel_zoom,save')
+                self.figure.image_rgba(image=[image], x=0, y=0, dw=xdim, dh=ydim)
+                self.figure.xaxis.visible = False
+                self.figure.yaxis.visible = False
+            else:
+                # If the listed file is missing, create an empty plot
+                self.figure = PlaceholderPlot('Calibrated Zeroth Group of Most Recent Dark', '', '').plot
+                self.figure.xaxis.visible = False
+                self.figure.yaxis.visible = False
 
         else:
-            # If the given file is missing, create an empty plot
+            # If no file is given, create an empty plot
             self.figure = PlaceholderPlot('Calibrated Zeroth Group of Most Recent Dark', '', '').plot
             self.figure.xaxis.visible = False
             self.figure.yaxis.visible = False

--- a/jwql/website/apps/jwql/monitor_pages/monitor_bias_bokeh.py
+++ b/jwql/website/apps/jwql/monitor_pages/monitor_bias_bokeh.py
@@ -115,6 +115,9 @@ class BiasMonitorData():
                                                                       'amp3_even_med', 'amp3_odd_med',
                                                                       'amp4_even_med', 'amp4_odd_med',
                                                                       'expstart_str', 'uncal_filename'])
+        uncal_basename = [os.path.basename(e) for e in self.trending_data['uncal_filename']]
+        self.trending_data['uncal_filename'] = uncal_basename
+
         # Add a column of expstart values that are datetime objects
         format_data = "%Y-%m-%dT%H:%M:%S.%f"
         datetimes = [datetime.strptime(entry, format_data) for entry in self.trending_data['expstart_str']]
@@ -567,10 +570,10 @@ class TrendingPlot():
             hover_tool = HoverTool(tooltips=[('File:', '@uncal_filename'),
                                              ('Even col bias:', f'@{even_col}'),
                                              ('Odd col bias:', f'@{odd_col}'),
-                                             ('Date:', '@expstart')
+                                             ('Date:', '@expstart_str')
                                              ]
                                    )
-            hover_tool.formatters = {'@expstart': 'datetime'}
+            #hover_tool.formatters = {'@expstart': 'datetime'}
             plot.tools.append(hover_tool)
             plot.xaxis.axis_label = x_label
             plot.yaxis.axis_label = y_label
@@ -589,7 +592,7 @@ class TrendingPlot():
         # Create one plot per amplifier
         for amp_num in range(1, 5):
             cols_to_use = [col for col in self.data.columns if str(amp_num) in col]
-            cols_to_use.append('expstart')
+            cols_to_use.extend(['expstart', 'expstart_str', 'uncal_filename'])
             subframe = self.data[cols_to_use]
             self.plots[amp_num] = self.create_amp_plot(amp_num, subframe)
 


### PR DESCRIPTION
Resolves #1241 

The bias monitor was crashing in a case where the database entry for the calibrated file name was empty. The check for this was in place, but incorrectly combined with a check that the given filename pointed to a real file. This PR splits those two conditions into two if statements, in order to correctly catch each issue.

- [x] Still need to test on the test server