### PR TITLE
Fix path to pyproject.toml

### DIFF
--- a/jwql/utils/logging_functions.py
+++ b/jwql/utils/logging_functions.py
@@ -223,7 +223,8 @@ def log_info(func):
         logging.info('Running as PID {}'.format(os.getpid()))
 
         # Read in setup.py file to build list of required modules
-        with open("pyproject.toml", "rb") as f:
+        toml_file = os.path.join(os.path.dirname(get_config()['setup_file']), 'pyproject.toml')
+        with open(toml_file, "rb") as f:
             data = tomllib.load(f)
 
         required_modules = data['project']['dependencies']


### PR DESCRIPTION
Fixes an issue with #1250 
In that PR, the full path to setup.py was replaced with pyproject.toml. But without the full path, the logging function was not finding pyproject.toml, and crashing. This PR restores the full path to pyproject.toml

