### PR TITLE
Add download links to image pages

### DIFF
--- a/jwql/website/apps/jwql/static/js/jwql.js
+++ b/jwql/website/apps/jwql/static/js/jwql.js
@@ -125,6 +125,11 @@
     document.getElementById("visit_id").innerHTML = parsed_name.visit_id;
     document.getElementById("detector").innerHTML = file_root.split('_')[3];
 
+    // Add a link to download the file from MAST
+     document.getElementById("fits_filename").setAttribute('href',
+         'https://mast.stsci.edu/api/v0.1/Download/file?uri=mast%3AJWST%2Fproduct%2F' +
+         fits_filename + '.fits');
+
     // Show the appropriate image
     var img = document.getElementById("image_viewer");
     var jpg_filepath = '/static/preview_images/' + parsed_name.program + '/' + file_root + '_' + type + '_integ0.jpg';

--- a/jwql/website/apps/jwql/templates/explore_image.html
+++ b/jwql/website/apps/jwql/templates/explore_image.html
@@ -12,9 +12,10 @@
     	<!-- Show fits file name -->
         <h3>Explore Mode </h3>
     	<h3>{{ file_root }}_{{ filetype }}.fits</h3>
-    	<p>
+        <p>
             <a class="btn btn-primary my-2 mx-2" role="button" href={{ url('jwql:view_image', args=[inst, file_root]) }}>View Image</a>
             <a class="btn btn-primary my-2 mx-2" role="button" href={{ url('jwql:archive_thumb_per_obs', args=[inst, file_root[2:7], file_root[7:10]]) }}> View Proposal</a>
+            <a class="btn btn-primary my-2 mx-2" role="button" href="https://mast.stsci.edu/api/v0.1/Download/file?uri=mast%3AJWST%2Fproduct%2F{{ file_root }}_{{ filetype }}.fits">Download File</a>
 	    </p>
 
         <!-- Allow the user to change the settings in the image to explore -->


### PR DESCRIPTION
Add a link to the MAST API to download the associated FITS file from the image page (preview or interactive).