### PR TITLE
update actions/checkout to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
           python-version: "3.x"
@@ -32,7 +32,7 @@ jobs:
         python-version: [3.9, "3.10"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: mamba-org/provision-with-micromamba@v15
         with:
@@ -43,7 +43,7 @@ jobs:
       - run: pip install -e .[test]
 
       - run: conda env export
-      
+
       - uses: supercharge/redis-github-action@1.4.0
         with:
           redis-version: 5.0


### PR DESCRIPTION
update the `actions/checkout` version from 3 to 4, for github actions