### PR TITLE
MAST Astroquery Param Update 

### DIFF
--- a/jwql/tests/test_mast_utils.py
+++ b/jwql/tests/test_mast_utils.py
@@ -34,8 +34,10 @@ if not ON_GITHUB_ACTIONS:
 def test_astroquery_mast():
     """Test if the astroquery.mast service can complete a request"""
     service = 'Mast.Caom.Filtered'
-    params = {'columns': 'COUNT_BIG(*)', 'filters': [], 'pagesize': 1,
-              'page': 1}
+    params = {'columns': 'COUNT_BIG(*)', 
+              'filters': [{"paramName": "obs_collection",
+                           "values": ["JWST"]},], 
+              'pagesize': 1, 'page': 1}
     response = Mast.service_request_async(service, params)
     result = response[0].json()
 

--- a/jwql/website/apps/jwql/data_containers.py
+++ b/jwql/website/apps/jwql/data_containers.py
@@ -1396,7 +1396,7 @@ def get_proposals_by_category(instrument):
 
     service = "Mast.Jwst.Filtered.{}".format(instrument)
     params = {"columns": "program, category",
-              "filters": []}
+              "filters": [{'paramName':'instrume', 'values':[instrument]}]}
     response = Mast.service_request_async(service, params)
     results = response[0].json()['data']
 


### PR DESCRIPTION
Adding `instrume` keyword to params for `get_proposals_by_category`. Updates to MAST is causing the previous iteration to fail. This is a quick fix and makes what we are searching for more explicit.