### PR TITLE
Hotfix: Crashing archive_database_update

### DIFF
--- a/jwql/website/apps/jwql/data_containers.py
+++ b/jwql/website/apps/jwql/data_containers.py
@@ -306,8 +306,10 @@ def create_archived_proposals_context(inst):
             # Add category type to list based on proposal number
             cat_types.append(proposals_by_category[int(proposal_num)])
         except KeyError:
-            logging.error(f"""Unable to populate proposals by category in MAST for proposal number {proposal_num}\n
-                          Proposal number {proposal_num} will not have category type associated with it""")
+            cat_types.append("MISSING")
+            logging.error(f"""Unable to populate proposals by category in MAST for proposal number {proposal_num}
+                          Proposal number {proposal_num} will 'MISSING' category type associated with it
+                          """)
 
     thumbnails_dict['proposals'] = proposal_nums
     thumbnails_dict['thumbnail_paths'] = thumbnail_paths

--- a/jwql/website/apps/jwql/data_containers.py
+++ b/jwql/website/apps/jwql/data_containers.py
@@ -309,7 +309,6 @@ def create_archived_proposals_context(inst):
             logging.error(f"""Unable to populate proposals by category in MAST for proposal number {proposal_num}\n
                           Proposal number {proposal_num} will not have category type associated with it""")
 
-
     thumbnails_dict['proposals'] = proposal_nums
     thumbnails_dict['thumbnail_paths'] = thumbnail_paths
     thumbnails_dict['num_files'] = total_files

--- a/jwql/website/apps/jwql/data_containers.py
+++ b/jwql/website/apps/jwql/data_containers.py
@@ -308,7 +308,7 @@ def create_archived_proposals_context(inst):
         except KeyError:
             cat_types.append("MISSING")
             logging.error(f"""Unable to populate proposals by category in MAST for proposal number {proposal_num}
-                          Proposal number {proposal_num} will 'MISSING' category type associated with it
+                          Proposal number {proposal_num} will have 'MISSING' category type associated with it
                           """)
 
     thumbnails_dict['proposals'] = proposal_nums

--- a/jwql/website/apps/jwql/data_containers.py
+++ b/jwql/website/apps/jwql/data_containers.py
@@ -302,8 +302,13 @@ def create_archived_proposals_context(inst):
         proposal_obs_times = [observation.obsstart for observation in prop_entries]
         thumb_obs_time.append(max(proposal_obs_times))
 
-        # Add category type to list based on proposal number
-        cat_types.append(proposals_by_category[int(proposal_num)])
+        try:
+            # Add category type to list based on proposal number
+            cat_types.append(proposals_by_category[int(proposal_num)])
+        except KeyError:
+            logging.error(f"""Unable to populate proposals by category in MAST for proposal number {proposal_num}\n
+                          Proposal number {proposal_num} will not have category type associated with it""")
+
 
     thumbnails_dict['proposals'] = proposal_nums
     thumbnails_dict['thumbnail_paths'] = thumbnail_paths


### PR DESCRIPTION
Archive Database Update is crashing with a key error when past does not return all values from a `get_proposals_by_category` call in data_containers.py

Add simple try except and logging