### PR TITLE
Increase MAST query limit. 

### DIFF
--- a/jwql/utils/constants.py
+++ b/jwql/utils/constants.py
@@ -613,7 +613,7 @@ JWST_MAST_SERVICES = [
 LOOK_OPTIONS = ["New", "Viewed"]
 
 # Maximum number of records returned by MAST for a single query
-MAST_QUERY_LIMIT = 500000
+MAST_QUERY_LIMIT = 550000
 
 # Expected position sensor values for MIRI. Used by the EDB monitor
 # to filter out bad values. Tuple values are the expected value and

--- a/jwql/website/apps/jwql/data_containers.py
+++ b/jwql/website/apps/jwql/data_containers.py
@@ -1409,6 +1409,9 @@ def get_proposals_by_category(instrument):
     response = Mast.service_request_async(service, params)
     results = response[0].json()['data']
 
+    if len(results) == MAST_QUERY_LIMIT:
+        logging.error(f"MAST_QUERY_LIMIT of {MAST_QUERY_LIMIT} reached for {instrument} in get_proposals_by_category")
+
     # Get all unique dictionaries
     unique_results = list(map(dict, set(tuple(sorted(sub.items())) for sub in results)))
 


### PR DESCRIPTION
In data_containers.get_proposals_by_category(), we are reaching the limit on the number of results returned by MAST for NIRCam queries. This PR makes a (short-term) fix by increasing the MAST limit. It also adds a logging error statement if the MAST query limit is reached. 

Longer term, we should find a better way to retrieve a list of an instrument's proposal numbers and categories.