### PR TITLE
NIRCam Background Monitor updates

### DIFF
--- a/environment_python_3.10.yml
+++ b/environment_python_3.10.yml
@@ -59,6 +59,7 @@ dependencies:
     - astroquery==0.4.6
     - bandit==1.7.5
     - jwst==1.12.3
+    - jwst_backgrounds==1.2.0
     - pysiaf==0.20.0
     - pysqlite3==0.5.2
     - pyvo==1.4.2

--- a/environment_python_3.9.yml
+++ b/environment_python_3.9.yml
@@ -59,6 +59,7 @@ dependencies:
     - astroquery==0.4.6
     - bandit==1.7.5
     - jwst==1.12.3
+    - jwst_backgrounds==1.2.0
     - pysiaf==0.20.0
     - pysqlite3==0.5.2
     - pyvo==1.4.2

--- a/jwql/database/monitor_table_definitions/nircam/nircam_claw_stats.txt
+++ b/jwql/database/monitor_table_definitions/nircam/nircam_claw_stats.txt
@@ -15,4 +15,6 @@ MEDIAN, float
 STDDEV, float
 FRAC_MASKED, float
 SKYFLAT_FILENAME, string
+DOY, float
+TOTAL_BKG, float
 ENTRY_DATE, datetime

--- a/jwql/instrument_monitors/nircam_monitors/claw_monitor.py
+++ b/jwql/instrument_monitors/nircam_monitors/claw_monitor.py
@@ -119,7 +119,7 @@ class ClawMonitor():
 
     def make_background_plots(self, plot_type='bkg'):
         """Makes plots of the background levels over time in NIRCam data.
-        
+
         Attributes
         ----------
         plot_type : str
@@ -173,7 +173,7 @@ class ClawMonitor():
                              (abs(1 - (df_orig['mean'] / df_orig['median'])) < 0.05)]
                 if len(df) > 0:
                     df = df.sort_values(by=['expstart_mjd'])
-                
+
                 # Get relevant background stat for plot type
                 if plot_type == 'bkg':
                     plot_data = df['median'].values
@@ -270,7 +270,7 @@ class ClawMonitor():
                 segmap_orig = detect_sources(data_conv, threshold, npixels=6)
                 segmap_orig = segmap_orig.data
                 stack[n] = np.ma.masked_array(data, mask=(segmap_orig != 0) | (dq & 1 != 0))
-                
+
                 # Calculate image stats. Before calculating, expand segmap of extended objects.
                 # This is only done after adding the data to the claw stack to avoid flagging the claws
                 # themselves from those stacks, but is needed here since extended wings can impact image
@@ -293,7 +293,7 @@ class ClawMonitor():
                 date = hdu[0].header['DATE-BEG']
                 doy = int(Time(date).yday.split(':')[1])
                 try:
-                    jbt.get_background(ra, dec, wv, thisday=doy, plot_background=False, plot_bathtub=False, 
+                    jbt.get_background(ra, dec, wv, thisday=doy, plot_background=False, plot_bathtub=False,
                                        write_bathtub=True, bathtub_file='background_versus_day.txt')
                     bkg_table = Table.read('background_versus_day.txt', names=('day', 'total_bkg'), format='ascii')
                     total_bkg = bkg_table['total_bkg'][bkg_table['day'] == doy][0]
@@ -414,9 +414,10 @@ class ClawMonitor():
         logging.info('{} files found between {} and {}.'.format(len(mast_table), self.query_start_mjd, self.query_end_mjd))
 
         # Define pivot wavelengths
-        self.filter_wave = {'F070W': 0.704, 'F090W': 0.902, 'F115W': 1.154, 'F150W': 1.501, 'F150W2': 1.659, \
-                            'F200W': 1.989, 'F212N': 2.121, 'F250M': 2.503, 'F277W': 2.762, 'F300M': 2.989, \
-                            'F322W2': 3.232, 'F356W': 3.568, 'F410M': 4.082, 'F430M': 4.281,  'F444W': 4.408, 'F480M': 4.874}
+        self.filter_wave = {'F070W': 0.704, 'F090W': 0.902, 'F115W': 1.154, 'F150W': 1.501, 'F150W2': 1.659,
+                            'F200W': 1.989, 'F212N': 2.121, 'F250M': 2.503, 'F277W': 2.762, 'F300M': 2.989,
+                            'F322W2': 3.232, 'F356W': 3.568, 'F410M': 4.082, 'F430M': 4.281,  'F444W': 4.408,
+                            'F480M': 4.874}
 
         # Create observation-level median stacks for each filter/pupil combo, in pixel-space
         combos = np.array(['{}_{}_{}_{}'.format(str(row['program']), row['observtn'], row['filter'], row['pupil']).lower() for row in mast_table])
@@ -438,8 +439,6 @@ class ClawMonitor():
                 except:
                     pass
             self.files = np.array(existing_files)
-            print(self.files)
-            print(mast_table_combo)
             self.detectors = np.array(mast_table_combo['detector'])
             if (not os.path.exists(self.outfile)) & (len(existing_files) == len(mast_table_combo)):
                 logging.info('Working on {}'.format(self.outfile))

--- a/jwql/instrument_monitors/nircam_monitors/claw_monitor.py
+++ b/jwql/instrument_monitors/nircam_monitors/claw_monitor.py
@@ -185,7 +185,7 @@ class ClawMonitor():
 
                 # Plot the background data over time
                 ax = fig.add_subplot(grid[i])
-                ax.scatter(plot_expstarts, plot_data)
+                ax.scatter(plot_expstarts, plot_data, alpha=0.5)
 
                 # Match scaling in all plots to the first detector with data.
                 if len(df) > 0:
@@ -199,7 +199,7 @@ class ClawMonitor():
                         time_tick_vals = np.linspace(start_mjd, end_mjd, 5)
                         time_tick_labels = [Time(m, format='mjd').isot.split('T')[0] for m in time_tick_vals]
                         found_limits = True
-                    ax.set_ylim(first_med - 5 * first_stddev, first_med + 5 * first_stddev)
+                    ax.set_ylim(first_med - 8 * first_stddev, first_med + 8 * first_stddev)
 
                     # Plot overall median line with shaded stddev
                     mean, med, stddev = sigma_clipped_stats(plot_data)

--- a/jwql/instrument_monitors/nircam_monitors/claw_monitor.py
+++ b/jwql/instrument_monitors/nircam_monitors/claw_monitor.py
@@ -30,6 +30,7 @@ import warnings
 from astropy.convolution import Gaussian2DKernel, convolve
 from astropy.io import fits
 from astropy.stats import gaussian_fwhm_to_sigma, sigma_clipped_stats
+from astropy.table import Table
 from astropy.time import Time
 from astroquery.mast import Mast
 import matplotlib
@@ -37,12 +38,14 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 from photutils.segmentation import detect_sources, detect_threshold
+from scipy.ndimage import binary_dilation
 
 from jwql.database.database_interface import session, engine
 from jwql.database.database_interface import NIRCamClawQueryHistory, NIRCamClawStats
 from jwql.utils import monitor_utils
 from jwql.utils.logging_functions import log_info, log_fail
 from jwql.utils.utils import ensure_dir_exists, filesystem_path, get_config
+from jwst_backgrounds import jbt
 
 matplotlib.use('Agg')
 warnings.filterwarnings('ignore', message="nan_treatment='interpolate', however, NaN values detected post convolution*")
@@ -114,27 +117,39 @@ class ClawMonitor():
         self.query_table = eval('NIRCamClawQueryHistory')
         self.stats_table = eval('NIRCamClawStats')
 
-    def make_background_plots(self):
+    def make_background_plots(self, plot_type='bkg'):
         """Makes plots of the background levels over time in NIRCam data.
+        
+        Attributes
+        ----------
+        plot_type : str
+            The type of plot to make, either ``bkg`` for background trending,
+            ``bkg_rms`` for background rms trending, or ``model`` for background
+            measured vs model trending.
         """
 
         # Get all of the background data.
         query = session.query(NIRCamClawStats.filename, NIRCamClawStats.filter, NIRCamClawStats.pupil, NIRCamClawStats.detector,
                               NIRCamClawStats.effexptm, NIRCamClawStats.expstart_mjd, NIRCamClawStats.entry_date, NIRCamClawStats.mean,
-                              NIRCamClawStats.median, NIRCamClawStats.frac_masked).all()
+                              NIRCamClawStats.median, NIRCamClawStats.stddev, NIRCamClawStats.frac_masked, NIRCamClawStats.total_bkg).all()
         df_orig = pd.DataFrame(query, columns=['filename', 'filter', 'pupil', 'detector', 'effexptm', 'expstart_mjd',
-                                               'entry_date', 'mean', 'median', 'frac_masked'])
+                                               'entry_date', 'mean', 'median', 'stddev', 'frac_masked', 'total_bkg'])
         df_orig = df_orig.drop_duplicates(subset='filename', keep="last")  # remove any duplicate filename entries, keep the most recent
 
-        # Use the same time xlimits/xticks for all plots
-        start_mjd = 59650  # March 2022, middle of commissioning
-        end_mjd = Time.now().mjd + 0.05 * (Time.now().mjd - start_mjd)
-        time_tick_vals = np.linspace(start_mjd, end_mjd, 5)
-        time_tick_labels = [Time(m, format='mjd').isot.split('T')[0] for m in time_tick_vals]
+        # Get label info based on plot type
+        if plot_type == 'bkg':
+            plot_title = 'backgrounds'
+            plot_label = 'Background [MJy/sr]'
+        if plot_type == 'bkg_rms':
+            plot_title = 'backgrounds_rms'
+            plot_label = 'Background RMS [MJy/sr]'
+        if plot_type == 'model':
+            plot_title = 'backgrounds_vs_models'
+            plot_label = 'Measured / Predicted'
 
         # Make backgroud trending plots for all wide filters
         for fltr in ['F070W', 'F090W', 'F115W', 'F150W', 'F200W', 'F277W', 'F356W', 'F444W']:
-            logging.info('Working on background trending plots for {}'.format(fltr))
+            logging.info('Working on {} trending plots for {}'.format(plot_title, fltr))
             found_limits = False
             if int(fltr[1:4]) < 250:  # i.e. SW
                 detectors_to_run = ['NRCA2', 'NRCA4', 'NRCB3', 'NRCB1', 'NRCA1', 'NRCA3', 'NRCB4', 'NRCB2']   # in on-sky order, don't change order
@@ -156,20 +171,42 @@ class ClawMonitor():
                 df = df_orig[(df_orig['filter'] == fltr) & (df_orig['pupil'] == 'CLEAR') & (df_orig['detector'] == det) &
                              (df_orig['effexptm'] > 300) & (df_orig['frac_masked'] < frack_masked_thresh) &
                              (abs(1 - (df_orig['mean'] / df_orig['median'])) < 0.05)]
+                if len(df) > 0:
+                    df = df.sort_values(by=['expstart_mjd'])
+                
+                # Get relevant background stat for plot type
+                if plot_type == 'bkg':
+                    plot_data = df['median'].values
+                if plot_type == 'bkg_rms':
+                    plot_data = df['stddev'].values
+                if plot_type == 'model':
+                    plot_data = df['median'].values / df['total_bkg'].values
+                plot_expstarts = df['expstart_mjd'].values
 
-                # Plot the background levels over time
+                # Plot the background data over time
                 ax = fig.add_subplot(grid[i])
-                ax.scatter(df['expstart_mjd'], df['median'])
+                ax.scatter(plot_expstarts, plot_data)
 
-                # Match scaling in all plots to the first detector with data. Shade median+/-10% region.
+                # Match scaling in all plots to the first detector with data.
                 if len(df) > 0:
                     if found_limits is False:
-                        first_med = np.nanmedian(df['median'])
+                        first_mean, first_med, first_stddev = sigma_clipped_stats(plot_data)
+                        start_mjd = plot_expstarts.min()
+                        end_mjd = Time.now().mjd
+                        padding = 0.05 * (end_mjd - start_mjd)
+                        start_mjd = start_mjd - padding
+                        end_mjd = end_mjd + padding
+                        time_tick_vals = np.linspace(start_mjd, end_mjd, 5)
+                        time_tick_labels = [Time(m, format='mjd').isot.split('T')[0] for m in time_tick_vals]
                         found_limits = True
-                    ax.set_ylim(first_med - first_med * 0.5, first_med + first_med * 0.5)
-                    med = np.nanmedian(df['median'])
+                    ax.set_ylim(first_med - 5 * first_stddev, first_med + 5 * first_stddev)
+
+                    # Plot overall median line with shaded stddev
+                    mean, med, stddev = sigma_clipped_stats(plot_data)
                     ax.axhline(med, ls='-', color='black')
-                    ax.axhspan(med - med * 0.1, med + med * 0.1, color='gray', alpha=0.4, lw=0)
+                    ax.axhspan(med - stddev, med + stddev, color='gray', alpha=0.4, lw=0)
+                else:
+                    start_mjd, end_mjd, time_tick_vals, time_tick_labels = 0, 1, [0.5], ['N/A']
 
                 # Axis formatting
                 ax.set_title(det, fontsize=40)
@@ -177,10 +214,9 @@ class ClawMonitor():
                 ax.set_xticks(time_tick_vals)
                 ax.set_xticklabels(time_tick_labels, fontsize=20, rotation=45)
                 ax.yaxis.set_tick_params(labelsize=20)
-                ax.set_ylabel('Background [MJy/sr]', fontsize=30)
-                # ax.set_xlabel('Date [YYYY-MM-DD]')
+                ax.set_ylabel(plot_label, fontsize=30)
                 ax.grid(ls='--', color='gray')
-            fig.savefig(os.path.join(self.output_dir_bkg, '{}_backgrounds.png'.format(fltr)), dpi=180, bbox_inches='tight')
+            fig.savefig(os.path.join(self.output_dir_bkg, '{}_{}.png'.format(fltr, plot_title)), dpi=180, bbox_inches='tight')
             fig.clf()
             plt.close()
 
@@ -222,7 +258,7 @@ class ClawMonitor():
                     obs_start = '{}T{}'.format(hdu[0].header['DATE-OBS'], hdu[0].header['TIME-OBS'])
                     pa_v3 = hdu[1].header['PA_V3']
 
-                # Make source segmap, add the masked data to the stack, and get background stats
+                # Make source segmap and add the masked data to the stack
                 data = hdu['SCI'].data
                 dq = hdu['DQ'].data
                 threshold = detect_threshold(data, 1.0)
@@ -230,11 +266,38 @@ class ClawMonitor():
                 kernel = Gaussian2DKernel(sigma, x_size=3, y_size=3)
                 kernel.normalize()
                 data_conv = convolve(data, kernel)
-                segmap = detect_sources(data_conv, threshold, npixels=6)
-                segmap = segmap.data
-                segmap[dq & 1 != 0] = 1  # flag DO_NOT_USE pixels
-                stack[n] = np.ma.masked_array(data, mask=segmap != 0)
-                mean, med, stddev = sigma_clipped_stats(data[segmap == 0])
+                segmap_orig = detect_sources(data_conv, threshold, npixels=6)
+                segmap_orig = segmap_orig.data
+                stack[n] = np.ma.masked_array(data, mask=(segmap_orig != 0) | (dq & 1 != 0))
+                
+                # Calculate image stats. Before calculating, expand segmap of extended objects.
+                # This is only done after adding the data to the claw stack to avoid flagging the claws
+                # themselves from those stacks, but is needed here since extended wings can impact image
+                # stats, mainly the stddev.
+                objects, object_counts = np.unique(segmap_orig, return_counts=True)
+                large_objects = objects[(object_counts > 200) & (objects != 0)]
+                segmap_extended = np.zeros(segmap_orig.shape).astype(int)
+                for object in large_objects:
+                    segmap_extended[segmap_orig == object] = 1
+                image_edge_mask = np.zeros(segmap_orig.shape).astype(int)
+                image_edge_mask[10:2038, 10:2038] = 1
+                segmap_extended[(image_edge_mask == 0) | (dq & 1 != 0)] = 0  # omit edge and other bpix from dilation
+                segmap_extended = binary_dilation(segmap_extended, iterations=30).astype(int)
+                segmap = segmap_extended + segmap_orig
+                mean, med, stddev = sigma_clipped_stats(data[(segmap == 0) & (dq == 0)])
+
+                # Get predicted background level using JWST background tool
+                ra, dec = hdu[1].header['RA_V1'], hdu[1].header['DEC_V1']
+                wv = self.filter_wave[self.fltr.upper()]
+                date = hdu[0].header['DATE-BEG']
+                doy = int(Time(date).yday.split(':')[1])
+                try:
+                    jbt.get_background(ra, dec, wv, thisday=doy, plot_background=False, plot_bathtub=False, 
+                                       write_bathtub=True, bathtub_file='background_versus_day.txt')
+                    bkg_table = Table.read('background_versus_day.txt', names=('day', 'total_bkg'), format='ascii')
+                    total_bkg = bkg_table['total_bkg'][bkg_table['day'] == doy][0]
+                except:
+                    total_bkg = np.nan
 
                 # Add this file's stats to the claw database table. Can't insert values with numpy.float32
                 # datatypes into database so need to change the datatypes of these values.
@@ -247,16 +310,19 @@ class ClawMonitor():
                                  'expstart': '{}T{}'.format(hdu[0].header['DATE-OBS'], hdu[0].header['TIME-OBS']),
                                  'expstart_mjd': hdu[0].header['EXPSTART'],
                                  'effexptm': hdu[0].header['EFFEXPTM'],
-                                 'ra': hdu[1].header['RA_V1'],
-                                 'dec': hdu[1].header['DEC_V1'],
+                                 'ra': ra,
+                                 'dec': dec,
                                  'pa_v3': hdu[1].header['PA_V3'],
                                  'mean': float(mean),
                                  'median': float(med),
                                  'stddev': float(stddev),
-                                 'frac_masked': len(segmap[segmap != 0]) / (segmap.shape[0] * segmap.shape[1]),
+                                 'frac_masked': len(segmap_orig[(segmap_orig != 0) | (dq & 1 != 0)]) / (segmap_orig.shape[0] * segmap_orig.shape[1]),
                                  'skyflat_filename': os.path.basename(self.outfile),
+                                 'doy': float(doy),
+                                 'total_bkg': float(total_bkg),
                                  'entry_date': datetime.datetime.now()
                                  }
+
                 with engine.begin() as connection:
                     connection.execute(self.stats_table.__table__.insert(), claw_db_entry)
                 hdu.close()
@@ -346,6 +412,11 @@ class ClawMonitor():
         mast_table = self.query_mast()
         logging.info('{} files found between {} and {}.'.format(len(mast_table), self.query_start_mjd, self.query_end_mjd))
 
+        # Define pivot wavelengths
+        self.filter_wave = {'F070W': 0.704, 'F090W': 0.902, 'F115W': 1.154, 'F150W': 1.501, 'F150W2': 1.659, \
+                            'F200W': 1.989, 'F212N': 2.121, 'F250M': 2.503, 'F277W': 2.762, 'F300M': 2.989, \
+                            'F322W2': 3.232, 'F356W': 3.568, 'F410M': 4.082, 'F430M': 4.281,  'F444W': 4.408, 'F480M': 4.874}
+
         # Create observation-level median stacks for each filter/pupil combo, in pixel-space
         combos = np.array(['{}_{}_{}_{}'.format(str(row['program']), row['observtn'], row['filter'], row['pupil']).lower() for row in mast_table])
         mast_table['combos'] = combos
@@ -366,6 +437,8 @@ class ClawMonitor():
                 except:
                     pass
             self.files = np.array(existing_files)
+            print(self.files)
+            print(mast_table_combo)
             self.detectors = np.array(mast_table_combo['detector'])
             if (not os.path.exists(self.outfile)) & (len(existing_files) == len(mast_table_combo)):
                 logging.info('Working on {}'.format(self.outfile))
@@ -377,7 +450,9 @@ class ClawMonitor():
         # Update the background trending plots, if any new data exists
         if len(mast_table) > 0:
             logging.info('Making background trending plots.')
-            self.make_background_plots()
+            self.make_background_plots(plot_type='bkg')
+            self.make_background_plots(plot_type='bkg_rms')
+            self.make_background_plots(plot_type='model')
 
         # Update the query history
         new_entry = {'instrument': 'nircam',

--- a/jwql/instrument_monitors/nircam_monitors/claw_monitor.py
+++ b/jwql/instrument_monitors/nircam_monitors/claw_monitor.py
@@ -416,7 +416,7 @@ class ClawMonitor():
         # Define pivot wavelengths
         self.filter_wave = {'F070W': 0.704, 'F090W': 0.902, 'F115W': 1.154, 'F150W': 1.501, 'F150W2': 1.659,
                             'F200W': 1.989, 'F212N': 2.121, 'F250M': 2.503, 'F277W': 2.762, 'F300M': 2.989,
-                            'F322W2': 3.232, 'F356W': 3.568, 'F410M': 4.082, 'F430M': 4.281,  'F444W': 4.408,
+                            'F322W2': 3.232, 'F356W': 3.568, 'F410M': 4.082, 'F430M': 4.281, 'F444W': 4.408,
                             'F480M': 4.874}
 
         # Create observation-level median stacks for each filter/pupil combo, in pixel-space

--- a/jwql/instrument_monitors/nircam_monitors/claw_monitor.py
+++ b/jwql/instrument_monitors/nircam_monitors/claw_monitor.py
@@ -154,13 +154,13 @@ class ClawMonitor():
             if int(fltr[1:4]) < 250:  # i.e. SW
                 detectors_to_run = ['NRCA2', 'NRCA4', 'NRCB3', 'NRCB1', 'NRCA1', 'NRCA3', 'NRCB4', 'NRCB2']   # in on-sky order, don't change order
                 grid = plt.GridSpec(2, 4, hspace=.4, wspace=.4, width_ratios=[1, 1, 1, 1])
-                fig = plt.figure(figsize=(40, 20))
+                fig = plt.figure(figsize=(45, 20))
                 fig.suptitle(fltr, fontsize=70)
                 frack_masked_thresh = 0.075
             else:  # i.e. LW
                 detectors_to_run = ['NRCALONG', 'NRCBLONG']
                 grid = plt.GridSpec(1, 2, hspace=.2, wspace=.4, width_ratios=[1, 1])
-                fig = plt.figure(figsize=(20, 10))
+                fig = plt.figure(figsize=(25, 10))
                 fig.suptitle(fltr, fontsize=70, y=1.05)
                 frack_masked_thresh = 0.15
             for i, det in enumerate(detectors_to_run):
@@ -178,6 +178,7 @@ class ClawMonitor():
                 if plot_type == 'bkg':
                     plot_data = df['median'].values
                 if plot_type == 'bkg_rms':
+                    df = df[df['stddev'] != 0]  # older data has no accurate stddev measures
                     plot_data = df['stddev'].values
                 if plot_type == 'model':
                     plot_data = df['median'].values / df['total_bkg'].values
@@ -185,7 +186,7 @@ class ClawMonitor():
 
                 # Plot the background data over time
                 ax = fig.add_subplot(grid[i])
-                ax.scatter(plot_expstarts, plot_data, alpha=0.5)
+                ax.scatter(plot_expstarts, plot_data, alpha=0.3)
 
                 # Match scaling in all plots to the first detector with data.
                 if len(df) > 0:

--- a/jwql/website/apps/jwql/monitor_views.py
+++ b/jwql/website/apps/jwql/monitor_views.py
@@ -71,14 +71,19 @@ def background_monitor(request):
     template = "background_monitor.html"
 
     # Get the background trending filters to display
-    server_name = get_config()['outputs'].split("outputs/", 1)[1]
-    output_dir_bkg = static(os.path.join("outputs", server_name, "claw_monitor", "backgrounds"))
+    #server_name = get_config()['outputs'].split("outputs/", 1)[1]  # todo uncomment
+    # output_dir_bkg = static(os.path.join("outputs", server_name, "claw_monitor", "backgrounds"))  # todo uncomment
+    output_dir_bkg = os.path.join('/static/miri1/outputs', "claw_monitor", "backgrounds")  # todo remove line
     fltrs = ['F070W', 'F090W', 'F115W', 'F150W', 'F200W', 'F277W', 'F356W', 'F444W']
     bkg_plots = [os.path.join(output_dir_bkg, '{}_backgrounds.png'.format(fltr)) for fltr in fltrs]
+    bkg_rms_plots = [os.path.join(output_dir_bkg, '{}_backgrounds_rms.png'.format(fltr)) for fltr in fltrs]
+    bkg_model_plots = [os.path.join(output_dir_bkg, '{}_backgrounds_vs_models.png'.format(fltr)) for fltr in fltrs]
 
     context = {
         'inst': 'NIRCam',
-        'bkg_plots': bkg_plots
+        'bkg_plots': bkg_plots,
+        'bkg_rms_plots': bkg_rms_plots,
+        'bkg_model_plots': bkg_model_plots
     }
 
     # Return a HTTP response with the template and dictionary of variables

--- a/jwql/website/apps/jwql/monitor_views.py
+++ b/jwql/website/apps/jwql/monitor_views.py
@@ -71,9 +71,8 @@ def background_monitor(request):
     template = "background_monitor.html"
 
     # Get the background trending filters to display
-    #server_name = get_config()['outputs'].split("outputs/", 1)[1]  # todo uncomment
-    # output_dir_bkg = static(os.path.join("outputs", server_name, "claw_monitor", "backgrounds"))  # todo uncomment
-    output_dir_bkg = os.path.join('/static/miri1/outputs', "claw_monitor", "backgrounds")  # todo remove line
+    server_name = get_config()['outputs'].split("outputs/", 1)[1]
+    output_dir_bkg = static(os.path.join("outputs", server_name, "claw_monitor", "backgrounds"))
     fltrs = ['F070W', 'F090W', 'F115W', 'F150W', 'F200W', 'F277W', 'F356W', 'F444W']
     bkg_plots = [os.path.join(output_dir_bkg, '{}_backgrounds.png'.format(fltr)) for fltr in fltrs]
     bkg_rms_plots = [os.path.join(output_dir_bkg, '{}_backgrounds_rms.png'.format(fltr)) for fltr in fltrs]

--- a/jwql/website/apps/jwql/monitor_views.py
+++ b/jwql/website/apps/jwql/monitor_views.py
@@ -162,7 +162,7 @@ def claw_monitor(request):
     query = session.query(NIRCamClawStats.expstart_mjd, NIRCamClawStats.skyflat_filename).order_by(NIRCamClawStats.expstart_mjd.desc()).all()
     df = pd.DataFrame(query, columns=['expstart_mjd', 'skyflat_filename'])
     recent_files = list(pd.unique(df['skyflat_filename'][df['expstart_mjd'] > Time.now().mjd - 10]))
-    
+
     server_name = get_config()['outputs'].split("outputs/", 1)[1]
     output_dir_claws = static(os.path.join("outputs", server_name, "claw_monitor", "claw_stacks"))
 

--- a/jwql/website/apps/jwql/templates/background_monitor.html
+++ b/jwql/website/apps/jwql/templates/background_monitor.html
@@ -17,53 +17,60 @@
 	<style>
 
 	/* Style the tab */
-	.tab {
-	overflow: hidden;
-	border: 1px solid #ccc;
-	background-color: #f1f1f1;
+	.tabs {
+		overflow: hidden;
+		border: 1px solid #ccc;
+		background-color: #f1f1f1;
 	}
 
 	/* Style the buttons inside the tab */
-	.tab button {
-	background-color: inherit;
-	float: left;
-	border: none;
-	outline: none;
-	cursor: pointer;
-	padding: 14px 16px;
-	transition: 0.3s;
-	font-size: 17px;
+	.tabs button {
+		float: left;
+		border: none;
+		outline: none;
+		cursor: pointer;
+		padding: 14px 16px;
+		transition: 0.3s;
+		font-size: 17px;
 	}
 
 	/* Change background color of buttons on hover */
-	.tab button:hover {
-	background-color: #ddd;
+	.tabs button:hover {
+		background-color: #ddd;
 	}
-
-	/* Create an active/current tablink class */
-	.tab button.active {
-	background-color: #ccc;
-	}
+	
+	/* Change background color of active tabs */
+	.active-tab {
+        background-color: #ddd;
+    }
 
 	/* Style the tab content */
-	.tabcontent {
-	display: none;
-	padding: 6px 12px;
-	border: 1px solid #ccc;
-	border-top: none;
+	.tab-content {
+		display: none;
+		padding: 6px 12px;
+		border: 1px solid #ccc;
+		border-top: none;
+	}
+
+	/* Style the active tab content */
+	.active-content {
+		display: block;
+		padding: 6px 12px;
+		border: 1px solid #ccc;
+		border-top: none;
 	}
 	</style>
 	</head>
 
 	<body>
 
-	<div class="tab">
-	<button class="tablinks" onclick="openCity(event, 'Background')">Background</button>
-	<button class="tablinks" onclick="openCity(event, 'Background RMS')">Background RMS</button>
-	<button class="tablinks" onclick="openCity(event, 'Background vs Model')">Background vs Model</button>
+	<div class="tabs">
+		<button class="tab active-tab" onclick="displayPlots('Background')">Background</button>
+		<button class="tab" onclick="displayPlots('BackgroundRMS')">Background RMS</button>
+		<button class="tab" onclick="displayPlots('BackgroundModel')">Background vs Model</button>
 	</div>
 
-	<div id="Background" class="tabcontent">
+	<div id="Background" class="tab-content active-content">
 		<div width=100% id="bkg">
 			{% for plot in bkg_plots %}
 				<img src={{ plot | safe }} width="100%">
@@ -72,7 +79,7 @@
 		</div>
 	</div>
 
-	<div id="Background RMS" class="tabcontent">
+	<div id="BackgroundRMS" class="tab-content">
 		<div width=100% id="bkg_rms">
 			{% for plot in bkg_rms_plots %}
 				<img src={{ plot | safe }} width="100%">
@@ -81,7 +88,7 @@
 		</div>
 	</div>
 
-	<div id="Background vs Model" class="tabcontent">
+	<div id="BackgroundModel" class="tab-content">
 		<div width=100% id="bkg">
 			{% for plot in bkg_model_plots %}
 				<img src={{ plot | safe }} width="100%">
@@ -91,23 +98,27 @@
 	</div>
 
 	<script>
-	function openCity(evt, cityName) {
-	var i, tabcontent, tablinks;
-	tabcontent = document.getElementsByClassName("tabcontent");
-	for (i = 0; i < tabcontent.length; i++) {
-		tabcontent[i].style.display = "none";
-	}
-	tablinks = document.getElementsByClassName("tablinks");
-	for (i = 0; i < tablinks.length; i++) {
-		tablinks[i].className = tablinks[i].className.replace(" active", "");
-	}
-	document.getElementById(cityName).style.display = "block";
-	evt.currentTarget.className += " active";
-	}
+		function displayPlots(tabId) {
+			// Hide all tab contents
+			var tabContents = document.getElementsByClassName('tab-content');
+			for (var i = 0; i < tabContents.length; i++) {
+				tabContents[i].style.display = 'none';
+			}
+	
+			// Remove 'active-tab' class from all tabs
+			var tabs = document.getElementsByClassName('tab');
+			for (var i = 0; i < tabs.length; i++) {
+				tabs[i].classList.remove('active-tab');
+			}
+	
+			// Show the selected tab content and mark the tab as active
+			document.getElementById(tabId).style.display = 'block';
+			document.querySelector('[onclick="displayPlots(\'' + tabId + '\')"]').classList.add('active-tab');
+		}
 	</script>
 
-	</main>
-	
 	</body>
+
+</main>
 
 {% endblock %}

--- a/jwql/website/apps/jwql/templates/background_monitor.html
+++ b/jwql/website/apps/jwql/templates/background_monitor.html
@@ -8,18 +8,106 @@
 
 {% block content %}
 
-    <main role="main" class="container">
+<main role="main" class="container">
 
-		<h1>{{ inst }} Background Monitor</h1>
-		<hr>
+	<h1>{{ inst }} Background Monitor</h1>
+	<hr>
 
-		<div width=100%>
-			{% for bkg_plot in bkg_plots %}
-				<img src={{ bkg_plot | safe }} width="100%">
+	<head>
+	<style>
+
+	/* Style the tab */
+	.tab {
+	overflow: hidden;
+	border: 1px solid #ccc;
+	background-color: #f1f1f1;
+	}
+
+	/* Style the buttons inside the tab */
+	.tab button {
+	background-color: inherit;
+	float: left;
+	border: none;
+	outline: none;
+	cursor: pointer;
+	padding: 14px 16px;
+	transition: 0.3s;
+	font-size: 17px;
+	}
+
+	/* Change background color of buttons on hover */
+	.tab button:hover {
+	background-color: #ddd;
+	}
+
+	/* Create an active/current tablink class */
+	.tab button.active {
+	background-color: #ccc;
+	}
+
+	/* Style the tab content */
+	.tabcontent {
+	display: none;
+	padding: 6px 12px;
+	border: 1px solid #ccc;
+	border-top: none;
+	}
+	</style>
+	</head>
+
+	<body>
+
+	<div class="tab">
+	<button class="tablinks" onclick="openCity(event, 'Background')">Background</button>
+	<button class="tablinks" onclick="openCity(event, 'Background RMS')">Background RMS</button>
+	<button class="tablinks" onclick="openCity(event, 'Background vs Model')">Background vs Model</button>
+	</div>
+
+	<div id="Background" class="tabcontent">
+		<div width=100% id="bkg">
+			{% for plot in bkg_plots %}
+				<img src={{ plot | safe }} width="100%">
 				<br><br><hr>
 			{% endfor %}
 		</div>
+	</div>
+
+	<div id="Background RMS" class="tabcontent">
+		<div width=100% id="bkg_rms">
+			{% for plot in bkg_rms_plots %}
+				<img src={{ plot | safe }} width="100%">
+				<br><br><hr>
+			{% endfor %}
+		</div>
+	</div>
+
+	<div id="Background vs Model" class="tabcontent">
+		<div width=100% id="bkg">
+			{% for plot in bkg_model_plots %}
+				<img src={{ plot | safe }} width="100%">
+				<br><br><hr>
+			{% endfor %}
+		</div>
+	</div>
+
+	<script>
+	function openCity(evt, cityName) {
+	var i, tabcontent, tablinks;
+	tabcontent = document.getElementsByClassName("tabcontent");
+	for (i = 0; i < tabcontent.length; i++) {
+		tabcontent[i].style.display = "none";
+	}
+	tablinks = document.getElementsByClassName("tablinks");
+	for (i = 0; i < tablinks.length; i++) {
+		tablinks[i].className = tablinks[i].className.replace(" active", "");
+	}
+	document.getElementById(cityName).style.display = "block";
+	evt.currentTarget.className += " active";
+	}
+	</script>
 
 	</main>
+	
+	</body>
 
 {% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ ipython==8.16.1
 jinja2==3.1.2
 jsonschema==4.19.1
 jwst==1.12.3
+jwst_backgrounds==1.2.0
 matplotlib==3.8.0
 nodejs==20.8.0
 numpy==1.25.2


### PR DESCRIPTION
This PR makes the following changes based on NIRCam team feedback:

- Incorporates the JWST background tool (JBT) predictions into the NIRCam Background Monitor (requires `pip install jwst_backgrounds` in jwql environment). This also requires two new columns in the NIRCamClawStats database (`doy` and `total_bkg`).
- Plots 3 types of trending plots on the Background Monitor page, that you can tab between (see screenshot below): background levels, background rms, and background/model.
- Expanded segmentation maps before calculating image statistics, mainly to allow for better rms calculations that aren't impacted by fainter source wings.

<img width="1017" alt="Screen Shot 2024-01-23 at 10 47 08 AM" src="https://github.com/spacetelescope/jwql/assets/16088329/fa20b958-8f2e-4027-83b7-4477edd39d95">
