### PR TITLE
bug fix for values_list

### DIFF
--- a/jwql/website/apps/jwql/data_containers.py
+++ b/jwql/website/apps/jwql/data_containers.py
@@ -1594,8 +1594,8 @@ def get_rootnames_from_query(parameters):
             current_ins_rootfileinfos = current_ins_rootfileinfos.order_by('-root_name')
 
         # Django is doing something wonky here.  I can't call values_list with a single parameter, even with 'flat=True' as per Django Docs.
-        #TODO: This is hacky and should be fixed.
-        filtered_list = list(current_ins_rootfileinfos.values_list('root_name','expstart'))
+        # TODO: This is hacky and should be fixed.
+        filtered_list = list(current_ins_rootfileinfos.values_list('root_name', 'expstart'))
         rootnames = [name[0] for name in filtered_list]
         filtered_rootnames.extend(rootnames)
 

--- a/jwql/website/apps/jwql/data_containers.py
+++ b/jwql/website/apps/jwql/data_containers.py
@@ -1593,7 +1593,10 @@ def get_rootnames_from_query(parameters):
         else:
             current_ins_rootfileinfos = current_ins_rootfileinfos.order_by('-root_name')
 
-        rootnames = [name[0] for name in current_ins_rootfileinfos.values_list('root_name')]
+        # Django is doing something wonky here.  I can't call values_list with a single parameter, even with 'flat=True' as per Django Docs.
+        #TODO: This is hacky and should be fixed.
+        filtered_list = list(current_ins_rootfileinfos.values_list('root_name','expstart'))
+        rootnames = [name[0] for name in filtered_list]
         filtered_rootnames.extend(rootnames)
 
     return filtered_rootnames


### PR DESCRIPTION
per django documentation,
values_list should be able to take a single column name ("root_name") with flat=True parameter.  This isn't taking in our current situation and is throwing an error sayin `'' is not an acceptable field`  Adding a bogus but existing second column of data resolves the issue.  Pushing forward to resolve the bug with this release but can re-evaluate issue with django if priorities permit.