### PR TITLE
Update Path For Claw and Background Monitor

### DIFF
--- a/jwql/website/apps/jwql/monitor_views.py
+++ b/jwql/website/apps/jwql/monitor_views.py
@@ -71,7 +71,7 @@ def background_monitor(request):
     template = "background_monitor.html"
 
     # Get the background trending filters to display
-    server_name = get_config()['outputs'].split("outputs/", 1)[1]
+    server_name = get_config()['outputs'].split("data/", 1)[1]
     output_dir_bkg = static(os.path.join("outputs", server_name, "claw_monitor", "backgrounds"))
     fltrs = ['F070W', 'F090W', 'F115W', 'F150W', 'F200W', 'F277W', 'F356W', 'F444W']
     bkg_plots = [os.path.join(output_dir_bkg, '{}_backgrounds.png'.format(fltr)) for fltr in fltrs]
@@ -159,7 +159,7 @@ def claw_monitor(request):
     df = pd.DataFrame(query, columns=['expstart_mjd', 'skyflat_filename'])
     recent_files = list(pd.unique(df['skyflat_filename'][df['expstart_mjd'] > Time.now().mjd - 10]))
     
-    server_name = get_config()['outputs'].split("outputs/", 1)[1]
+    server_name = get_config()['outputs'].split("data/", 1)[1]
     output_dir_claws = static(os.path.join("outputs", server_name, "claw_monitor", "claw_stacks"))
 
     claw_stacks = [os.path.join(output_dir_claws, filename) for filename in recent_files]


### PR DESCRIPTION
Claw and background monitor require path to point to static pngs. With changes merged in #1397 these paths need to be updated as well.