### PR TITLE
Add script to automatically delete old log files

### DIFF
--- a/jwql/website/apps/jwql/clean_old_log_files.py
+++ b/jwql/website/apps/jwql/clean_old_log_files.py
@@ -74,10 +74,8 @@ def run(time_limit=timedelta(days=14)):
                     last_modified_time = datetime.fromtimestamp(stat_result.st_mtime)
                     age = now - last_modified_time
                     if age > time_limit:
-                        #os.remove(item.name)
                         full_path = os.path.join(log_dir, logtype, item)
-                        print(f'DELETING {full_path}')
-    print('Once initial testing is complete, replace the print statement above with the os.remove line above it.')
+                        os.remove(full_path)
 
 
 if __name__ == '__main__':

--- a/jwql/website/apps/jwql/clean_old_log_files.py
+++ b/jwql/website/apps/jwql/clean_old_log_files.py
@@ -67,7 +67,8 @@ def run(time_limit=timedelta(days=14)):
         if logtype.is_dir():
             for item in os.scandir(logtype):
                 # We only try to delete log files produced by the machine on which
-                # this script is running. e.g.
+                # this script is running. e.g. log files produced by the test server
+                # can only be deleted by running this script on the test server.
                 if HOSTNAME in item.name and item.name[-4:] == '.log':
                     stat_result = item.stat()
                     last_modified_time = datetime.fromtimestamp(stat_result.st_mtime)

--- a/jwql/website/apps/jwql/clean_old_log_files.py
+++ b/jwql/website/apps/jwql/clean_old_log_files.py
@@ -42,6 +42,7 @@ def define_options():
                         help='Time limit in days. Log files older than this will be deleted.')
     return parser
 
+
 def run(time_limit=timedelta(days=14)):
     """Look through log directories and delete log files that are older than ``time_limit``.
     Have time_limit default to be 14 days.
@@ -65,7 +66,7 @@ def run(time_limit=timedelta(days=14)):
     for logtype in os.scandir(log_dir):
         if logtype.is_dir():
             for item in os.scandir(logtype):
-                # We only try to delete log files produced by the machine one which
+                # We only try to delete log files produced by the machine on which
                 # this script is running. e.g.
                 if HOSTNAME in item.name and item.name[-4:] == '.log':
                     stat_result = item.stat()
@@ -76,6 +77,7 @@ def run(time_limit=timedelta(days=14)):
                         full_path = os.path.join(log_dir, logtype, item)
                         print(f'DELETING {full_path}')
     print('Once initial testing is complete, replace the print statement above with the os.remove line above it.')
+
 
 if __name__ == '__main__':
     parser = define_options()

--- a/jwql/website/apps/jwql/clean_old_log_files.py
+++ b/jwql/website/apps/jwql/clean_old_log_files.py
@@ -1,0 +1,83 @@
+#! /usr/bin/env python
+
+"""Clean old log files from the collection of log files
+
+Authors
+-------
+
+    - Bryan Hilbert
+
+Use
+---
+
+    To delete log files that are older than some threshold age:
+    ::
+
+    > python clean_old_log_files.py --time_limit 7  # days
+
+"""
+import argparse
+from datetime import datetime, timedelta
+import os
+import socket
+
+from jwql.utils.utils import get_config
+
+HOSTNAME = socket.gethostname()
+configs = get_config()
+LOG_BASE_DIR = configs['log_dir']
+
+
+def define_options():
+    """Create parser to take the time limit.
+
+    Returns
+    -------
+    parser : argparse.ArgumentParser
+        Parser containing time limit
+    """
+    usage = 'clean_old_log_files.py -t 14'
+    parser = argparse.ArgumentParser(usage=usage)
+    parser.add_argument('-t', '--time_limit', type=int, default=14,
+                        help='Time limit in days. Log files older than this will be deleted.')
+    return parser
+
+def run(time_limit=timedelta(days=14)):
+    """Look through log directories and delete log files that are older than ``time_limit``.
+    Have time_limit default to be 14 days.
+
+    Inputs
+    ------
+    time_limit : datetime.timdelta
+        Files older than this time limit will be deleted
+    """
+    now = datetime.now()
+
+    if 'pljwql' in HOSTNAME:
+        subdir = 'ops'
+    elif 'tljwql' in HOSTNAME:
+        subdir = 'test'
+    else:
+        # This should cover the dev server as well as local machines
+        subdir = 'dev'
+
+    log_dir = os.path.join(LOG_BASE_DIR, subdir)
+    for logtype in os.scandir(log_dir):
+        if logtype.is_dir():
+            for item in os.scandir(logtype):
+                # We only try to delete log files produced by the machine one which
+                # this script is running. e.g.
+                if HOSTNAME in item.name and item.name[-4:] == '.log':
+                    stat_result = item.stat()
+                    last_modified_time = datetime.fromtimestamp(stat_result.st_mtime)
+                    age = now - last_modified_time
+                    if age > time_limit:
+                        #os.remove(item.name)
+                        full_path = os.path.join(log_dir, logtype, item)
+                        print(f'DELETING {full_path}')
+    print('Once initial testing is complete, replace the print statement above with the os.remove line above it.')
+
+if __name__ == '__main__':
+    parser = define_options()
+    args = parser.parse_args()
+    run(timedelta(days=args.time_limit))


### PR DESCRIPTION
Resolves #1434 

This PR introduces a script that will delete all log files older than a given threshold age. We can run this via cron job, which would then prevent the build-up of tons of log files, especially in the archive_database_update directory.

@mfixstsci @BradleySappington I think this is ready for review. (The line that does the actual deletion is commented out at the moment in favor of a print statement saying what it would delete.)

I tested on my local machine, and the log files it said it would delete were correct.
