### PR TITLE
Get subarray lists from datamodels schema

### DIFF
--- a/jwql/utils/constants.py
+++ b/jwql/utils/constants.py
@@ -921,7 +921,7 @@ SUBARRAYS_PER_INSTRUMENT = {
     "nirspec": ['FULL'] + sorted(schema["properties"]["meta"]["properties"]["subarray"]["properties"]["name"]["anyOf"][6]['enum']),
     "miri": ['FULL'] + sorted(schema["properties"]["meta"]["properties"]["subarray"]["properties"]["name"]["anyOf"][1]['enum']),
     "fgs": ['FULL'] + sorted(schema["properties"]["meta"]["properties"]["subarray"]["properties"]["name"]["anyOf"][0]['enum'])
-                           }
+    }
 
 # Filename suffixes that need to include the association value in the suffix in
 # order to identify the preview image file. This should only be crf and crfints,

--- a/jwql/utils/constants.py
+++ b/jwql/utils/constants.py
@@ -28,6 +28,7 @@ References
     ``utils.py``
 """
 
+import asdf
 import inflection
 
 # Each amplifier is represented by 2 tuples, the first for x coordinates
@@ -913,58 +914,14 @@ SUBARRAYS_ONE_OR_FOUR_AMPS = [
     "SUBGRISMSTRIPE256",
 ]
 
+schema = asdf.schema.load_schema("http://stsci.edu/schemas/jwst_datamodel/subarray.schema")
 SUBARRAYS_PER_INSTRUMENT = {
-    "nircam": [
-        "FULL",
-        "FULLP",
-        "SUB640",
-        "SUB320",
-        "SUB160",
-        "SUB400P",
-        "SUB160P",
-        "SUB64P",
-        "SUB32TATS",
-        "SUB640A210R",
-        "SUB640ASWB",
-        "SUB320A335R",
-        "SUB320A430R",
-        "SUB320ALWB",
-        "SUBGRISM256",
-        "SUBGRISM128",
-        "SUBGRISM64",
-        "SUB32TATSGRISM",
-    ],
-    "niriss": [
-        "FULL",
-        "SUBSTRIP96",
-        "SUBSTRIP256",
-        "SUB80",
-        "SUB64",
-        "SUB128",
-        "SUB256",
-        "WFSS64R",
-        "WFSS128R",
-        "WFSS64C",
-        "WFSS128C",
-        "SUBAMPCAL",
-        "SUBTAAMI",
-        "SUBTASOSS",
-    ],
-    "nirspec": [],
-    "miri": [
-        "BRIGHTSKY",
-        "FULL",
-        "MASK1065",
-        "MASK1140",
-        "MASK1550",
-        "MASKLYOT",
-        "SLITLESSPRISM",
-        "SUB64",
-        "SUB128",
-        "SUB256",
-    ],
-    "fgs": [],
-}
+    "nircam": ['FULL'] + sorted(schema["properties"]["meta"]["properties"]["subarray"]["properties"]["name"]["anyOf"][2]['enum']),
+    "niriss": ['FULL'] + sorted(schema["properties"]["meta"]["properties"]["subarray"]["properties"]["name"]["anyOf"][4]['enum']),
+    "nirspec": ['FULL'] + sorted(schema["properties"]["meta"]["properties"]["subarray"]["properties"]["name"]["anyOf"][6]['enum']),
+    "miri": ['FULL'] + sorted(schema["properties"]["meta"]["properties"]["subarray"]["properties"]["name"]["anyOf"][1]['enum']),
+    "fgs": ['FULL'] + sorted(schema["properties"]["meta"]["properties"]["subarray"]["properties"]["name"]["anyOf"][0]['enum'])
+    }
 
 # Filename suffixes that need to include the association value in the suffix in
 # order to identify the preview image file. This should only be crf and crfints,

--- a/jwql/utils/constants.py
+++ b/jwql/utils/constants.py
@@ -921,7 +921,7 @@ SUBARRAYS_PER_INSTRUMENT = {
     "nirspec": ['FULL'] + sorted(schema["properties"]["meta"]["properties"]["subarray"]["properties"]["name"]["anyOf"][6]['enum']),
     "miri": ['FULL'] + sorted(schema["properties"]["meta"]["properties"]["subarray"]["properties"]["name"]["anyOf"][1]['enum']),
     "fgs": ['FULL'] + sorted(schema["properties"]["meta"]["properties"]["subarray"]["properties"]["name"]["anyOf"][0]['enum'])
-    }
+                            }
 
 # Filename suffixes that need to include the association value in the suffix in
 # order to identify the preview image file. This should only be crf and crfints,

--- a/jwql/utils/constants.py
+++ b/jwql/utils/constants.py
@@ -921,7 +921,7 @@ SUBARRAYS_PER_INSTRUMENT = {
     "nirspec": ['FULL'] + sorted(schema["properties"]["meta"]["properties"]["subarray"]["properties"]["name"]["anyOf"][6]['enum']),
     "miri": ['FULL'] + sorted(schema["properties"]["meta"]["properties"]["subarray"]["properties"]["name"]["anyOf"][1]['enum']),
     "fgs": ['FULL'] + sorted(schema["properties"]["meta"]["properties"]["subarray"]["properties"]["name"]["anyOf"][0]['enum'])
-                            }
+                           }
 
 # Filename suffixes that need to include the association value in the suffix in
 # order to identify the preview image file. This should only be crf and crfints,

--- a/jwql/website/apps/jwql/templates/jwql_query.html
+++ b/jwql/website/apps/jwql/templates/jwql_query.html
@@ -211,6 +211,18 @@
                                 <div class="input-group-addon" style='width:60px'></div>
                             </div>
                         </section>
+
+                        <section class="col-md">
+                            <span class="help-block">FGS Subarrays</span>
+                            <div class="form-control" id='fgs_subarray'>
+                                {% for field in form.fgs_subarray %}
+                                <div class="row-2">
+                                    {{ field }}
+                                </div>
+                                {% endfor %}
+                            </div>
+                        </section>
+
                     </div>
 
                     <!-- MIRI Fields -->
@@ -546,6 +558,18 @@
                                 <div class="input-group-addon" style='width:60px'></div>
                             </div>
                         </section>
+
+                        <section class="col-md">
+                            <span class="help-block">NIRSpec Subarrays</span>
+                            <div class="form-control" id='nirspec_subarray'>
+                                {% for field in form.nirspec_subarray %}
+                                <div class="row-2">
+                                    {{ field }}
+                                </div>
+                                {% endfor %}
+                            </div>
+                        </section>
+
                     </div>
                     <hr class="col-md-12">
                     <div class='form-group'>


### PR DESCRIPTION
Resolves #1389 

Rather than relying on manually provided subarray lists (which had been missing some entries), get subarray lists from the subarray schema file in the stdatamodels package. This ensures that all available subarrays will be present on the JWQL query page.

One downside to this is the way the schema file is read in. Since the instrument names are in commented lines in the schema file, the subarray lists are accessed through hard-coded indexing. If the order of the instruments' lists ever change in the schema file, we would need to update this code. That seems pretty unlikely though.

Local testing looks good.