### PR TITLE
Claw monitor migrate

### DIFF
--- a/jwql/instrument_monitors/nircam_monitors/claw_monitor.py
+++ b/jwql/instrument_monitors/nircam_monitors/claw_monitor.py
@@ -137,7 +137,7 @@ class ClawMonitor():
             measured vs model trending.
         """
 
-        columns = ['filename', 'filter', 'pupil', 'detector', 'effexptm', 'expstart_mjd', 'entry_date', 'mean', 'median', 
+        columns = ['filename', 'filter', 'pupil', 'detector', 'effexptm', 'expstart_mjd', 'entry_date', 'mean', 'median',
                    'stddev', 'frac_masked']  # , 'total_bkg']
 
         # Get all of the background data.
@@ -145,13 +145,6 @@ class ClawMonitor():
         df_orig = pd.DataFrame.from_records(background_data)
         # remove any duplicate filename entries, keep the most recent
         df_orig = df_orig.drop_duplicates(subset='filename', keep="last")
-
-        try:
-            jbt.get_background(ra, dec, wv, thisday=doy, plot_background=False, plot_bathtub=False,
-                               write_bathtub=True, bathtub_file='background_versus_day.txt')
-            bkg_table = Table.read('background_versus_day.txt', names=('day', 'total_bkg'), format='ascii')
-        except:
-            bkg_table = None
 
         # Get label info based on plot type
         if plot_type == 'bkg':
@@ -186,9 +179,9 @@ class ClawMonitor():
 
                 # Get relevant data for this filter/detector and remove bad datasets, e.g. crowded fields,
                 # extended objects, nebulas, short exposures.
-                df = df_orig[(df_orig['filter'] == fltr) & (df_orig['pupil'] == 'CLEAR') & (df_orig['detector'] == det) &
-                             (df_orig['effexptm'] > 300) & (df_orig['frac_masked'] < frack_masked_thresh) &
-                             (abs(1 - (df_orig['mean'] / df_orig['median'])) < 0.05)]
+                df = df_orig[(df_orig['filter'] == fltr) & (df_orig['pupil'] == 'CLEAR') & (df_orig['detector'] == det)
+                             & (df_orig['effexptm'] > 300) & (df_orig['frac_masked'] < frack_masked_thresh)
+                             & (abs(1 - (df_orig['mean'] / df_orig['median'])) < 0.05)]
                 if len(df) > 0:
                     df = df.sort_values(by=['expstart_mjd'])
 
@@ -316,7 +309,7 @@ class ClawMonitor():
                                        write_bathtub=True, bathtub_file='background_versus_day.txt')
                     bkg_table = Table.read('background_versus_day.txt', names=('day', 'total_bkg'), format='ascii')
                     total_bkg = bkg_table['total_bkg'][bkg_table['day'] == doy][0]
-                except:
+                except Exception as e:
                     total_bkg = np.nan
 
                 # Add this file's stats to the claw database table. Can't insert values with numpy.float32
@@ -338,8 +331,8 @@ class ClawMonitor():
                                  'stddev': float(stddev),
                                  'frac_masked': len(segmap_orig[(segmap_orig != 0) | (dq & 1 != 0)]) / (segmap_orig.shape[0] * segmap_orig.shape[1]),
                                  'skyflat_filename': os.path.basename(self.outfile),
-#                                  'doy': float(doy),
-#                                  'total_bkg': float(total_bkg),
+                                 # 'doy': float(doy),
+                                 # 'total_bkg': float(total_bkg),
                                  'entry_date': datetime.datetime.now()
                                  }
                 entry = self.stats_table(**claw_db_entry)
@@ -454,7 +447,7 @@ class ClawMonitor():
             for row in mast_table_combo:
                 try:
                     existing_files.append(filesystem_path(row['filename']))
-                except:
+                except Exception as e:
                     pass
             self.files = np.array(existing_files)
             self.detectors = np.array(mast_table_combo['detector'])

--- a/jwql/instrument_monitors/nircam_monitors/claw_monitor.py
+++ b/jwql/instrument_monitors/nircam_monitors/claw_monitor.py
@@ -138,13 +138,20 @@ class ClawMonitor():
         """
 
         columns = ['filename', 'filter', 'pupil', 'detector', 'effexptm', 'expstart_mjd', 'entry_date', 'mean', 'median', 
-                   'stddev', 'frac_masked', 'total_bkg']
+                   'stddev', 'frac_masked']  # , 'total_bkg']
 
         # Get all of the background data.
-        background_data = NIRCamClawStats.objects.only(*columns)
-        df_orig = pd.DataFrame(background_data, columns=columns)
+        background_data = NIRCamClawStats.objects.all().values(*columns)
+        df_orig = pd.DataFrame.from_records(background_data)
         # remove any duplicate filename entries, keep the most recent
         df_orig = df_orig.drop_duplicates(subset='filename', keep="last")
+
+        try:
+            jbt.get_background(ra, dec, wv, thisday=doy, plot_background=False, plot_bathtub=False,
+                               write_bathtub=True, bathtub_file='background_versus_day.txt')
+            bkg_table = Table.read('background_versus_day.txt', names=('day', 'total_bkg'), format='ascii')
+        except:
+            bkg_table = None
 
         # Get label info based on plot type
         if plot_type == 'bkg':
@@ -192,7 +199,8 @@ class ClawMonitor():
                     df = df[df['stddev'] != 0]  # older data has no accurate stddev measures
                     plot_data = df['stddev'].values
                 if plot_type == 'model':
-                    plot_data = df['median'].values / df['total_bkg'].values
+                    total_bkg = [1. for x in df['median'].values]
+                    plot_data = df['median'].values  # / df['total_bkg'].values
                 plot_expstarts = df['expstart_mjd'].values
 
                 # Plot the background data over time
@@ -330,8 +338,8 @@ class ClawMonitor():
                                  'stddev': float(stddev),
                                  'frac_masked': len(segmap_orig[(segmap_orig != 0) | (dq & 1 != 0)]) / (segmap_orig.shape[0] * segmap_orig.shape[1]),
                                  'skyflat_filename': os.path.basename(self.outfile),
-                                 'doy': float(doy),
-                                 'total_bkg': float(total_bkg),
+#                                  'doy': float(doy),
+#                                  'total_bkg': float(total_bkg),
                                  'entry_date': datetime.datetime.now()
                                  }
                 entry = self.stats_table(**claw_db_entry)

--- a/jwql/instrument_monitors/nircam_monitors/claw_monitor.py
+++ b/jwql/instrument_monitors/nircam_monitors/claw_monitor.py
@@ -40,14 +40,11 @@ import pandas as pd
 from photutils.segmentation import detect_sources, detect_threshold
 from scipy.ndimage import binary_dilation
 
-# astroquery.mast import that depends on value of auth_mast
-# this import has to be made before any other import of astroquery.mast
-ON_GITHUB_ACTIONS = '/home/runner' in os.path.expanduser('~') or '/Users/runner' in os.path.expanduser('~')
-
-# Determine if the code is being run as part of a Readthedocs build
-ON_READTHEDOCS = False
-if 'READTHEDOCS' in os.environ:  # pragma: no cover
-    ON_READTHEDOCS = os.environ['READTHEDOCS']
+from jwql.utils import monitor_utils
+from jwql.utils.constants import ON_GITHUB_ACTIONS, ON_READTHEDOCS
+from jwql.utils.logging_functions import log_info, log_fail
+from jwql.utils.utils import ensure_dir_exists, filesystem_path, get_config
+from jwst_backgrounds import jbt
 
 if not ON_GITHUB_ACTIONS and not ON_READTHEDOCS:
     # Need to set up django apps before we can access the models
@@ -58,11 +55,6 @@ if not ON_GITHUB_ACTIONS and not ON_READTHEDOCS:
     # Import * is okay here because this module specifically only contains database models
     # for this monitor
     from jwql.website.apps.jwql.monitor_models.claw import *  # noqa: E402 (module level import not at top of file)
-
-from jwql.utils import monitor_utils
-from jwql.utils.logging_functions import log_info, log_fail
-from jwql.utils.utils import ensure_dir_exists, filesystem_path, get_config
-from jwst_backgrounds import jbt
 
 matplotlib.use('Agg')
 warnings.filterwarnings('ignore', message="nan_treatment='interpolate', however, NaN values detected post convolution*")

--- a/jwql/website/apps/jwql/monitor_models/claw.py
+++ b/jwql/website/apps/jwql/monitor_models/claw.py
@@ -27,7 +27,6 @@ References
 # This is an auto-generated Django model module.
 # Feel free to rename the models, but don't rename db_table values or field names.
 from django.db import models
-from django.contrib.postgres.fields import ArrayField
 
 
 class NIRCamClawQueryHistory(models.Model):

--- a/jwql/website/apps/jwql/monitor_models/common.py
+++ b/jwql/website/apps/jwql/monitor_models/common.py
@@ -83,6 +83,20 @@ run the query. Instead, it will be run when you operate on it, such as
 * Printing out any of the results
 * Asking for the value of one of the fields (e.g. `records[3].aperture`)
 
+Retrieving Specific Columns
+===========================
+
+Django offers two ways of doing this. The first one is to use the `only()` function, which
+immediately loads only the relevant columns. For example,
+
+.. code-block:: python
+
+    records = MIRIMyMonitorStats.objects.only("aperture", "mjd_start", "relevant_item")
+
+will immediately load only the three columns selected (although the rest will be retrieved
+from the database, and can still be accessed, for no immediately understandable reason).
+The other method is the `defer()` method, which loads every column *except* the ones listed.
+
 Q Objects
 =========
 

--- a/jwql/website/apps/jwql/monitor_views.py
+++ b/jwql/website/apps/jwql/monitor_views.py
@@ -39,9 +39,8 @@ import json
 import pandas as pd
 
 from . import bokeh_containers
-from jwql.database.database_interface import session
-from jwql.database.database_interface import NIRCamClawStats
 from jwql.website.apps.jwql import bokeh_containers
+from jwql.website.apps.jwql.monitor_models.claw import NIRCamClawStats
 from jwql.website.apps.jwql.monitor_pages.monitor_readnoise_bokeh import ReadNoiseFigure
 from jwql.utils.constants import JWST_INSTRUMENT_NAMES_MIXEDCASE
 from jwql.utils.utils import get_config, get_base_url
@@ -158,9 +157,9 @@ def claw_monitor(request):
     template = "claw_monitor.html"
 
     # Get all recent claw stack images from the last 10 days
-    query = session.query(NIRCamClawStats.expstart_mjd, NIRCamClawStats.skyflat_filename).order_by(NIRCamClawStats.expstart_mjd.desc()).all()
+    mjd = Time.now().mjd - 10
+    query = NIRCamClawStats.filter(expstart_mjd__gte=mjd).order_by('-expstart_mjd').only('expstart_mjd', 'skyflat_filename')
     df = pd.DataFrame(query, columns=['expstart_mjd', 'skyflat_filename'])
-    recent_files = list(pd.unique(df['skyflat_filename'][df['expstart_mjd'] > Time.now().mjd - 10]))
     output_dir_claws = static(os.path.join("outputs", "claw_monitor", "claw_stacks"))
     claw_stacks = [os.path.join(output_dir_claws, filename) for filename in recent_files]
 

--- a/jwql/website/apps/jwql/monitor_views.py
+++ b/jwql/website/apps/jwql/monitor_views.py
@@ -157,12 +157,10 @@ def claw_monitor(request):
     template = "claw_monitor.html"
 
     # Get all recent claw stack images from the last 10 days
-    query = NIRCamClawStats.objects  #.filter(expstart_mjd__gte=mjd)
+    query = NIRCamClawStats.objects  # .filter(expstart_mjd__gte=(Time.now().mjd - 10))
     query = query.order_by('-expstart_mjd').all().values('expstart_mjd', 'skyflat_filename')
     df = pd.DataFrame.from_records(query)
-    print(df)
     recent_files = list(pd.unique(df['skyflat_filename'][df['expstart_mjd'] > Time.now().mjd - 10]))
-    print(recent_files)
     output_dir_claws = static(os.path.join("outputs", "claw_monitor", "claw_stacks"))
     claw_stacks = [os.path.join(output_dir_claws, filename) for filename in recent_files]
 

--- a/jwql/website/apps/jwql/monitor_views.py
+++ b/jwql/website/apps/jwql/monitor_views.py
@@ -157,9 +157,12 @@ def claw_monitor(request):
     template = "claw_monitor.html"
 
     # Get all recent claw stack images from the last 10 days
-    mjd = Time.now().mjd - 10
-    query = NIRCamClawStats.filter(expstart_mjd__gte=mjd).order_by('-expstart_mjd').only('expstart_mjd', 'skyflat_filename')
-    df = pd.DataFrame(query, columns=['expstart_mjd', 'skyflat_filename'])
+    query = NIRCamClawStats.objects  #.filter(expstart_mjd__gte=mjd)
+    query = query.order_by('-expstart_mjd').all().values('expstart_mjd', 'skyflat_filename')
+    df = pd.DataFrame.from_records(query)
+    print(df)
+    recent_files = list(pd.unique(df['skyflat_filename'][df['expstart_mjd'] > Time.now().mjd - 10]))
+    print(recent_files)
     output_dir_claws = static(os.path.join("outputs", "claw_monitor", "claw_stacks"))
     claw_stacks = [os.path.join(output_dir_claws, filename) for filename in recent_files]
 


### PR DESCRIPTION
Migrates the claw monitor to using the django models. This is an initial PR, with a second to follow which will add the new columns to the claw monitor.