### PR TITLE
Fix Bokeh `file_html` Call

### DIFF
--- a/jwql/website/apps/jwql/monitor_pages/monitor_bad_pixel_bokeh.py
+++ b/jwql/website/apps/jwql/monitor_pages/monitor_bad_pixel_bokeh.py
@@ -162,7 +162,8 @@ class BadPixelPlots():
         template_dir = os.path.join(os.path.dirname(__file__), '../templates')
         template_file = os.path.join(template_dir, 'bad_pixel_monitor_savefile_basic.html')
         temp_vars = {'inst': self.instrument, 'plot_script': script, 'plot_div': div}
-        self._html = file_html(tabs, CDN, f'{self.instrument} bad pix monitor', template_file, temp_vars)
+        self._html = file_html(tabs, CDN, title=f'{self.instrument} bad pix monitor', 
+                               template=template_file, template_variables=temp_vars)
 
         # Modify the html such that our Django-related lines are kept in place,
         # which will allow the page to keep the same formatting and styling as

--- a/jwql/website/apps/jwql/monitor_pages/monitor_bad_pixel_bokeh.py
+++ b/jwql/website/apps/jwql/monitor_pages/monitor_bad_pixel_bokeh.py
@@ -162,7 +162,7 @@ class BadPixelPlots():
         template_dir = os.path.join(os.path.dirname(__file__), '../templates')
         template_file = os.path.join(template_dir, 'bad_pixel_monitor_savefile_basic.html')
         temp_vars = {'inst': self.instrument, 'plot_script': script, 'plot_div': div}
-        self._html = file_html(tabs, CDN, title=f'{self.instrument} bad pix monitor', 
+        self._html = file_html(tabs, CDN, title=f'{self.instrument} bad pix monitor',
                                template=template_file, template_variables=temp_vars)
 
         # Modify the html such that our Django-related lines are kept in place,

--- a/jwql/website/apps/jwql/monitor_pages/monitor_bias_bokeh.py
+++ b/jwql/website/apps/jwql/monitor_pages/monitor_bias_bokeh.py
@@ -303,7 +303,8 @@ class BiasMonitorPlots():
         """
         # Insert into our html template and save
         temp_vars = {'inst': self.instrument, 'plot_script': self.script, 'plot_div': self.div}
-        html_lines = file_html(self.tabs, CDN, f'{self.instrument} bias monitor', self.html_file, temp_vars)
+        html_lines = file_html(self.tabs, CDN, title=f'{self.instrument} bias monitor', 
+                               template=self.html_file, template_variables=temp_vars)
 
         lines = html_lines.split('\n')
 


### PR DESCRIPTION
Bokeh's `file_html` method takes multiple optional parameters. Without specifying the parameter names, the method gets confused by the positions of the parameters passed in the method call.