### PR TITLE
fix release upload step condition to match workflow trigger

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           name: ${{ steps.filename.outputs.filename }}
           path: ${{ steps.filename.outputs.filename }}
-      - if: (github.event_name == 'release' && github.event.action == 'published')
+      - if: (github.event_name == 'release' && github.event.action == 'released')
         uses: svenstaro/upload-release-action@v2
         with:
           file: ${{ steps.filename.outputs.filename }}


### PR DESCRIPTION
the event type in the `if:` condition (`published`) was not the same as the event type in the trigger (`released`). Thus, the workflow would never satisfy the condition 😅