### PR TITLE
Remove P750L from list of NIRSpec filters

### DIFF
--- a/jwql/utils/constants.py
+++ b/jwql/utils/constants.py
@@ -470,7 +470,6 @@ FILTERS_PER_INSTRUMENT = {
         "F170LP",
         "F290LP",
         "OPAQUE",
-        "P750L",
     ],
 }
 


### PR DESCRIPTION
Resolves #1597 

Remove P750L from the list of NIRSpec filters, since it is a MIRI filter.