### PR TITLE
[build] fix `runs-on:` and update build filename for easier parsing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     with:
       upload_to_pypi: false
   freeze:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           args: --strict --pattern "default-unprefixed" --style semver
       - id: filename
-        run: echo "filename=jwql_conda_py${{ matrix.python-version }}_${{ steps.version.outputs.version }}_${{ matrix.os }}.yml" >> $GITHUB_OUTPUT
+        run: echo "filename=jwql_${{ steps.version.outputs.version }}_conda_${{ runner.os }}_${{ runner.arch }}_py${{ matrix.python-version }}.yml" >> $GITHUB_OUTPUT
       - run: conda env export --no-build | grep -v "name:" | grep -v "prefix:" > ${{ steps.filename.outputs.filename }}
       - run: cat ${{ steps.filename.outputs.filename }}
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
- reordered filename to have the JWQL version at the beginning and the OS and Python version at the end
- added architecture to the OS part
- fix `runs-on:` value (wasn't set to `matrix: os:`)
```diff
- jwql_conda_py3.11_1.2.9-b_macos-latest.yml
+ jwql_1.2.9-b_conda_macOS_ARM64_py3.11.yml 
```