### PR TITLE
Added logging configuration to config file, and use it when opening logging

### DIFF
--- a/jwql/example_config.json
+++ b/jwql/example_config.json
@@ -47,5 +47,50 @@
     "cores" : "",
     "redis_host": "",
     "redis_port": "",
-    "transfer_dir": ""
+    "transfer_dir": "",
+    "logging": {
+        "version": 1,
+        "disable_existing_loggers": true,
+        "formatters": {
+            "simple": {
+                "format": "%(asctime)s %(levelname)s: %(message)s",
+                "datefmt": "%m/%d/%Y %H:%M:%S %p"
+            }
+        },
+        "filters": {
+            "warnings_and_below": {
+                "()" : "jwql.utils.logging_functions.filter_maker",
+                "level": "WARNING"
+            }
+        },
+        "handlers": {
+            "stdout": {
+                "class": "logging.StreamHandler",
+                "level": "INFO",
+                "formatter": "simple",
+                "stream": "ext://sys.stdout",
+                "filters": ["warnings_and_below"]
+            },
+            "stderr": {
+                "class": "logging.StreamHandler",
+                "level": "ERROR",
+                "formatter": "simple",
+                "stream": "ext://sys.stderr"
+            },
+            "file": {
+                "class": "logging.FileHandler",
+                "formatter": "simple",
+                "filename": "app.log",
+                "mode": "a"
+            }
+        },
+        "root": {
+            "level": "DEBUG",
+            "handlers": [
+                "stderr",
+                "stdout",
+                "file"
+            ]
+        }
+    }
 }

--- a/jwql/utils/logging_functions.py
+++ b/jwql/utils/logging_functions.py
@@ -106,7 +106,7 @@ def configure_logging(module):
     """
     Configure the log file with a standard logging format. The format in question is
     set up as follows:
-    
+
     - DEBUG messages are ignored
     - INFO and WARNING messages go to both the log file and sys.stdout
     - ERROR and CRITICAL messages go to both the log file and sys.stderr
@@ -275,7 +275,7 @@ def log_info(func):
 
         # nosec comment added to ignore bandit security check
         try:
-            environment = subprocess.check_output('conda env export', universal_newlines=True, shell=True) # nosec
+            environment = subprocess.check_output('conda env export', universal_newlines=True, shell=True)  # nosec
             logging.info('Environment:')
             for line in environment.split('\n'):
                 logging.info(line)


### PR DESCRIPTION
Note that the config.json files on dev/test/ops have already been updated, since adding the logging configuration to those files shouldn't be an issue because it won't affect anything until it's called.