### PR TITLE
Exclude source-specific WFSS files from observation page

### DIFF
--- a/jwql/website/apps/jwql/data_containers.py
+++ b/jwql/website/apps/jwql/data_containers.py
@@ -2144,7 +2144,7 @@ def thumbnails_ajax(inst, proposal, obs_num=None):
     ----------
     inst : str
         Name of JWST instrument
-    proposal : str (optional)
+    proposal : str
         Number of APT proposal to filter
     obs_num : str (optional)
         Observation number
@@ -2193,6 +2193,12 @@ def thumbnails_ajax(inst, proposal, obs_num=None):
     # Gather data for each rootname, and construct a list of all observations
     # in the proposal
     for rootname in rootnames:
+        # Skip over unsupported filenames
+        # e.g. jw02279-o001_s000... are spec2 products for WFSS with one file per source
+        # Any filename with a dash after the proposal number is either this spec2 product
+        # or a level 3 product
+        if f'jw{proposal}-' in rootname:
+            continue
 
         # Parse filename
         filename_dict = filename_parser(rootname)
@@ -2202,6 +2208,9 @@ def thumbnails_ajax(inst, proposal, obs_num=None):
                 continue
 
         else:
+            # Skip over files not recognized by the filename_parser
+            continue
+            '''
             # Temporary workaround for noncompliant files in filesystem
             filename_dict = {'activity': rootname[17:19],
                              'detector': rootname[26:],
@@ -2214,6 +2223,7 @@ def thumbnails_ajax(inst, proposal, obs_num=None):
                              'group_root': rootname[:26]}
             logging.warning((f'While running thumbnails_ajax() on rootname {rootname}, '
                              'filename_parser() failed to recognize the file pattern.'))
+            '''
 
         # Get list of available filenames and exposure start times. All files with a given
         # rootname will have the same exposure start time, so just keep the first.

--- a/jwql/website/apps/jwql/data_containers.py
+++ b/jwql/website/apps/jwql/data_containers.py
@@ -2206,24 +2206,9 @@ def thumbnails_ajax(inst, proposal, obs_num=None):
             # Weed out file types that are not supported by generate_preview_images
             if 'stage_3' in filename_dict['filename_type']:
                 continue
-
         else:
             # Skip over files not recognized by the filename_parser
             continue
-            '''
-            # Temporary workaround for noncompliant files in filesystem
-            filename_dict = {'activity': rootname[17:19],
-                             'detector': rootname[26:],
-                             'exposure_id': rootname[20:25],
-                             'observation': rootname[7:10],
-                             'parallel_seq_id': rootname[16],
-                             'program_id': rootname[2:7],
-                             'visit': rootname[10:13],
-                             'visit_group': rootname[14:16],
-                             'group_root': rootname[:26]}
-            logging.warning((f'While running thumbnails_ajax() on rootname {rootname}, '
-                             'filename_parser() failed to recognize the file pattern.'))
-            '''
 
         # Get list of available filenames and exposure start times. All files with a given
         # rootname will have the same exposure start time, so just keep the first.


### PR DESCRIPTION
WFSS source specific files have started showing up on JWQL's observation level pages. I'm not sure how this happened. The filenames come in from the MAST query. Maybe the metadata examined by MAST has changed?  This was leading to a lot of extra thumbnail placeholders being added to WFSS programs on the observation level pages. I don't think we want to keep track of these files, even though they are an output of the spec2 pipeline, and JWQL generally supports stage 2 outputs. In WFSS there is one file for each extracted source. By default the pipeline now keeps only the top 100 brightest sources per exposure. I think adding 100*n_exposures files to the page could quickly become overwhelming. Maybe if we come up with a better way to organize these, we can add them back in. They are 2D images of extracted spectra.

This is not tested yet. 