### PR TITLE
Switch URL for prog info scraping to use the OPO site

### DIFF
--- a/jwql/website/apps/jwql/data_containers.py
+++ b/jwql/website/apps/jwql/data_containers.py
@@ -2057,12 +2057,15 @@ def text_scrape(prop_id):
     program_meta : dict
         Dictionary containing information about program
     """
+    # Ensure prop_id is a 5-digit string
+    prop_id = str(prop_id).zfill(5)
 
     # Generate url
-    url = 'http://www.stsci.edu/cgi-bin/get-proposal-info?id=' + str(prop_id) + '&submit=Go&observatory=JWST'
+    url = f'https://www.stsci.edu/jwst-program-info/program/?program={prop_id}'
     html = BeautifulSoup(requests.get(url).text, 'lxml')
     not_available = "not available via this interface" in html.text
     not_available |= "temporarily unable" in html.text
+    not_available |= "internal error" in html.text
 
     program_meta = {}
     program_meta['prop_id'] = prop_id


### PR DESCRIPTION
The site that JWQL had been using to scrape for proposal information went down last week, and is not yet back up. JWQL did not check for the internal server error returned for those pages, which was causing JWQL to crash when trying to load any observation-level page. 

This PR switches over to use the OPO version of the proposal information pages. It also adds a check for an internal server error when scraping the page.

Resolves #1660 