### PR TITLE
Fix program type info from new link

### DIFF
--- a/jwql/website/apps/jwql/data_containers.py
+++ b/jwql/website/apps/jwql/data_containers.py
@@ -2084,7 +2084,7 @@ def text_scrape(prop_id):
 
         links = html.findAll('a')
 
-        proposal_type = links[0].contents[0]
+        proposal_type = links[3].contents[0]
 
         program_meta['prop_type'] = proposal_type
 


### PR DESCRIPTION
Quick fix to correctly display the proposal type when using the new URL from #1660 