### PR TITLE
Update jwqldb page with django model names

### DIFF
--- a/jwql/utils/constants.py
+++ b/jwql/utils/constants.py
@@ -581,6 +581,9 @@ INSTRUMENT_SERVICE_MATCH = {
     "NIRSpec": "Mast.Jwst.Filtered.Nirspec",
 }
 
+# Database tables to exclude from the JWQLDB page
+JWQLDB_EXCLUDED = ['RootFileInfo', 'Archive', 'Observation']
+
 # JWST data products
 JWST_DATAPRODUCTS = [
     "IMAGE",

--- a/jwql/website/apps/jwql/templates/jwqldb_table_viewer.html
+++ b/jwql/website/apps/jwql/templates/jwqldb_table_viewer.html
@@ -13,18 +13,18 @@
 
         <p align="justify">
             This page allows users to interactively explore the JWQL database tables. The main function of this tool is to
-            visually inspect data through the JWQL Web Application. Simply select a table from the dropdown menu to begin,
-            if further investigation of the table is needed, you can click the "Download Data" button to obtain the displayed
-            table as a CSV file.
+            visually inspect data through the JWQL Web Application. Simply select a table from the dropdown menu to display
+            the contents below. If further investigation of the table is needed, you can click the "Download Data" button to
+            obtain the displayed table as a CSV file.
 
             <br><br>
             The database table naming convention follows:
 
-            <xmp><instrument>_<monitor>_<stat_type></stat_type></xmp>
+            <xmp><Instrument><Monitor><Stat_type></xmp>
 
             For example, if a user is interested in the statistics from the NIRCAM Bias Monitor, the table to investigate would be
 
-            <xmp>nircam_bias_stats</xmp>
+            <xmp>NircamBiasStats</xmp>
         </p>
 
         <hr>
@@ -34,14 +34,15 @@
             <h4>Select JWQL Database Table</h4>
             <div class="db_table_select">
                 <select name="db_table_select" id="db_table_select" onchange="this.form.submit()">
+
+                    {% if table_name %}
+                        <option value="{{ table_name }}" selected>{{ table_name }}</option>
+                    {% endif %}
                     {% for instrument in all_jwql_tables %}
                     <optgroup label="{{ instrument }}">
                         {% for table in all_jwql_tables[instrument] %}
                             <option value="{{ table }}">{{ table }}</option>
                         {% endfor %}
-                    {% if tablename %}
-                        <option value="{{ tablename }}" selected>{{ tablename }}</option>
-                    {% endif %}
                     </optgroup>
                     {% endfor %}
                 </select>
@@ -51,7 +52,7 @@
             <!-- If tablename is passed, render table. -->
             <!-- Table is not rendered when coming from home/monitor views -->
             {% if table_name %}
-                <h4> {{ table_name|safe }} </h4><hr>
+                <h5> {{ table_name|safe }} </h5><hr>
                 <a href="{{ '/download_table/%s'%table_name }}" name=download_data class="btn btn-primary my-2" type="submit" value="{{ tablename }}">Download Data</a>
                 <table id="jwqltable" class="display" style="width:100%">
                     <thead>
@@ -84,7 +85,7 @@
         <h2>Importing A Table Using Python's Pandas Library</h2><hr>
         <p>
             After downloading JWQLDB data, it is simple to import this data in a python session
-            using pandas. Visit the <a href="https://pandas.pydata.org/docs/" target="_blank">pandas documentation</a> 
+            using pandas. Visit the <a href="https://pandas.pydata.org/docs/" target="_blank">pandas documentation</a>
             for more information.
             <pre>
                 <code class="python">

--- a/jwql/website/apps/jwql/views.py
+++ b/jwql/website/apps/jwql/views.py
@@ -647,9 +647,6 @@ def jwqldb_table_viewer(request, tablename_param=None):
 
     all_jwql_tables = import_all_models()
 
-    #if 'django_migrations' in all_jwql_tables:
-    #    all_jwql_tables.remove('django_migrations')  # No necessary information.
-
     jwql_tables_by_instrument = {}
     instruments = ['nircam', 'nirspec', 'niriss', 'miri', 'fgs']
 

--- a/jwql/website/apps/jwql/views.py
+++ b/jwql/website/apps/jwql/views.py
@@ -59,9 +59,8 @@ from django.http import HttpResponse, JsonResponse
 from django.shortcuts import redirect, render
 from sqlalchemy import inspect
 
-from jwql.database.database_interface import load_connection
 from jwql.utils import monitor_utils
-from jwql.utils.constants import JWST_INSTRUMENT_NAMES_MIXEDCASE, QUERY_CONFIG_TEMPLATE, URL_DICT, QueryConfigKeys
+from jwql.utils.constants import JWQLDB_EXCLUDED, JWST_INSTRUMENT_NAMES_MIXEDCASE, QUERY_CONFIG_TEMPLATE, URL_DICT, QueryConfigKeys
 from jwql.utils.interactive_preview_image import InteractivePreviewImg
 from jwql.utils.utils import filename_parser, get_base_url, get_config, get_rootnames_for_instrument_proposal, query_unformat
 
@@ -81,6 +80,7 @@ from .data_containers import (
     get_image_info,
     get_instrument_looks,
     get_rootnames_from_query,
+    import_all_models,
     random_404_page,
     text_scrape,
     thumbnails_ajax,
@@ -645,21 +645,24 @@ def jwqldb_table_viewer(request, tablename_param=None):
     else:
         table_meta = build_table(tablename)
 
-    _, _, engine, _ = load_connection(get_config()['connection_string'])
-    all_jwql_tables = inspect(engine).get_table_names()
+    all_jwql_tables = import_all_models()
 
-    if 'django_migrations' in all_jwql_tables:
-        all_jwql_tables.remove('django_migrations')  # No necessary information.
+    #if 'django_migrations' in all_jwql_tables:
+    #    all_jwql_tables.remove('django_migrations')  # No necessary information.
 
     jwql_tables_by_instrument = {}
     instruments = ['nircam', 'nirspec', 'niriss', 'miri', 'fgs']
 
     #  Sort tables by instrument
     for instrument in instruments:
-        jwql_tables_by_instrument[instrument] = [tablename for tablename in all_jwql_tables if instrument in tablename]
+        jwql_tables_by_instrument[instrument] = [tablename for tablename in all_jwql_tables if instrument in tablename.lower() and tablename not in JWQLDB_EXCLUDED]
+
+    # Wisp finder DB doesn't follow the naming convention. Add it here.
+    jwql_tables_by_instrument['nircam'].append('WispFinderB4QueryHistory')
 
     # Don't forget tables that dont contain instrument specific instrument information.
-    jwql_tables_by_instrument['general'] = [table for table in all_jwql_tables if not any(instrument in table for instrument in instruments)]
+    jwql_tables_by_instrument['general'] = [table for table in all_jwql_tables if not any(instrument in table.lower() for instrument in instruments) and table not in JWQLDB_EXCLUDED]
+    jwql_tables_by_instrument['general'].remove('WispFinderB4QueryHistory')
 
     template = 'jwqldb_table_viewer.html'
 


### PR DESCRIPTION
Remove old sqlalchemy db table names and replace with Django model names. 
This also removes another call to database_interface and sqlalchemy.
Also tweak drop-down menu to show the name of the displayed table rather than reverting to show the first table name in the list.

