### PR TITLE
Update query date range picker

### DIFF
--- a/jwql/website/apps/jwql/templates/base.html
+++ b/jwql/website/apps/jwql/templates/base.html
@@ -27,10 +27,15 @@
 		<script type="text/javascript" src="https://cdn.bokeh.org/bokeh/release/bokeh-tables-{{ bokeh_version }}.min.js"></script>
 		<script src="{{ static('js/jwql.js') }}?{% now 'U' %}"></script>
 
-		<!-- Needed for Daterange on Query Page -->
+		<!-- Needed for Daterange on Query Page
 		<script type="text/javascript" src="https://cdn.jsdelivr.net/momentjs/latest/moment.min.js"></script>
 		<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/daterangepicker/daterangepicker.min.js"></script>
 		<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/daterangepicker/daterangepicker.css" />
+		-->
+
+		<!-- Better date range picker tool for Query Page -->
+		<!-- Flatpickr CSS -->
+		<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
 
 		{% block preamble %}
         {% endblock %}
@@ -239,5 +244,9 @@
 		<!-- Needed javascript -->
 		<!-- IMPORTANT: needed for EDB plots -->
 		<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p" crossorigin="anonymous"></script>
+
+		<!-- Needed javascript -->
+		<!-- Flatpickr JS for Query page date range picker -->
+		<script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
 	</body>
 </html>

--- a/jwql/website/apps/jwql/templates/base.html
+++ b/jwql/website/apps/jwql/templates/base.html
@@ -27,12 +27,6 @@
 		<script type="text/javascript" src="https://cdn.bokeh.org/bokeh/release/bokeh-tables-{{ bokeh_version }}.min.js"></script>
 		<script src="{{ static('js/jwql.js') }}?{% now 'U' %}"></script>
 
-		<!-- Needed for Daterange on Query Page
-		<script type="text/javascript" src="https://cdn.jsdelivr.net/momentjs/latest/moment.min.js"></script>
-		<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/daterangepicker/daterangepicker.min.js"></script>
-		<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/daterangepicker/daterangepicker.css" />
-		-->
-
 		<!-- Better date range picker tool for Query Page -->
 		<!-- Flatpickr CSS -->
 		<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">

--- a/jwql/website/apps/jwql/templates/jwql_query.html
+++ b/jwql/website/apps/jwql/templates/jwql_query.html
@@ -90,6 +90,11 @@
                                     ],
                                     minDate: new Date("2021-12-25")
                                 });
+                                console.log(document.querySelector("#date_range").value);
+                                const dateRange = document.querySelector("#date_range").value;
+                                const [startDate, endDate] = dateRange.split(" to ");
+                                console.log("Start Date:", startDate);
+                                console.log("End Date:", endDate);
                                 </script>
                             </div>
                         </div>

--- a/jwql/website/apps/jwql/templates/jwql_query.html
+++ b/jwql/website/apps/jwql/templates/jwql_query.html
@@ -74,10 +74,18 @@
                 <hr class="col-md-12">
                 <div class='instrument-form-group' id='instrument_form_group'>
                     <div style="display: flex" id="DATERANGE">
-                        <div class="col-md-3">
+                        <div class="col-md-8">
                             <span class="help-block">Date Range</span>
                             <div class="form-control" id='date_range'>
+                                <input type="text" id="date_range" name="date_range" placeholder="Select date and time range" style="cursor: pointer; padding: 5px 10px; width: 100%; box-sizing: border-box;" />
+
+                                <!--
+                                style="cursor: pointer; padding: 5px 10px; width: 100%"/>
+                                -->
+
+                                <!--
                                 <input type="text" id="date_range" placeholder="Select date and time range" style="cursor: pointer; padding: 5px 10px; width: 100%"/>
+
                                 <script>
                                 flatpickr("#date_range", {
                                     mode: "range",
@@ -90,12 +98,31 @@
                                     ],
                                     minDate: new Date("2021-12-25")
                                 });
-                                console.log(document.querySelector("#date_range").value);
                                 const dateRange = document.querySelector("#date_range").value;
-                                const [startDate, endDate] = dateRange.split(" to ");
+                                const [startRaw, endRaw] = dateRange.split(" to ");
+                                const startDate = new Date(startRaw).toISOString();
+                                const endDate = new Date(endRaw).toISOString();
                                 console.log("Start Date:", startDate);
                                 console.log("End Date:", endDate);
                                 </script>
+                                -->
+
+                                <script>
+                                flatpickr("input[name='date_range']", {
+                                    mode: "range",
+                                    enableTime: true,
+                                    time_24hr: true,
+                                    dateFormat: "Y/m/d H:i", // matches 'YYYY/MM/DD hh:mm'
+                                    defaultDate: [
+                                        new Date(new Date().setDate(new Date().getDate() - 7)), // 7 days ago
+                                        new Date()
+                                    ],
+                                    minDate: "2021-12-05"
+                                });
+                                </script>
+
+
+
                             </div>
                         </div>
                     </div>

--- a/jwql/website/apps/jwql/templates/jwql_query.html
+++ b/jwql/website/apps/jwql/templates/jwql_query.html
@@ -74,55 +74,28 @@
                 <hr class="col-md-12">
                 <div class='instrument-form-group' id='instrument_form_group'>
                     <div style="display: flex" id="DATERANGE">
-                        <div class="col-md-8">
+                        <div class="col-md-4">
                             <span class="help-block">Date Range</span>
                             <div class="form-control" id='date_range'>
-                                <input type="text" id="date_range" name="date_range" placeholder="Select date and time range" style="cursor: pointer; padding: 5px 10px; width: 100%; box-sizing: border-box;" />
-
-                                <!--
-                                style="cursor: pointer; padding: 5px 10px; width: 100%"/>
-                                -->
-
-                                <!--
-                                <input type="text" id="date_range" placeholder="Select date and time range" style="cursor: pointer; padding: 5px 10px; width: 100%"/>
-
-                                <script>
-                                flatpickr("#date_range", {
-                                    mode: "range",
-                                    enableTime: true,
-                                    time_24hr: true,
-                                    dateFormat: "Y/m/d H:i",
-                                    defaultDate: [
-                                        new Date(new Date().setDate(new Date().getDate() - 7)), // 7 days ago
-                                        new Date() // now
-                                    ],
-                                    minDate: new Date("2021-12-25")
-                                });
-                                const dateRange = document.querySelector("#date_range").value;
-                                const [startRaw, endRaw] = dateRange.split(" to ");
-                                const startDate = new Date(startRaw).toISOString();
-                                const endDate = new Date(endRaw).toISOString();
-                                console.log("Start Date:", startDate);
-                                console.log("End Date:", endDate);
-                                </script>
-                                -->
-
+                                <input type="text" id="date_range" name="date_range" placeholder="Select date and time range" style="cursor: pointer; padding: 5px 10px; width: 100%;" />
                                 <script>
                                 flatpickr("input[name='date_range']", {
                                     mode: "range",
                                     enableTime: true,
-                                    time_24hr: true,
-                                    dateFormat: "Y/m/d H:i", // matches 'YYYY/MM/DD hh:mm'
+                                    time_24hr: false,  // use 12-hour time
+                                    dateFormat: "Y/m/d h:iK",  // h = 12-hour, K = AM/PM
                                     defaultDate: [
-                                        new Date(new Date().setDate(new Date().getDate() - 7)), // 7 days ago
+                                        new Date(new Date().setDate(new Date().getDate() - 7)),
                                         new Date()
                                     ],
-                                    minDate: "2021-12-05"
+                                    minDate: "2021-12-05",
+
+                                    onChange: function(selectedDates, dateStr, instance) {
+                                    const formattedStr = dateStr.replace(" to ", " - ");
+                                    instance.input.value = formattedStr;
+                                    }
                                 });
                                 </script>
-
-
-
                             </div>
                         </div>
                     </div>

--- a/jwql/website/apps/jwql/templates/jwql_query.html
+++ b/jwql/website/apps/jwql/templates/jwql_query.html
@@ -77,20 +77,18 @@
                         <div class="col-md-3">
                             <span class="help-block">Date Range</span>
                             <div class="form-control" id='date_range'>
-                                <input type="text" name="date_range" style="cursor: pointer; padding: 5px 10px; width: 100%"/>
+                                <input type="text" id="date_range" placeholder="Select date and time range" style="cursor: pointer; padding: 5px 10px; width: 100%"/>
                                 <script>
-                                $(function() {
-                                    $('input[name="date_range"]').daterangepicker({
-                                        timePicker: true,
-                                        timePicker24Hour: true,
-                                        showDropdowns: true,
-                                        minDate: "2021/12/05",
-                                        startDate: "2021/12/05",
-                                        endDate: moment().startOf('hour'),
-                                        locale: {
-                                        format: 'YYYY/MM/DD hh:mmA'
-                                        }
-                                    });
+                                flatpickr("#date_range", {
+                                    mode: "range",
+                                    enableTime: true,
+                                    time_24hr: true,
+                                    dateFormat: "Y/m/d H:i",
+                                    defaultDate: [
+                                        new Date(new Date().setDate(new Date().getDate() - 7)), // 7 days ago
+                                        new Date() // now
+                                    ],
+                                    minDate: new Date("2021-12-25")
                                 });
                                 </script>
                             </div>


### PR DESCRIPTION
The old calendar date range picker was sometimes clunky and awkward. This PR replaces the date range picker with a more modern and better-supported tool.

Looks good with local testing.

Resolves #1566 