### PR TITLE
Wisp finder fixes

### DIFF
--- a/jwql/instrument_monitors/nircam_monitors/prepare_wisp_pngs.py
+++ b/jwql/instrument_monitors/nircam_monitors/prepare_wisp_pngs.py
@@ -56,7 +56,8 @@ def rescale_array(arr):
 
     # Rescale the image
     adjusted_image = alpha * arr + beta
-    adjusted_image = np.clip(adjusted_image, 0, 255).astype(np.uint8)
+    mask = ~np.isnan(adjusted_image)
+    adjusted_image[mask] = np.clip(adjusted_image[mask], 0, 255).astype(np.uint8)
 
     return adjusted_image
 

--- a/jwql/instrument_monitors/nircam_monitors/wisp_finder.py
+++ b/jwql/instrument_monitors/nircam_monitors/wisp_finder.py
@@ -17,7 +17,6 @@ Use
 
 Overall flow:
 
-
 1. Look in database table for last successful run on the monitor.
 2. Get the datetime of that run.
 3. Query MAST for all NIRCam B4 full frame files (exclude coron?) since that datetime
@@ -28,8 +27,6 @@ Overall flow:
 8. For those files where the prediction is that a wisp is present, set the wisp flag in the anomalies database
 9. Delete pngs
 10. Update the database with the datetime of the current run
-
-
 """
 
 import argparse
@@ -39,6 +36,7 @@ import os
 import shutil
 import warnings
 
+from astropy.time import Time
 from astroquery.mast import Observations
 from django import setup
 from django.utils import timezone
@@ -55,6 +53,7 @@ from jwql.utils.logging_functions import log_info, log_fail
 from jwql.utils.utils import get_config
 from jwql.website.apps.jwql.archive_database_update import files_in_filesystem
 from jwql.instrument_monitors.nircam_monitors import prepare_wisp_pngs
+from jwql.utils.utils import filesystem_path
 
 if not ON_GITHUB_ACTIONS and not ON_READTHEDOCS:
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "jwql.website.jwql_proj.settings")
@@ -110,7 +109,11 @@ def copy_files_to_working_dir(filepaths):
         List of new locations for the files
     """
     working_dir = get_config()["working"]
+
+    if not os.path.isdir(working_dir):
+        os.makedirs(working_dir)
     copied_filepaths = []
+
     for filepath in filepaths:
         shutil.copy2(filepath, working_dir)
         copied_filepaths.append(os.path.join(working_dir, os.path.basename(filepath)))
@@ -343,12 +346,14 @@ def remove_duplicate_files(file_list):
     """
     file_list = np.array(file_list)
     unique_files = []
-    basenames_only = set([os.path.basename(e) for e in file_list])
+    basenames_only = sorted(list(set([os.path.basename(e) for e in file_list])))
+
     for basename in basenames_only:
         matches = np.array([basename in e for e in file_list])
-        unique_files.append(file_list[matches][0])
-    return unique_files
 
+        if os.path.exists(file_list[matches][0]):
+            unique_files.append(file_list[matches][0])
+    return unique_files
 
 @log_fail
 @log_info
@@ -391,6 +396,8 @@ def run(model_filename=None, starting_date=None, ending_date=None, file_list=Non
         # If ending_date is not provided, set it equal to the current time
         if ending_date is None:
             ending_date = timezone.now()
+            t_end = Time(ending_date, scale='utc')
+            ending_date = t_end.mjd
 
         # If starting date is not provided, then query the database for the last
         # successful run of this monitor. Use the ending date of that run for the
@@ -404,7 +411,7 @@ def run(model_filename=None, starting_date=None, ending_date=None, file_list=Non
         # Query MAST between starting_date and ending_date, and get a list of files
         # to run the wisp prediction on.
         rate_files = query_mast(starting_date, ending_date)
-        logging.info(f"Found {len(rate_files)} rate files")
+        logging.info(f"MAST query returned {len(rate_files)} rate files")
 
     else:
         rate_files = file_list
@@ -416,11 +423,18 @@ def run(model_filename=None, starting_date=None, ending_date=None, file_list=Non
 
         # Find the location in the filesystem for all files
         logging.info("Locating files in the filesystem")
-        filepaths_public = files_in_filesystem(rate_files, 'public')
-        filepaths_proprietary = files_in_filesystem(rate_files, 'proprietary')
-        filepaths = filepaths_public + filepaths_proprietary
+        filepaths = []
+        for rate_file in rate_files:
+            try:
+                filepaths.append(filesystem_path(rate_file, check_existence=True))
+            except Exception as e:
+                logging.warning(f"Failed to find {rate_file} with error {e}")
+
+        # Remove any duplicates coming from files that are present in both the
+        # public and proprietary filesystems
         filepaths = remove_duplicate_files(filepaths)
 
+        # Copy files to working directory
         logging.info("Copying files from the filesystem to the working directory.")
         working_filepaths = copy_files_to_working_dir(filepaths)
 
@@ -435,24 +449,24 @@ def run(model_filename=None, starting_date=None, ending_date=None, file_list=Non
         for working_filepath in working_filepaths:
             # Create png
             working_dir = os.path.dirname(working_filepath)
+            logging.info(f'Creating png for {os.path.filename(working_filepath)}. Saving to {working_dir}')
             png_filename = prepare_wisp_pngs.run(working_filepath, out_dir=working_dir)
 
             # Predict
             prediction = predict_wisp(model, png_filename, transform)
-
-            print(png_filename, prediction)  # FOR DEVELOPMENT ONLY. REMOVE BEFORE MERGING
 
             # If a wisp is predicted, set the wisp flag in the anomalies database
             if prediction == "wisp":
                 # Create the rootname. Strip off the path info, and remove '.fits' and the suffix
                 # (i.e. 'rate'')
                 rootfile = '_'.join(os.path.basename(working_filepath).split('.')[0].split('_')[0:-1])
-                logging.info(f"Found wisp in {rootfile}")
+                logging.info(f"\tFound wisp in {rootfile}\n")
 
                 # Add the wisp flag to the RootFileInfo object for the rootfile
                 add_wisp_flag(rootfile)
             else:
-                pass
+                rootfile = '_'.join(os.path.basename(working_filepath).split('.')[0].split('_')[0:-1])
+                logging.info(f'\tNo wisp in {rootfile}\n')
 
             # Delete the png and fits files
             os.remove(png_filename)
@@ -475,11 +489,9 @@ def run(model_filename=None, starting_date=None, ending_date=None, file_list=Non
 
     logging.info('Wisp Finder Monitor completed successfully.')
 
-
 if __name__ == '__main__':
     module = os.path.basename(__file__).strip('.py')
     start_time, log_file = monitor_utils.initialize_instrument_monitor(module)
-
     parser = define_options()
     args = parser.parse_args()
 

--- a/jwql/instrument_monitors/nircam_monitors/wisp_finder.py
+++ b/jwql/instrument_monitors/nircam_monitors/wisp_finder.py
@@ -353,8 +353,8 @@ def remove_duplicate_files(file_list):
     for basename in basenames_only:
         matches = np.array([basename in e for e in file_list])
 
-        if os.path.exists(file_list[matches][0]):
-            unique_files.append(file_list[matches][0])
+        # We've already checked for file existence, so no need to do that here
+        unique_files.append(file_list[matches][0])
     return unique_files
 
 @log_fail

--- a/jwql/instrument_monitors/nircam_monitors/wisp_finder.py
+++ b/jwql/instrument_monitors/nircam_monitors/wisp_finder.py
@@ -62,6 +62,8 @@ if not ON_GITHUB_ACTIONS and not ON_READTHEDOCS:
     from jwql.website.apps.jwql.monitor_models.wisp_finder import WispFinderB4QueryHistory
 
 
+MAX_QUERY_DURATION = 7.  # days
+
 def add_wisp_flag(basename):
     """Add the wisps flag to the RootFileInfo entry for the given filename
 
@@ -408,23 +410,66 @@ def run(model_filename=None, starting_date=None, ending_date=None, file_list=Non
 
         logging.info(f"Using MJD {starting_date} to {ending_date} to search for files")
 
-        # Query MAST between starting_date and ending_date, and get a list of files
-        # to run the wisp prediction on.
-        rate_files = query_mast(starting_date, ending_date)
-        logging.info(f"MAST query returned {len(rate_files)} rate files")
+        # If the starting and ending dates span a long time, break up the time into
+        # smaller chunks in order to get reasonable MAST query lists and so as not to
+        # copy really large numbers of files to the working directory
+        if ending_date - starting_date > MAX_QUERY_DURATION:
+            logging.info(f"Time range is greater than the maximum allowed duration of {MAX_QUERY_DURATION} days")
+            starting_dates = np.arange(starting_date, ending_date, MAX_QUERY_DURATION)
+            # Make the ending_dates 0.1 second shy of MAX_QUERY_DURATION so that they are not
+            # exactly the same as the subsequent starting_date
+            ending_dates = starting_dates + MAX_QUERY_DURATION - (0.1 / 3600. / 24.)
+            # Set the final ending_date equal to the originally requested ending_date
+            if ending_dates[-1] > ending_date:
+                ending_dates[-1] = ending_date
+            logging.info(f"Breaking up the query into {len(starting_dates)} smaller queries.")
+        else:
+            starting_dates = np.array([starting_date])
+            ending_dates = np.array([ending_date])
+
+        for subq_starting_date, subq_ending_date in zip(starting_dates, ending_dates):
+            # Query MAST between starting_date and ending_date, and get a list of files
+            # to run the wisp prediction on.
+            rate_files = query_mast(subq_starting_date, subq_ending_date)
+            logging.info(f"MAST query betwen MJD {subq_starting_date} and {subq_ending_date} returned {len(rate_files)} rate files")
+            run_predictor(rate_files, model_filename, subq_starting_date, subq_ending_date)
 
     else:
         rate_files = file_list
         starting_date = 0.0
         ending_date = 0.0
+        logging.info(f"Running predictor on list of {len(rate_files)} files.")
+        run_predictor(rate_files, model_filename, subq_starting_date, subq_ending_date)
 
-    if len(rate_files) > 0:
+    logging.info('Wisp Finder Monitor completed successfully.')
+
+
+def run_predictor(ratefiles, model_file, start_date, end_date):
+    """Given a list of files, a ML model file, and dates, check all of the files for wisps.
+
+    Parameters
+    ----------
+    ratefiles : list
+        List of fits files to check for wisps.
+
+    model_file : str
+        Name of a file containing the ML model to be used
+
+    start_date : float
+        MJD of the starting date of the range encompassing ``ratefiles``.
+        Used for populating the history database table.
+
+    end_date : float
+        MJD of the ending date of the range encompassing ``ratefiles``.
+        Used for populating the history database table.
+    """
+    if len(ratefiles) > 0:
         monitor_run = True
 
         # Find the location in the filesystem for all files
         logging.info("Locating files in the filesystem")
         filepaths = []
-        for rate_file in rate_files:
+        for rate_file in ratefiles:
             try:
                 filepaths.append(filesystem_path(rate_file, check_existence=True))
             except Exception as e:
@@ -439,8 +484,7 @@ def run(model_filename=None, starting_date=None, ending_date=None, file_list=Non
         working_filepaths = copy_files_to_working_dir(filepaths)
 
         # Load the trained ML model
-        logging.info(f"Loading ML model from {model_filename}")
-        model = load_ml_model(model_filename)
+        model = load_ml_model(model_file)
 
         # Create transform to use when creating image tensor
         transform = create_transform()
@@ -449,7 +493,7 @@ def run(model_filename=None, starting_date=None, ending_date=None, file_list=Non
         for working_filepath in working_filepaths:
             # Create png
             working_dir = os.path.dirname(working_filepath)
-            logging.info(f'Creating png for {os.path.filename(working_filepath)}. Saving to {working_dir}')
+            logging.info(f'Creating png for {os.path.basename(working_filepath)}. Saving to {working_dir}')
             png_filename = prepare_wisp_pngs.run(working_filepath, out_dir=working_dir)
 
             # Predict
@@ -472,22 +516,21 @@ def run(model_filename=None, starting_date=None, ending_date=None, file_list=Non
             os.remove(png_filename)
             os.remove(working_filepath)
     else:
-        # If no rate_files are found
+        # If no ratefiles are found
         logging.info(f"No rate files found. Ending monitor run.")
         monitor_run = False
 
     # Update the database with info about this run of the monitor. We keep the
-    # staring and ending dates of the search. No need to keep the names of the files
+    # starting and ending dates of the search. No need to keep the names of the files
     # that are found to contain a wisp, because that info will be in the  RootFileInfo
     # instances.
-    new_entry = {'start_time_mjd': starting_date,
-                 'end_time_mjd': ending_date,
+    new_entry = {'start_time_mjd': start_date,
+                 'end_time_mjd': end_date,
                  'run_monitor': monitor_run,
                  'entry_date': datetime.datetime.now(datetime.timezone.utc)}
     entry = WispFinderB4QueryHistory(**new_entry)
     entry.save()
 
-    logging.info('Wisp Finder Monitor completed successfully.')
 
 if __name__ == '__main__':
     module = os.path.basename(__file__).strip('.py')

--- a/jwql/tests/test_wisp_finder.py
+++ b/jwql/tests/test_wisp_finder.py
@@ -21,12 +21,13 @@ import datetime
 import os
 import pytest
 
+from django import setup
 import numpy as np
 import torch
 import torchvision
 
 from jwql.instrument_monitors.nircam_monitors import wisp_finder, prepare_wisp_pngs
-from jwql.utils.constants import ON_GITHUB_ACTIONS
+from jwql.utils.constants import ON_GITHUB_ACTIONS, ON_READTHEDOCS
 from jwql.utils.utils import get_config
 from jwql.website.apps.jwql.archive_database_update import files_in_filesystem
 


### PR DESCRIPTION
Update the wisp_finder to:

1. Remove the appearance of duplicate files
2. Clean up extra log entries
3. Split the file query into week-long blocks in order to prevent extra large MAST query results and excessive disk space