### PR TITLE
Set wisp probability threshold to 1%

### DIFF
--- a/jwql/instrument_monitors/nircam_monitors/wisp_finder.py
+++ b/jwql/instrument_monitors/nircam_monitors/wisp_finder.py
@@ -48,7 +48,7 @@ from torchvision import transforms
 import torchvision.models as models
 
 from jwql.utils import monitor_utils
-from jwql.utils.constants import ON_GITHUB_ACTIONS, ON_READTHEDOCS
+from jwql.utils.constants import ON_GITHUB_ACTIONS, ON_READTHEDOCS, WISP_PROBABILITY_THRESHOLD
 from jwql.utils.logging_functions import log_info, log_fail
 from jwql.utils.utils import get_config
 from jwql.website.apps.jwql.archive_database_update import files_in_filesystem
@@ -263,7 +263,7 @@ def predict_wisp(model, image_path, transform):
     # The model outputs a single probability (e.g., for "wisp"). So, use a threshold
     # to determine whether the prediction is wisp or no_wisp.
     probability = torch.sigmoid(output).item()
-    threshold = 0.01  # Determined during test runs on the test server using the MAST filesystem
+    threshold = WISP_PROBABILITY_THRESHOLD
     prediction_label = "wisp" if probability >= threshold else "no wisp"
     return prediction_label, probability, threshold
 

--- a/jwql/instrument_monitors/nircam_monitors/wisp_finder.py
+++ b/jwql/instrument_monitors/nircam_monitors/wisp_finder.py
@@ -263,7 +263,7 @@ def predict_wisp(model, image_path, transform):
     # The model outputs a single probability (e.g., for "wisp"). So, use a threshold
     # to determine whether the prediction is wisp or no_wisp.
     probability = torch.sigmoid(output).item()
-    threshold = 0.5
+    threshold = 0.01  # Determined during test runs on the test server using the MAST filesystem
     prediction_label = "wisp" if probability >= threshold else "no wisp"
     return prediction_label, probability, threshold
 
@@ -324,7 +324,7 @@ def query_mast(starttime, endtime):
                                                          productType='SCIENCE',
                                                          productSubGroupDescription='RATE',
                                                          calib_level=[2])
-        logging.info(f"\tExpore {i+1} of {len(sci_obs_id_table)}: {len(products)} products filters to {len(filtered_products)} rate files")
+        logging.info(f"\tExposure {i+1} of {len(sci_obs_id_table)}: {len(products)} products filters to {len(filtered_products)} rate files")
         sci_files_to_download.extend(filtered_products['dataURI'])
 
     # The current ML wisp finder model is only trained for the wisps on the B4 detector,

--- a/jwql/utils/constants.py
+++ b/jwql/utils/constants.py
@@ -1062,3 +1062,6 @@ MAX_LEN_VISIT = 30
 
 # STScI VAO server url
 STSCI_VO_URL = "https://mast.stsci.edu/vo-tap/api/v0.1/caom"
+
+# Threshold probability needed by the wisp finder to declare a wisp
+WISP_PROBABILITY_THRESHOLD = 0.01  # Determined during test runs on the test server using the MAST filesystem


### PR DESCRIPTION
Running the wisp finder on the test server using all MAST data between launch and now seems to show that a probability threshold of 1% is better for accurately identifying wisps than the 50% threshold currently in use. This PR updates the threshold.