### PR TITLE
Adding CLEAR to list of niriss filters

### DIFF
--- a/jwql/utils/constants.py
+++ b/jwql/utils/constants.py
@@ -448,6 +448,7 @@ FILTERS_PER_INSTRUMENT = {
         "F322W2",
     ],
     "niriss": [
+        "CLEAR",
         "F090W",
         "F115W",
         "F140M",


### PR DESCRIPTION
CLEAR was missing from the list of NIRISS filters (not to be confused with the CLEARP pupil), so it has now been added to list of constants. I haven't verified locally that this doesn't break anything.