### PR TITLE
Fix Row for NRC Exposure Level View

### DIFF
--- a/jwql/website/apps/jwql/templates/view_exposure.html
+++ b/jwql/website/apps/jwql/templates/view_exposure.html
@@ -122,7 +122,7 @@
                             </a>
                         </span>
                     </div>
-                    <div id="view_{{detector1}}" class="col" id="{{ detector1 }}_view_fallback">
+                    <div class="col" id="{{ detector1 }}_view_fallback">
                         <span class="image_preview">
                             <a id="view_{{detector1}}_fallback" href="{{ base_url }}/{{ inst }}/{{ group_root }}_{{ detector1 }}/">
                                 <img class="image_preview_viewer thumbnail" id="fallback_image_viewer_{{ detector1 }}"


### PR DESCRIPTION
Having an extra id in this tag was creating artificial space for a fall back image. Typically, we show 4 rows of NRC exposures per row, this extra id created a blank space for the fallback image with display set to `none`. This fixes the issue and spans the images to their proper size.