### PR TITLE
Fix new calendar widget for default date range

### DIFF
--- a/jwql/website/apps/jwql/data_containers.py
+++ b/jwql/website/apps/jwql/data_containers.py
@@ -1661,7 +1661,7 @@ def get_detectors_by_rootname(rootname):
     """
     Return a list of exposures with the same rootname as the provided rootname, but
     including all available detectors.
-    
+
     Parameters
     ----------
     rootname : str
@@ -1812,7 +1812,7 @@ def get_rootnames_from_query(parameters):
 
     # Parse DATE_RANGE string into correct format
     date_range = parameters[QueryConfigKeys.DATE_RANGE]
-    start_date_range, stop_date_range = date_range.split(" - ")
+    start_date_range, stop_date_range = date_range.split(" to ")
     # Parse the strings into datetime objects
     start_datetime = datetime.strptime(start_date_range, DATE_FORMAT)
     stop_datetime = datetime.strptime(stop_date_range, DATE_FORMAT)

--- a/jwql/website/apps/jwql/templates/jwql_query.html
+++ b/jwql/website/apps/jwql/templates/jwql_query.html
@@ -91,8 +91,20 @@
                                     minDate: "2021-12-05",
 
                                     onChange: function(selectedDates, dateStr, instance) {
-                                    const formattedStr = dateStr.replace(" to ", " - ");
-                                    instance.input.value = formattedStr;
+                                    instance.input.value = dateStr;
+                                    },
+                                    onReady: function(selectedDates, dateStr, instance) {
+                                    // Wait one tick so Flatpickr can render defaults before we format manually
+                                    setTimeout(() => {
+                                        if (selectedDates.length === 2) {
+                                                const formattedStr =
+                                                        instance.formatDate(selectedDates[0], "Y/m/d h:iK") +
+                                                        " to " +
+                                                        instance.formatDate(selectedDates[1], "Y/m/d h:iK");
+                                                instance.input.value = formattedStr;
+                                                }
+                                            },
+                                        0);
                                     }
                                 });
                                 </script>


### PR DESCRIPTION
In the new calendar widget on the query page, the default dates were appearing on the webpage, but were not being populated into the actual variable used by the widget. Once a user changed the dates, the variable was being populated. So in cases where the user kept the default date range, the widget was failing with Null dates.

This PR updates the widget so that the variable does contain the default date range upon page load. This way if the user does not change the dates, they are still defined.

We also simplify the code a bit by setting the calendar widget to use 'to' as delimiter between the starting and ending dates, rather than manually switching to a dash.