### PR TITLE
Make sure orphaned figures are closed. Remove repeated prog numbers.

### DIFF
--- a/jwql/jwql_monitors/generate_preview_images.py
+++ b/jwql/jwql_monitors/generate_preview_images.py
@@ -33,6 +33,7 @@ import multiprocessing
 import os
 import re
 
+import matplotlib.pyplot as plt
 import numpy as np
 
 from jwql.utils import permissions
@@ -598,7 +599,9 @@ def generate_preview_images(overwrite, programs=None):
                 logging.info(f'Program {prog} not present in filesystem. Excluding.')
 
     if len(program_list) > 0:
-        program_list = sorted(program_list, reverse=True)
+        # Remove any repeats due to programs being listed in public and proprietary dirs at the same time.
+        # Sort into descending order
+        program_list = sorted(list(set(program_list)), reverse=True)
     else:
         no_prog_message = f'Empty list of programs. No preview images to be made.'
         logging.info(no_prog_message)
@@ -822,6 +825,9 @@ def process_program(program, overwrite):
 
         except (ValueError, AttributeError) as error:
             logging.warning(error)
+        finally:
+            # Make sure all figures are closed.
+            plt.close('all')
 
     logging.info(f"Created {new_preview_counter} new preview images.")
     logging.info(f"Skipped {existing_preview_counter} previously-existing preview images.")


### PR DESCRIPTION
Resolves #1716 

When generating preview images, make sure that any orphaned figures are closed. This can happen in cases where there is some error when trying to generate a preview image after the self.fig, ax = plt.subpots() call. When there is a problem after that point, the code falls into the 'except' clause, but the figure that was created before the failure is not closed.

This PR adds a plt.close('all') to be sure that all figures are closed, so that we don't end up with a growing list of open figures.

It also removes duplicates from the list of all programs, which were creeping in for programs that are present in the pubic and proprietary filesystems at the same time.