### PR TITLE
Avoid negative colorbar widths

### DIFF
--- a/jwql/utils/preview_image.py
+++ b/jwql/utils/preview_image.py
@@ -498,7 +498,7 @@ class PreviewImage():
 
             # Catch images where all pixel values are zero. e.g. trapsfilled files
             if delta == 0:
-                delta = 1e-6
+                delta = 0.01
 
             # For cases where the the distance between min_value and max_value is very small,
             # adjust the tick labels to avoid having the same number label for all ticks

--- a/jwql/utils/preview_image.py
+++ b/jwql/utils/preview_image.py
@@ -496,6 +496,18 @@ class PreviewImage():
             format_string = "%.{}f".format(dig)
             tlabelstr = [format_string % number for number in tlabelflt]
 
+            # Catch images where all pixel values are zero. e.g. trapsfilled files
+            if delta == 0:
+                delta = 1e-6
+
+            # For cases where the the distance between min_value and max_value is very small,
+            # adjust the tick labels to avoid having the same number label for all ticks
+            zeros = np.log10(np.abs(delta))
+            if zeros < -3:
+                # For cases where the signal range is only 1e-3, use scientific notation for
+                # the tick labels
+                tlabelstr = [f"{num:.3e}" for num in tlabelflt]
+
             xyratio = xsize / ysize
             if xyratio < 1.6:
                 # For apertures that are taller than they are wide, square, or that are wider than
@@ -525,6 +537,10 @@ class PreviewImage():
             else:
                 # For apertures that are significantly wider than they are tall, put the colorbar
                 # under the image.
+
+                # Adjustment to prevent negative colorbar width
+                if xyratio < 2:
+                    xyratio = 2.5
 
                 # Again, some magic numbers controlling the positioning and height of the
                 # colorbar, based on testing.


### PR DESCRIPTION
For some exposures with a subarray size that is (rare and) just the right aspect ratio, the calculated colorbar width when generating the preview image is negative. This was leading to crashes in the preview image generator. This PR fixes those cases.

The colorbar width is adjusted to be positive by changing the xyratio from the image dimensions. 

This also catches a rare case seen in some of the same images with the negative colorbar widths, where the data span a very small range. This was leading to all the colorbar tick labels having the same value. We change that here to print the tick labels in scientific notation if the signal range is small enough.