### PR TITLE
Fix filename_parser and null read_patt_num

### DIFF
--- a/jwql/utils/utils.py
+++ b/jwql/utils/utils.py
@@ -445,8 +445,8 @@ def filename_parser(filename):
         r"-(?P<ac_id>(o\d{" + f"{FILE_AC_O_ID_LEN}" + r"}|(c|a|r)\d{" + f"{FILE_AC_CAR_ID_LEN}" + "}))"\
         r"_(?P<target_id>(t)\d{" + f"{FILE_TARG_ID_LEN}" + "})"\
         r"_(?P<instrument>(nircam|niriss|nirspec|miri|fgs))"\
-        r"[_-](?P<optical_elements>[a-zA-Z0-9\-]{5,})"\
-        r"-(?P<subarray>[a-zA-Z0-9\-]+)"
+        r"[_-](?P<optical_elements>[a-zA-Z0-9\-]+?)"\
+        r"-(?P<subarray>(sub|full|bright|mask|miri|all|wfss)[a-zA-Z0-9]*)"
 
     # Stage 3 filenames with target ID
     # e.g. "jw01076-o002_t001_nircam_f444w-grismr_x1d.fits or c1d.fits"

--- a/jwql/website/apps/jwql/archive_database_update.py
+++ b/jwql/website/apps/jwql/archive_database_update.py
@@ -43,6 +43,7 @@ Dependencies
 import logging
 import os
 import argparse
+import numbers
 import re
 
 import numpy as np
@@ -368,6 +369,7 @@ def update_database_table(update, instrument, prop, obs, thumbnail, obsfiles, ty
                                                                                       instrument=instrument,
                                                                                       obsnum=obs_instance,
                                                                                       proposal=prop)
+
             if update or rfi_created:
                 # Updating defaults only on update or creation to prevent querying MAST on every file name.
                 # Use mast_query_by_filename() rather than mast_query_by_rootname() because with level 3 files
@@ -376,6 +378,14 @@ def update_database_table(update, instrument, prop, obs, thumbnail, obsfiles, ty
                 # and we would need to keep track of all of these files. By querying by filename, we remove the
                 # confusion over having multiple files associated with a single rootname.
                 defaults_dict = mast_query_by_filename(instrument, filename)
+
+                # Some level 3 files seem to have read_patt_num set to None in the results returned
+                # from MAST. But read_patt_num cannot be null in RootFileInfo. So check for this condition
+                # and set read_patt_num to the default if it is None
+                if 'patt_num' in defaults_dict:
+                    if not isinstance(defaults_dict['patt_num'], numbers.Number):
+                        logging.debug(f'In {filename}, patt_num is {defaults_dict["patt_num"]}')
+                        defaults_dict['patt_num'] = 1
 
                 defaults = dict(filter=defaults_dict.get('filter', DEFAULT_MODEL_CHARFIELD),
                                 detector=defaults_dict.get('detector', DEFAULT_MODEL_CHARFIELD),
@@ -516,6 +526,14 @@ def fill_empty_rootfileinfo(rootfileinfo_set):
     saved_rootfileinfos = 0
     for rootfileinfo_mod in rootfileinfo_set:
         defaults_dict = mast_query_by_rootname(rootfileinfo_mod.instrument, rootfileinfo_mod.root_name)
+
+        # Some level 3 files seem to have read_patt_num set to None in the results returned
+        # from MAST. But read_patt_num cannot be null in RootFileInfo. So check for this condition
+        # and set read_patt_num to the default if it is None
+        if 'patt_num' in defaults_dict:
+            if not isinstance(defaults_dict['patt_num'], numbers.Number):
+                logging.debug(f'In {ootfileinfo_mod.root_name}, patt_num is {defaults_dict["patt_num"]}')
+                defaults_dict['patt_num'] = 1
 
         defaults = dict(filter=defaults_dict.get('filter', DEFAULT_MODEL_CHARFIELD),
                         detector=defaults_dict.get('detector', DEFAULT_MODEL_CHARFIELD),


### PR DESCRIPTION
Fixes for the filename_parser and archive_database_update that were revealed through testing with level 3 files.

Make one of the filename_parser regular expressions more specific, in order to prevent matching with files it shouldn't.
Also, in some MAST queries for specific filenames, the results come back with patt_num set to None. However, read_patt_num in the RootFileInfo instances is non-nullable. Add a check for this, and set read_patt_num to 1 in cases where it is None in MAST. 