### PR TITLE
Sort proposal_nums list as integers rather than strings

### DIFF
--- a/jwql/website/apps/jwql/data_containers.py
+++ b/jwql/website/apps/jwql/data_containers.py
@@ -249,7 +249,7 @@ def create_archived_proposals_context(inst):
     proposal_nums = [entry.prop_id for entry in prop_objects]
 
     # Put proposals into descending order
-    proposal_nums.sort(reverse=True)
+    proposal_nums.sort(key=int, reverse=True)
 
     # Total number of proposals for the instrument
     num_proposals = len(proposal_nums)


### PR DESCRIPTION
Fix a bug where, on the archive proposals page for a given instrument, proposal numbers with 5 digits were being interspersed with those containing 4-digits after sorting. 
e.g. 4567, 3333, 2532, 1874, 11234, 1062

This was happening because the program numbers are stored as a list of strings, and were being sorted as strings. This PR changes the sorting such that the entries are treated as integers during the sorting process. (But the values are still strings.) With this change, higher numbered programs will remain at the top of the list, as expected, regardless of whether they contain 4 or 5 digits.