### PR TITLE
Show level 3 files on exposure and detector level pages

### DIFF
--- a/jwql/jwql_monitors/generate_preview_images.py
+++ b/jwql/jwql_monitors/generate_preview_images.py
@@ -210,7 +210,7 @@ def check_existence(file_list, outdir):
     # for a preview image name that contains the detector name
     if len(file_list) == 1:
         filename = os.path.split(file_list[0])[1]
-        search_string = filename.split('.fits')[0] + '_*.jpg'
+        search_string = filename.split('.fits')[0] + '*jpg'
     else:
         # If file_list contains multiple files, then we need to search
         # for the appropriately named jpg of the mosaic, which depends

--- a/jwql/utils/constants.py
+++ b/jwql/utils/constants.py
@@ -1004,7 +1004,7 @@ SUBARRAYS_PER_INSTRUMENT = {
 SUFFIXES_TO_ADD_ASSOCIATION = ["crf", "crfints"]
 
 # Filename suffixes where data have been averaged over integrations
-SUFFIXES_WITH_AVERAGED_INTS = ["rate", "cal", "crf", "i2d", "bsub"]
+SUFFIXES_WITH_AVERAGED_INTS = ["rate", "cal", "crf", "i2d", "bsub", "x1d"]
 
 # boolean accessed according to a viewed flag
 THUMBNAIL_FILTER_LOOK = ["New", "Viewed"]

--- a/jwql/utils/constants.py
+++ b/jwql/utils/constants.py
@@ -998,6 +998,9 @@ SUBARRAYS_PER_INSTRUMENT = {
     "fgs": ['FULL'] + sorted(schema["properties"]["meta"]["properties"]["subarray"]["properties"]["name"]["anyOf"][0]['enum'])
 }
 
+# File suffixes for ecsv files that JWQL tracks
+SUFFIXES_OF_ECSV_FILES = ['whtlt', 'phot']
+
 # Filename suffixes that need to include the association value in the suffix in
 # order to identify the preview image file. This should only be crf and crfints,
 # since those are essentially level 2 files that are output by the level 3 pipeline.

--- a/jwql/utils/constants.py
+++ b/jwql/utils/constants.py
@@ -553,7 +553,7 @@ GUIDER_SUFFIX_TYPES = [
 ]
 
 # JWQL should ignore some filetypes in the filesystem.
-IGNORED_SUFFIXES = ["original", "stream", "x1d", "x1dints", "c1d", "pre-image", "ami"]
+IGNORED_SUFFIXES = ["original", "stream", "pre-image"]
 
 # Instrument monitor database tables
 INSTRUMENT_MONITOR_DATABASE_TABLES = {

--- a/jwql/utils/utils.py
+++ b/jwql/utils/utils.py
@@ -800,16 +800,20 @@ def filesystem_path(filename, check_existence=True, search=None):
         parts = filename.split('_')
         id1 = parts[0].split('-')[1]
         id2 = parts[1]
+        # Some source-based filenames use v{source_number}, but these
+        # will be in the s subdir
+        if i2d == 'v':
+            id2 = 's'
         subdir2 = f'L3/{id2[0]}/{id1}'
 
     if search:
-        full_subdir = os.path.join(subdir1, subdir2, '{}{}'.format(filename, search))
+        full_subdir = os.path.join(subdir1, subdir2, f'{filename}{search}')
         filenames_found = glob.glob(os.path.join(FILESYSTEM, 'public', full_subdir))
         filenames_found.extend(glob.glob(os.path.join(FILESYSTEM, 'proprietary', full_subdir)))
         if len(filenames_found) > 0:
             filename = os.path.basename(filenames_found[0])
         else:
-            raise FileNotFoundError('{} did not yield any files in predicted location {}'.format(search, full_subdir))
+            raise FileNotFoundError(f'{search} did not yield any files in predicted location {full_subdir}')
 
     full_path = os.path.join(subdir1, subdir2, filename)
 

--- a/jwql/utils/utils.py
+++ b/jwql/utils/utils.py
@@ -802,7 +802,7 @@ def filesystem_path(filename, check_existence=True, search=None):
         id2 = parts[1]
         # Some source-based filenames use v{source_number}, but these
         # will be in the s subdir
-        if i2d == 'v':
+        if id2[0] == 'v':
             id2 = 's'
         subdir2 = f'L3/{id2[0]}/{id1}'
 

--- a/jwql/website/apps/jwql/data_containers.py
+++ b/jwql/website/apps/jwql/data_containers.py
@@ -1491,6 +1491,18 @@ def get_image_info(file_root):
         filenames.extend(glob.glob(
             os.path.join(FILESYSTEM_DIR, 'proprietary', proposal_dir,
                     'L3', f'*/{ostr}/', f'{file_root}*.fits')))
+
+        # Second search, for whtlt and phot files, which are ecsv rather
+        # than fits. Can't search for *.escv though, because we don't want
+        # the source catalog files, which are *_cat.ecsv
+        ecsv_suffixes = ['whtlt', 'phot']
+        for ecsv_suffix in ecsv_suffixes:
+            filenames.extend(glob.glob(
+                os.path.join(FILESYSTEM_DIR, 'public', proposal_dir,
+                        'L3', f'*/{ostr}/', f'{file_root}*{ecsv_suffix}.ecsv')))
+            filenames.extend(glob.glob(
+                os.path.join(FILESYSTEM_DIR, 'proprietary', proposal_dir,
+                        'L3', f'*/{ostr}/', f'{file_root}*{ecsv_suffix}.ecsv')))
         image_info['level'] = 3
 
     logging.debug(f"Files before filtering: {filenames}")
@@ -1503,7 +1515,7 @@ def get_image_info(file_root):
 
     try:
         image_info['obsnum'] = fits.getheader(image_info['all_files'][0])['OBSERVTN']
-    except KeyError:
+    except (KeyError, OSError):
         image_info['obsnum'] = 'N/A'
 
     # Determine the jpg directory

--- a/jwql/website/apps/jwql/data_containers.py
+++ b/jwql/website/apps/jwql/data_containers.py
@@ -1587,7 +1587,7 @@ def get_image_info(file_root):
 
         # For crf or crfints suffixes, we need to also include the association value
         # in the suffix, so that preview images can be found later.
-        if suffix in SUFFIXES_TO_ADD_ASSOCIATION:
+        if ((image_info['level'] == 2) & (suffix in SUFFIXES_TO_ADD_ASSOCIATION)):
             assn = filename.split('_')[-2]
             suffix = f'{assn}_{suffix}'
 

--- a/jwql/website/apps/jwql/data_containers.py
+++ b/jwql/website/apps/jwql/data_containers.py
@@ -1501,6 +1501,11 @@ def get_image_info(file_root):
     logging.debug(f"Files after filtering: {filenames}")
     image_info['all_files'] = filenames
 
+    try:
+        image_info['obsnum'] = fits.getheader(image_info['all_files'][0])['OBSERVTN']
+    except KeyError:
+        image_info['obsnum'] = 'N/A'
+
     # Determine the jpg directory
     prev_img_filesys = configs['preview_image_filesystem']
     jpg_dir = os.path.join(prev_img_filesys, proposal_dir)

--- a/jwql/website/apps/jwql/data_containers.py
+++ b/jwql/website/apps/jwql/data_containers.py
@@ -1458,7 +1458,10 @@ def get_header_info_ecsv(filename, filetype):
     """
 
     # Initialize dictionary to store header information
-    header_info = {}
+    header_info = {0: {'EXTNAME': 'PRIMARY',
+                       'XTENSION': 'PRIMARY'
+                       }
+                   }
 
     # Open the file
     try:
@@ -1468,15 +1471,20 @@ def get_header_info_ecsv(filename, filetype):
         header_info = {}
         return header_info
 
-    header_info['PRIMARY'] = parse_meta_section_of_ecsv(fits_filepath)
+    metadata = parse_meta_section_of_ecsv(fits_filepath)
+
+    header_info[0]['keywords'] = [item for item in list(metadata.keys())]
+    header_info[0]['values'] = []
+    for key in header_info[0]['keywords']:
+        header_info[0]['values'].append(metadata[key])
 
     # Populate info needed for the webpage
     data_dict = {}
-    data_dict['Keyword'] = header_info['PRIMARY']['keywords']
-    data_dict['Value'] = header_info['PRIMARY']['values']
-    header_info['PRIMARY']['table'] = pd.DataFrame(data_dict)
-    header_info['PRIMARY']['table_rows'] = header_info['PRIMARY']['table'].values
-    header_info['PRIMARY']['table_columns'] = header_info['PRIMARY']['table'].columns.values
+    data_dict['Keyword'] = header_info[0]['keywords']
+    data_dict['Value'] = header_info[0]['values']
+    header_info[0]['table'] = pd.DataFrame(data_dict)
+    header_info[0]['table_rows'] = header_info[0]['table'].values
+    header_info[0]['table_columns'] = header_info[0]['table'].columns.values
     return header_info
 
 

--- a/jwql/website/apps/jwql/data_containers.py
+++ b/jwql/website/apps/jwql/data_containers.py
@@ -402,7 +402,9 @@ def get_additional_exposure_info(root_file_infos, image_info):
     # suffixes. The order of possible_suffixes_to_use is itentional, because the
     # uncal file will not have info on the pipeline version used, and so we would
     # rather grab information from the rate or cal files.
-    possible_suffixes_to_use = np.array(['rate', 'rateints', 'cal', 'calints', 'uncal'])
+    #possible_suffixes_to_use = np.array(['rate', 'rateints', 'cal', 'calints', 'uncal', 'i2d', 's3d', 's2d', 'x1d', 'crf'])
+    suffixes_to_ignore = set(['trapsfilled', 'msa', 'cat', 'segm', 'phot', 'whtlt'])
+    possible_suffixes_to_use = np.array([item for item in EXPOSURE_PAGE_SUFFIX_ORDER if item not in suffixes_to_ignore])
     existing_suffixes = np.array([suffix in image_info['suffixes'] for suffix in possible_suffixes_to_use])
 
     if isinstance(root_file_infos, QuerySet):

--- a/jwql/website/apps/jwql/data_containers.py
+++ b/jwql/website/apps/jwql/data_containers.py
@@ -1440,6 +1440,46 @@ def get_header_info(filename, filetype):
     return header_info
 
 
+def get_header_info_ecsv(filename, filetype):
+    """Return the header information for a given ecsv ``filename``.
+
+    Parameters
+    ----------
+    filename : str
+        The name of the file of interest, without the extension
+        (e.g. ``'jw86600008001_02101_00007_guider2_uncal'``).
+    filetype : str
+        The type of the file of interest, (e.g. ``'uncal'``)
+
+    Returns
+    -------
+    header_info : dict
+        The FITS headers of the extensions in the given ``file``.
+    """
+
+    # Initialize dictionary to store header information
+    header_info = {}
+
+    # Open the file
+    try:
+        fits_filepath = filesystem_path(filename, search=f'*_{filetype}.ecsv')
+    except FileNotFoundError as e:
+        #raise e
+        header_info = {}
+        return header_info
+
+    header_info['PRIMARY'] = parse_meta_section_of_ecsv(fits_filepath)
+
+    # Populate info needed for the webpage
+    data_dict = {}
+    data_dict['Keyword'] = header_info['PRIMARY']['keywords']
+    data_dict['Value'] = header_info['PRIMARY']['values']
+    header_info['PRIMARY']['table'] = pd.DataFrame(data_dict)
+    header_info['PRIMARY']['table_rows'] = header_info['PRIMARY']['table'].values
+    header_info['PRIMARY']['table_columns'] = header_info['PRIMARY']['table'].columns.values
+    return header_info
+
+
 def get_image_info(file_root):
     """Build and return a dictionary containing information for a given
     ``file_root``. Supports level 2 or level 3 file_root values.
@@ -2125,6 +2165,49 @@ def log_into_mast(request):
         return Mast.authenticated()
     else:
         return False
+
+
+def parse_meta_section_of_ecsv(filepath):
+    """Extract the meta section from a level 3 ecsv file (i.e. whtlt or phot)
+
+    Parameters
+    ----------
+    filepath : str
+        Name of the ecsv file to read in
+
+    Returns
+    -------
+    result : dict
+        Dictionary of metadata
+    """
+    result = {}
+    in_meta = False
+    pattern = r'\{(\w+):\s*([^}]+)\}'
+
+    with open(filepath, 'r') as f:
+        for line in f:
+            # Detect start of meta section
+            if line.strip() == '# meta: !!omap':
+                in_meta = True
+                continue
+
+            # Stop when we hit another top-level section or non-comment line
+            if in_meta:
+                if not line.startswith('#'):
+                    break
+                if re.match(r'^# \w+:', line) and 'meta' not in line:
+                    break
+
+            if in_meta:
+                match = re.search(pattern, line)
+                if match:
+                    key = match.group(1)
+                    value = match.group(2).strip()
+                    if value == 'null':
+                        value = None
+                    result[key] = value
+
+    return result
 
 
 def proposal_rootnames_by_instrument(proposal):

--- a/jwql/website/apps/jwql/data_containers.py
+++ b/jwql/website/apps/jwql/data_containers.py
@@ -1379,7 +1379,10 @@ def get_header_info(filename, filetype):
     try:
         fits_filepath = filesystem_path(filename, search=f'*_{filetype}.fits')
     except FileNotFoundError as e:
-        raise e
+        #raise e
+        header_info = {}
+        return header_info
+
     hdulist = fits.open(fits_filepath)
 
     # Extract header information from file

--- a/jwql/website/apps/jwql/data_containers.py
+++ b/jwql/website/apps/jwql/data_containers.py
@@ -1279,7 +1279,7 @@ def get_filesystem_filenames(proposal=None, rootname=None,
     if proposal is not None:
         proposal_string = '{:05d}'.format(int(proposal))
 
-        # Level 2 and 3
+        # Level 2 only. This "proposal" block is not currently used anywhere.
         filenames = glob.glob(
             os.path.join(FILESYSTEM_DIR, 'public',
                          'jw{}'.format(proposal_string), '*/*'))

--- a/jwql/website/apps/jwql/data_containers.py
+++ b/jwql/website/apps/jwql/data_containers.py
@@ -1278,21 +1278,37 @@ def get_filesystem_filenames(proposal=None, rootname=None,
     """
     if proposal is not None:
         proposal_string = '{:05d}'.format(int(proposal))
+
+        # Level 2 and 3
         filenames = glob.glob(
             os.path.join(FILESYSTEM_DIR, 'public',
                          'jw{}'.format(proposal_string), '*/*'))
         filenames.extend(glob.glob(
             os.path.join(FILESYSTEM_DIR, 'proprietary',
                          'jw{}'.format(proposal_string), '*/*')))
+
     elif rootname is not None:
         proposal_dir = rootname[0:7]
+
+        # Level 2 files
         observation_dir = rootname.split('_')[0]
         filenames = glob.glob(
             os.path.join(FILESYSTEM_DIR, 'public', proposal_dir,
-                         observation_dir, '{}*'.format(rootname)))
+                         observation_dir, f'{rootname}*'))
         filenames.extend(glob.glob(
             os.path.join(FILESYSTEM_DIR, 'proprietary', proposal_dir,
-                         observation_dir, '{}*'.format(rootname))))
+                         observation_dir, f'{rootname}*')))
+
+        # Level 3 files
+        if len(filenames) == 0:
+            ostr = rootname.split('-')[1].split('_')[0]
+            filenames = glob.glob(
+                os.path.join(FILESYSTEM_DIR, 'public', proposal_dir,
+                             'L3', f'*/{ostr}/', f'{rootname}*'))
+            filenames.extend(glob.glob(
+                os.path.join(FILESYSTEM_DIR, 'proprietary', proposal_dir,
+                             'L3', f'*/{ostr}/', f'{rootname}*')))
+
     else:
         logging.warning("Must provide either proposal or rootname; "
                         "no files returned.")
@@ -1451,6 +1467,7 @@ def get_image_info(file_root):
     image_info['available_ints'] = {}
     image_info['total_ints'] = {}
     image_info['detectors'] = set()
+    image_info['level'] = 2
 
     # Find all the matching files
     proposal_dir = file_root[:7]
@@ -1474,6 +1491,7 @@ def get_image_info(file_root):
         filenames.extend(glob.glob(
             os.path.join(FILESYSTEM_DIR, 'proprietary', proposal_dir,
                     'L3', f'*/{ostr}/', f'{file_root}*.fits')))
+        image_info['level'] = 3
 
     logging.debug(f"Files before filtering: {filenames}")
     # Certain suffixes are always ignored
@@ -1511,17 +1529,32 @@ def get_image_info(file_root):
         image_info['suffixes'].append(suffix)
 
         # Determine JPEG file location
+        # Level 2 files will end with "integ?.jpg", but level 3 files typically will not
         jpg_filename = os.path.basename(os.path.splitext(filename)[0] + '_integ0.jpg')
         jpg_filepath = os.path.join(jpg_dir, jpg_filename)
 
-        # Record how many integrations have been saved as preview images per filetype
-        jpgs = glob.glob(os.path.join(prev_img_filesys, proposal_dir, '{}*_{}_integ*.jpg'.format(file_root, suffix)))
-        image_info['available_ints'][suffix] = sorted(set([int(jpg.split('_')[-1].replace('.jpg', '').replace('integ', '')) for jpg in jpgs]))
-        image_info['num_ints'][suffix] = len(image_info['available_ints'][suffix])
-        image_info['all_jpegs'].append(jpg_filepath)
+        if os.path.isfile(jpg_filepath):
+            # Level 2 files
+            jpgs = glob.glob(os.path.join(prev_img_filesys, proposal_dir, f'{file_root}*_{suffix}_integ*.jpg'))
+
+            # Record how many integrations have been saved as preview images per filetype
+            image_info['available_ints'][suffix] = sorted(set([int(jpg.split('_')[-1].replace('.jpg', '').replace('integ', '')) for jpg in jpgs]))
+            image_info['num_ints'][suffix] = len(image_info['available_ints'][suffix])
+            image_info['all_jpegs'].append(jpg_filepath)
+        else:
+            # Level 3 files
+            jpg_filename = os.path.basename(os.path.splitext(filename)[0] + '.jpg')
+            jpg_filepath = os.path.join(jpg_dir, jpg_filename)
+
+            # Will there ever be more than one jpg for a level 3 file/suffix?
+            jpgs = glob.glob(os.path.join(prev_img_filesys, proposal_dir, f'{file_root}*_{suffix}*jpg'))
+
+            image_info['available_ints'][suffix] = ['N/A']
+            image_info['num_ints'][suffix] = len(image_info['available_ints'][suffix])
+            image_info['all_jpegs'].append(jpg_filepath)
 
         # Record how many integrations exist per filetype.
-        if suffix not in SUFFIXES_WITH_AVERAGED_INTS:
+        if ((suffix not in SUFFIXES_WITH_AVERAGED_INTS) and (image_info['available_ints'][suffix] != ['N/A'])):
             header = fits.getheader(filename)
             nint = header['NINTS']
             if 'time_series' in parsed_fn['filename_type']:
@@ -1745,6 +1778,7 @@ def get_detectors_by_rootname(rootname):
     -------
     detector_list : list
         A list of images that are part of the same exposure but with all detectors.
+        e.g. ['jw01068001001_02101_00001_nrca1', 'jw01068001001_02101_00001_nrca2']
     """
     detector_list = []
     search_rootname = rootname[:25]

--- a/jwql/website/apps/jwql/static/js/jwql.js
+++ b/jwql/website/apps/jwql/static/js/jwql.js
@@ -57,6 +57,7 @@ function handle_change(type, file_root, inst, f_paths, f_rl, n_ints, t_ints, idx
         document.getElementById("jpg_filename").innerHTML = file_root + '_' + type + '.jpg';
         document.getElementById("obs_id").innerHTML = obsnum;  - need to define obsnum
         document.getElementById("detector").innerHTML = 'N/A';
+    }
 
     document.getElementById("fits_filename").innerHTML = fits_filename + '.fits';
     document.getElementById("proposal").innerHTML = parsed_name.proposal;

--- a/jwql/website/apps/jwql/static/js/jwql.js
+++ b/jwql/website/apps/jwql/static/js/jwql.js
@@ -222,22 +222,22 @@ function set_view(view, inst, file_root_list, idx) {
         // Level 3 files
 
         // Update the filename lists
-        var filename_option = document.getElementById("level3_filename");   // WHAT DO WE CHANGE THIS TO?
+        var filename_option = document.getElementById("level3_filename");
         filename_option.value = inst + '/' + group_root + '_' + type;
         filename_option.textContent = group_root + '_' + type;
 
         // Show the appropriate image
-        var img = document.getElementById("image_viewer_level3");  // WHAT DO WE CHANGE THIS TO?
+        var img = document.getElementById("image_viewer_level3");
         var jpg_filepath = '/static/preview_images/' + parsed_name.program +
                         '/' + group_root + '_' + type + '.jpg';
         img.src = jpg_filepath;
         img.alt = jpg_filepath;
 
-        var main_link = document.getElementById("view_level3"); // WHAT DO WE CHANGE THIS TO?
+        var main_link = document.getElementById("view_level3");
         var new_url = base_url + "/" + inst + "/" + group_root + "?suffix=" + type;
         main_link.setAttribute('href', new_url);
 
-        var fallback_link = document.getElementById("view_level3_fallback");   // WHAT DO WE CHANGE THIS TO?
+        var fallback_link = document.getElementById("view_level3_fallback");
         var new_url = base_url + "/" + inst + "/" + group_root + "?suffix=" + type;
         fallback_link.setAttribute('href', new_url);
 

--- a/jwql/website/apps/jwql/static/js/jwql.js
+++ b/jwql/website/apps/jwql/static/js/jwql.js
@@ -778,6 +778,11 @@ function parse_filename(root_name) {
     var obs_id = root_name.slice(7, 10);
     var visit_id = root_name.slice(10, 13);
 
+    if (obs_id.includes('-')) {
+        obs_id = "N/A";
+        visit_id = "N/A";
+    }
+
     const parsed_name = {program: program, proposal: proposal,
                          obs_id: obs_id, visit_id: visit_id};
     return parsed_name;

--- a/jwql/website/apps/jwql/static/js/jwql.js
+++ b/jwql/website/apps/jwql/static/js/jwql.js
@@ -16,7 +16,7 @@
  * @param {String} file_root - The rootname of the file
  * @param {String} inst - The instrument for the given file
  */
-function handle_change(type, file_root, inst, f_paths, f_rl, n_ints, t_ints, idx) {
+function handle_change(type, file_root, inst, obsnumber, f_paths, f_rl, n_ints, t_ints, idx) {
     // Log the input values at the start of the function in case of anything breaking.
     console.log("Type: " + type);
     console.log("File Root: " + file_root);
@@ -50,17 +50,16 @@ function handle_change(type, file_root, inst, f_paths, f_rl, n_ints, t_ints, idx
     if (parsed_name.obs_id != 'N/A') {
         // Level 2 file
         document.getElementById("jpg_filename").innerHTML = file_root + '_' + type + '_integ0.jpg';
-        document.getElementById("obs_id").innerHTML = parsed_name.obs_id;
         document.getElementById("detector").innerHTML = file_root.split('_')[3];
     } else {
         // Level 3 file
         document.getElementById("jpg_filename").innerHTML = file_root + '_' + type + '.jpg';
-        document.getElementById("obs_id").innerHTML = obsnum;  - need to define obsnum
         document.getElementById("detector").innerHTML = 'N/A';
     }
 
     document.getElementById("fits_filename").innerHTML = fits_filename + '.fits';
     document.getElementById("proposal").innerHTML = parsed_name.proposal;
+    document.getElementById("obs_id").innerHTML = obsnumber;
     document.getElementById("visit_id").innerHTML = parsed_name.visit_id;
 
     // Add a link to download the file from MAST

--- a/jwql/website/apps/jwql/static/js/jwql.js
+++ b/jwql/website/apps/jwql/static/js/jwql.js
@@ -41,7 +41,7 @@ function handle_change(type, file_root, inst, f_paths, f_rl, n_ints, t_ints, idx
     var newURL = "https://jwqlquickview.stsci.edu?file=" + file_path;
     console.log("Frame loading: " + newURL);
     frame.contentWindow.location.replace(newURL);
-    
+
     document.getElementById(type).checked = true;
 
     // Store the currently displayed suffix
@@ -77,12 +77,12 @@ function handle_change(type, file_root, inst, f_paths, f_rl, n_ints, t_ints, idx
     // Update the image exploration and header links
     document.getElementById("view_header").href = '/' + inst + '/' + file_root + '_' + type + '/header/';
     document.getElementById("view_exposure").href = '/' + inst + '/exposure/' + exposure_str + "?suffix=" + type;
-    
+
     var preview_type = document.getElementById("view_preview_type").getAttribute("data-current-preview");
     console.log("Preview type: " + preview_type);
     var get_string = "?suffix=" + type + "&preview=" + preview_type;
     console.log("Get String: " + get_string);
-    
+
     var file_root_list = f_rl;
     var index = Number(idx);
     document.getElementById("prev_button").href = '/' + inst + '/' + file_root_list[index - 1] + get_string;
@@ -161,29 +161,65 @@ function set_view(view, inst, file_root_list, idx) {
     document.getElementById("proposal").innerHTML = parsed_name.proposal;
     document.getElementById("obs_id").innerHTML = parsed_name.obs_id;
     document.getElementById("visit_id").innerHTML = parsed_name.visit_id;
-    
+
     var detector_list = detectors.split(',');
-    for (let i = 0; i < detector_list.length; i++) {
-        var detector = detector_list[i];
+
+    // Level 3 files will have no detector defined. In that case, set
+    // detector to an empty string
+    //if (detector_list.includes("Unknown")) {
+    //    detector_list = [""];
+    //}
+
+    if (!detector_list.includes("Unknown")) {
+
+        // Level 2 files
+        for (let i = 0; i < detector_list.length; i++) {
+            var detector = detector_list[i];
+
+            // Update the filename lists
+            var filename_option = document.getElementById(detector + "_filename");
+            filename_option.value = inst + '/' + group_root + '_' + detector + '_' + type;
+            filename_option.textContent = group_root + '_' + detector + '_' + type;
+
+            // Show the appropriate image
+            var img = document.getElementById("image_viewer_" + detector);
+            var jpg_filepath = '/static/preview_images/' + parsed_name.program +
+                           '/' + group_root + '_' + detector + '_' + type + '_integ0.jpg';
+            img.src = jpg_filepath;
+            img.alt = jpg_filepath;
+
+            var main_link = document.getElementById("view_" + detector);
+            var new_url = base_url + "/" + inst + "/" + group_root + "_" + detector + "?suffix=" + type;
+            main_link.setAttribute('href', new_url);
+
+            var fallback_link = document.getElementById("view_" + detector + "_fallback");
+            var new_url = base_url + "/" + inst + "/" + group_root + "_" + detector + "?suffix=" + type;
+            fallback_link.setAttribute('href', new_url);
+
+            // Show/hide the viewer as appropriate
+            show_viewer(detector, jpg_filepath);
+        }
+    } else {
+        // Level 3 files
 
         // Update the filename lists
-        var filename_option = document.getElementById(detector + "_filename");
-        filename_option.value = inst + '/' + group_root + '_' + detector + '_' + type;
-        filename_option.textContent = group_root + '_' + detector + '_' + type;
+        var filename_option = document.getElementById("level3_filename");   // WHAT DO WE CHANGE THIS TO?
+        filename_option.value = inst + '/' + group_root + '_' + type;
+        filename_option.textContent = group_root + '_' + type;
 
         // Show the appropriate image
-        var img = document.getElementById("image_viewer_" + detector);
+        var img = document.getElementById("image_viewer_level3");  // WHAT DO WE CHANGE THIS TO?
         var jpg_filepath = '/static/preview_images/' + parsed_name.program +
-                           '/' + group_root + '_' + detector + '_' + type + '_integ0.jpg';
+                        '/' + group_root + '_' + type + '.jpg';
         img.src = jpg_filepath;
         img.alt = jpg_filepath;
-        
-        var main_link = document.getElementById("view_" + detector);
-        var new_url = base_url + "/" + inst + "/" + group_root + "_" + detector + "?suffix=" + type;
+
+        var main_link = document.getElementById("view_level3"); // WHAT DO WE CHANGE THIS TO?
+        var new_url = base_url + "/" + inst + "/" + group_root + "?suffix=" + type;
         main_link.setAttribute('href', new_url);
 
-        var fallback_link = document.getElementById("view_" + detector + "_fallback");
-        var new_url = base_url + "/" + inst + "/" + group_root + "_" + detector + "?suffix=" + type;
+        var fallback_link = document.getElementById("view_level3_fallback");   // WHAT DO WE CHANGE THIS TO?
+        var new_url = base_url + "/" + inst + "/" + group_root + "?suffix=" + type;
         fallback_link.setAttribute('href', new_url);
 
         // Show/hide the viewer as appropriate

--- a/jwql/website/apps/jwql/static/js/jwql.js
+++ b/jwql/website/apps/jwql/static/js/jwql.js
@@ -159,8 +159,8 @@ function set_view(view, inst, file_root_list, idx) {
     // Update the APT parameters
     var parsed_name = parse_filename(group_root);
     document.getElementById("proposal").innerHTML = parsed_name.proposal;
-    document.getElementById("obs_id").innerHTML = parsed_name.obs_id;
-    document.getElementById("visit_id").innerHTML = parsed_name.visit_id;
+    // document.getElementById("obs_id").innerHTML = parsed_name.obs_id;
+    // document.getElementById("visit_id").innerHTML = parsed_name.visit_id;
 
     var detector_list = detectors.split(',');
 

--- a/jwql/website/apps/jwql/static/js/jwql.js
+++ b/jwql/website/apps/jwql/static/js/jwql.js
@@ -66,7 +66,6 @@ function handle_change(type, file_root, inst, f_paths, f_rl, n_ints, t_ints, idx
         var exposure_str = file_root
     }
 
-    document.getElementById("fits_filename").innerHTML = fits_filename + '.fits';
     document.getElementById("proposal").innerHTML = parsed_name.proposal;
     document.getElementById("visit_id").innerHTML = parsed_name.visit_id;
 
@@ -76,6 +75,7 @@ function handle_change(type, file_root, inst, f_paths, f_rl, n_ints, t_ints, idx
     if (ecsv_types.includes(type)) {
         var filetype = ".ecsv"
     }
+    document.getElementById("fits_filename").innerHTML = fits_filename + filetype;
     document.getElementById("fits_filename").setAttribute('href',
         'https://mast.stsci.edu/api/v0.1/Download/file?uri=mast%3AJWST%2Fproduct%2F' +
         fits_filename + filetype);

--- a/jwql/website/apps/jwql/static/js/jwql.js
+++ b/jwql/website/apps/jwql/static/js/jwql.js
@@ -159,8 +159,7 @@ function set_view(view, inst, file_root_list, idx) {
     // Update the APT parameters
     var parsed_name = parse_filename(group_root);
     document.getElementById("proposal").innerHTML = parsed_name.proposal;
-    // document.getElementById("obs_id").innerHTML = parsed_name.obs_id;
-    // document.getElementById("visit_id").innerHTML = parsed_name.visit_id;
+    document.getElementById("visit_id").innerHTML = parsed_name.visit_id;
 
     var detector_list = detectors.split(',');
 

--- a/jwql/website/apps/jwql/static/js/jwql.js
+++ b/jwql/website/apps/jwql/static/js/jwql.js
@@ -196,7 +196,7 @@ function set_view(view, inst, file_root_list, idx) {
             // Show the appropriate image
             var img = document.getElementById("image_viewer_" + detector);
             var jpg_filepath = '/static/preview_images/' + parsed_name.program +
-                           '/' + group_root + '_' + detector + '_' + type + '_integ0.jpg';  ---- need to make an update like this with big ifelse block, around line 68.
+                           '/' + group_root + '_' + detector + '_' + type + '_integ0.jpg';
             img.src = jpg_filepath;
             img.alt = jpg_filepath;
 

--- a/jwql/website/apps/jwql/static/js/jwql.js
+++ b/jwql/website/apps/jwql/static/js/jwql.js
@@ -16,7 +16,7 @@
  * @param {String} file_root - The rootname of the file
  * @param {String} inst - The instrument for the given file
  */
-function handle_change(type, file_root, inst, obsnumber, f_paths, f_rl, n_ints, t_ints, idx) {
+function handle_change(type, file_root, inst, f_paths, f_rl, n_ints, t_ints, idx) {
     // Log the input values at the start of the function in case of anything breaking.
     console.log("Type: " + type);
     console.log("File Root: " + file_root);
@@ -59,7 +59,6 @@ function handle_change(type, file_root, inst, obsnumber, f_paths, f_rl, n_ints, 
 
     document.getElementById("fits_filename").innerHTML = fits_filename + '.fits';
     document.getElementById("proposal").innerHTML = parsed_name.proposal;
-    document.getElementById("obs_id").innerHTML = obsnumber;
     document.getElementById("visit_id").innerHTML = parsed_name.visit_id;
 
     // Add a link to download the file from MAST
@@ -67,6 +66,7 @@ function handle_change(type, file_root, inst, obsnumber, f_paths, f_rl, n_ints, 
     var ecsv_types = ["whtlt", "phot", "cat"]
     if (ecsv_types.includes(type)) {
         var filetype = ".ecsv"
+    }
     document.getElementById("fits_filename").setAttribute('href',
         'https://mast.stsci.edu/api/v0.1/Download/file?uri=mast%3AJWST%2Fproduct%2F' +
         fits_filename + filetype);
@@ -82,6 +82,9 @@ function handle_change(type, file_root, inst, obsnumber, f_paths, f_rl, n_ints, 
     } else {
         var jpg_filepath = '/static/preview_images/' + parsed_name.program + '/' + file_root + '_' + type + '.jpg';
     }
+
+    console.log("jpg_filepath: " + jpg_filepath);
+
     img.src = jpg_filepath;
     img.alt = jpg_filepath;
     // if previous image had error, remove error sizing

--- a/jwql/website/apps/jwql/static/js/jwql.js
+++ b/jwql/website/apps/jwql/static/js/jwql.js
@@ -51,10 +51,19 @@ function handle_change(type, file_root, inst, f_paths, f_rl, n_ints, t_ints, idx
         // Level 2 file
         document.getElementById("jpg_filename").innerHTML = file_root + '_' + type + '_integ0.jpg';
         document.getElementById("detector").innerHTML = file_root.split('_')[3];
+
+        // Get the exposure-level string for the "View Exposure" button
+        var exposure_array = file_root.split("_");
+        exposure_array.pop();
+        var exposure_str = exposure_array.join("_");
+
     } else {
         // Level 3 file
         document.getElementById("jpg_filename").innerHTML = file_root + '_' + type + '.jpg';
         document.getElementById("detector").innerHTML = 'N/A';
+
+        // Get the exposure-level string for the "View Exposure" button
+        var exposure_str = file_root
     }
 
     document.getElementById("fits_filename").innerHTML = fits_filename + '.fits';
@@ -70,10 +79,6 @@ function handle_change(type, file_root, inst, f_paths, f_rl, n_ints, t_ints, idx
     document.getElementById("fits_filename").setAttribute('href',
         'https://mast.stsci.edu/api/v0.1/Download/file?uri=mast%3AJWST%2Fproduct%2F' +
         fits_filename + filetype);
-
-    var exposure_array = file_root.split("_");
-    exposure_array.pop();
-    var exposure_str = exposure_array.join("_");
 
     // Show the appropriate image
     var img = document.getElementById("image_viewer");

--- a/jwql/website/apps/jwql/static/js/jwql.js
+++ b/jwql/website/apps/jwql/static/js/jwql.js
@@ -166,10 +166,6 @@ function set_view(view, inst, file_root_list, idx) {
 
     // Level 3 files will have no detector defined. In that case, set
     // detector to an empty string
-    //if (detector_list.includes("Unknown")) {
-    //    detector_list = [""];
-    //}
-
     if (!detector_list.includes("Unknown")) {
 
         // Level 2 files
@@ -223,7 +219,7 @@ function set_view(view, inst, file_root_list, idx) {
         fallback_link.setAttribute('href', new_url);
 
         // Show/hide the viewer as appropriate
-        show_viewer(detector, jpg_filepath);
+        show_viewer("level3", jpg_filepath);
     }
 
     // Reset the slider values

--- a/jwql/website/apps/jwql/static/js/jwql.js
+++ b/jwql/website/apps/jwql/static/js/jwql.js
@@ -47,17 +47,29 @@ function handle_change(type, file_root, inst, f_paths, f_rl, n_ints, t_ints, idx
     // Store the currently displayed suffix
     document.getElementById("view_file_type").setAttribute('data-current-suffix', type);
 
-    document.getElementById("jpg_filename").innerHTML = file_root + '_' + type + '_integ0.jpg';
+    if (parsed_name.obs_id != 'N/A') {
+        // Level 2 file
+        document.getElementById("jpg_filename").innerHTML = file_root + '_' + type + '_integ0.jpg';
+        document.getElementById("obs_id").innerHTML = parsed_name.obs_id;
+        document.getElementById("detector").innerHTML = file_root.split('_')[3];
+    } else {
+        // Level 3 file
+        document.getElementById("jpg_filename").innerHTML = file_root + '_' + type + '.jpg';
+        document.getElementById("obs_id").innerHTML = obsnum;  - need to define obsnum
+        document.getElementById("detector").innerHTML = 'N/A';
+
     document.getElementById("fits_filename").innerHTML = fits_filename + '.fits';
     document.getElementById("proposal").innerHTML = parsed_name.proposal;
-    document.getElementById("obs_id").innerHTML = parsed_name.obs_id;
     document.getElementById("visit_id").innerHTML = parsed_name.visit_id;
-    document.getElementById("detector").innerHTML = file_root.split('_')[3];
 
     // Add a link to download the file from MAST
+    var filetype = ".fits"
+    var ecsv_types = ["whtlt", "phot", "cat"]
+    if (ecsv_types.includes(type)) {
+        var filetype = ".ecsv"
     document.getElementById("fits_filename").setAttribute('href',
         'https://mast.stsci.edu/api/v0.1/Download/file?uri=mast%3AJWST%2Fproduct%2F' +
-        fits_filename + '.fits');
+        fits_filename + filetype);
 
     var exposure_array = file_root.split("_");
     exposure_array.pop();
@@ -65,7 +77,11 @@ function handle_change(type, file_root, inst, f_paths, f_rl, n_ints, t_ints, idx
 
     // Show the appropriate image
     var img = document.getElementById("image_viewer");
-    var jpg_filepath = '/static/preview_images/' + parsed_name.program + '/' + file_root + '_' + type + '_integ0.jpg';
+    if (parsed_name.obs_id != 'N/A') {
+        var jpg_filepath = '/static/preview_images/' + parsed_name.program + '/' + file_root + '_' + type + '_integ0.jpg';
+    } else {
+        var jpg_filepath = '/static/preview_images/' + parsed_name.program + '/' + file_root + '_' + type + '.jpg';
+    }
     img.src = jpg_filepath;
     img.alt = jpg_filepath;
     // if previous image had error, remove error sizing
@@ -179,7 +195,7 @@ function set_view(view, inst, file_root_list, idx) {
             // Show the appropriate image
             var img = document.getElementById("image_viewer_" + detector);
             var jpg_filepath = '/static/preview_images/' + parsed_name.program +
-                           '/' + group_root + '_' + detector + '_' + type + '_integ0.jpg';
+                           '/' + group_root + '_' + detector + '_' + type + '_integ0.jpg';  ---- need to make an update like this with big ifelse block, around line 68.
             img.src = jpg_filepath;
             img.alt = jpg_filepath;
 

--- a/jwql/website/apps/jwql/templates/view_exposure.html
+++ b/jwql/website/apps/jwql/templates/view_exposure.html
@@ -297,12 +297,10 @@
             <script>update_viewed_button(false, true)</script>
         {% endif %}
         <!-- Determine which filetype should be shown on load -->
-        {% set loaded = namespace(found=false) %}
         {% if (initial_suffix|length > 0) and (initial_suffix in suffixes) %}
             <script>change_all_filetypes('{{initial_suffix}}', '{{group_root}}', '{{num_ints}}', '{{available_ints}}', '{{total_ints}}', '{{inst}}', "{{ detectors|join(',') }}", '{{base_url}}');</script>
         {% elif suffixes|length == 1 %}
             <script>change_all_filetypes('{{suffixes.0}}', '{{group_root}}', '{{num_ints}}', "{{available_ints}}", "{{total_ints}}", '{{inst}}', "{{ detectors|join(',') }}", '{{base_url}}');</script>
-            {% set loaded.found = true %}
         {% else %}
             <a>Unable to show image for: {{suffixes}}</a>
         {% endif %}

--- a/jwql/website/apps/jwql/templates/view_exposure.html
+++ b/jwql/website/apps/jwql/templates/view_exposure.html
@@ -299,12 +299,28 @@
         <!-- Determine which filetype should be shown on load -->
         {% if (initial_suffix|length > 0) and (initial_suffix in suffixes) %}
             <script>change_all_filetypes('{{initial_suffix}}', '{{group_root}}', '{{num_ints}}', '{{available_ints}}', '{{total_ints}}', '{{inst}}', "{{ detectors|join(',') }}", '{{base_url}}');</script>
+
+        {% set preferred_suffixes = ["rate", "dark", "uncal", "i2d", "c1d", "x1d", "s3d", "s2d", "whtlt", "phot", "psfsub", "psfstack", "ami", "aminorm", "cal"] %}
+        {% set ns = namespace(found=false) %}
+        {% for suffix in preferred_suffixes %}
+            {% if suffix in suffixes and not ns.found %}
+                {% set ns.found = true %}
+                <script>change_all_filetypes(suffix, '{{group_root}}', '{{num_ints}}', '{{available_ints}}', '{{total_ints}}', '{{inst}}', "{{ detectors|join(',') }}", '{{base_url}}');</script>
+            {% endif %}
+        {% endfor %}
+
+        <!--
         {% elif 'rate' in suffixes %}
             <script>change_all_filetypes('rate', '{{group_root}}', '{{num_ints}}', '{{available_ints}}', '{{total_ints}}', '{{inst}}', "{{ detectors|join(',') }}", '{{base_url}}');</script>
         {% elif 'dark' in suffixes %}
             <script>change_all_filetypes('dark', '{{group_root}}', '{{num_ints}}', "{{available_ints}}", "{{total_ints}}", '{{inst}}', "{{ detectors|join(',') }}", '{{base_url}}');</script>
         {% elif 'uncal' in suffixes %}
             <script>change_all_filetypes('uncal', '{{group_root}}', '{{num_ints}}', "{{available_ints}}", "{{total_ints}}", '{{inst}}', "{{ detectors|join(',') }}", '{{base_url}}');</script>
+        -->
+
+
+
+
         {% elif suffixes|length == 1 %}
             <script>change_all_filetypes('{{suffixes.0}}', '{{group_root}}', '{{num_ints}}', "{{available_ints}}", "{{total_ints}}", '{{inst}}', "{{ detectors|join(',') }}", '{{base_url}}');</script>
         {% else %}

--- a/jwql/website/apps/jwql/templates/view_exposure.html
+++ b/jwql/website/apps/jwql/templates/view_exposure.html
@@ -302,7 +302,7 @@
             <script>change_all_filetypes('{{initial_suffix}}', '{{group_root}}', '{{num_ints}}', '{{available_ints}}', '{{total_ints}}', '{{inst}}', "{{ detectors|join(',') }}", '{{base_url}}');</script>
         {% elif suffixes|length == 1 %}
             <script>change_all_filetypes('{{suffixes.0}}', '{{group_root}}', '{{num_ints}}', "{{available_ints}}", "{{total_ints}}", '{{inst}}', "{{ detectors|join(',') }}", '{{base_url}}');</script>
-            {% set found.found = true %}
+            {% set loaded.found = true %}
         {% else %}
             <a>Unable to show image for: {{suffixes}}</a>
         {% endif %}

--- a/jwql/website/apps/jwql/templates/view_exposure.html
+++ b/jwql/website/apps/jwql/templates/view_exposure.html
@@ -14,8 +14,8 @@
 
         <!-- Specify the attributes of what is currently being shown -->
         <div class="d-flex flex-row">
-            <div class="APT_parameters">Proposal: {{ prop_id }}<a id="proposal" href="{{ url('jwql:archive_thumb_per_obs', args=[inst, prop_id, obsnum]) }}"></a></div>
-            <div class="APT_parameters">Observation: {{ obsnum }}<a id="obs_id"></a></div>
+            <div class="APT_parameters">Proposal: <a id="proposal" href="{{ url('jwql:archive_thumb_per_obs', args=[inst, prop_id, obsnum]) }}"></a></div>
+            <div class="APT_parameters">Observation: <a id="obs_id"></a></div>
             <div class="APT_parameters">Visit: <a id="visit_id"></a></div>
             <div class="APT_parameters"> <a></a></div>
             <input class="btn btn-primary" id="viewed" value=" " type="button" onclick='toggle_viewed_group("{{group_root}}", "{{base_url}}");'>
@@ -297,33 +297,27 @@
             <script>update_viewed_button(false, true)</script>
         {% endif %}
         <!-- Determine which filetype should be shown on load -->
+        {% set loaded = namespace(found=false) %}
         {% if (initial_suffix|length > 0) and (initial_suffix in suffixes) %}
             <script>change_all_filetypes('{{initial_suffix}}', '{{group_root}}', '{{num_ints}}', '{{available_ints}}', '{{total_ints}}', '{{inst}}', "{{ detectors|join(',') }}", '{{base_url}}');</script>
+            {% set found.found = true %}
 
-        {% set preferred_suffixes = ["rate", "dark", "uncal", "i2d", "c1d", "x1d", "s3d", "s2d", "whtlt", "phot", "psfsub", "psfstack", "ami", "aminorm", "cal"] %}
-        {% set ns = namespace(found=false) %}
-        {% for suffix in preferred_suffixes %}
-            {% if suffix in suffixes and not ns.found %}
-                {% set ns.found = true %}
-                <script>change_all_filetypes(suffix, '{{group_root}}', '{{num_ints}}', '{{available_ints}}', '{{total_ints}}', '{{inst}}', "{{ detectors|join(',') }}", '{{base_url}}');</script>
-                <h3>Found {{ suffix }}</h3>
-            {% endif %}
-        {% endfor %}
+        {% elif initial_suffix|length == 0 %}
 
-        <!--
-        {% elif 'rate' in suffixes %}
-            <script>change_all_filetypes('rate', '{{group_root}}', '{{num_ints}}', '{{available_ints}}', '{{total_ints}}', '{{inst}}', "{{ detectors|join(',') }}", '{{base_url}}');</script>
-        {% elif 'dark' in suffixes %}
-            <script>change_all_filetypes('dark', '{{group_root}}', '{{num_ints}}', "{{available_ints}}", "{{total_ints}}", '{{inst}}', "{{ detectors|join(',') }}", '{{base_url}}');</script>
-        {% elif 'uncal' in suffixes %}
-            <script>change_all_filetypes('uncal', '{{group_root}}', '{{num_ints}}', "{{available_ints}}", "{{total_ints}}", '{{inst}}', "{{ detectors|join(',') }}", '{{base_url}}');</script>
-        -->
+            {% set preferred_suffixes = ["rate", "dark", "uncal", "i2d", "c1d", "x1d", "s3d", "s2d", "whtlt", "phot", "psfsub", "psfstack", "ami", "aminorm", "cal"] %}
+            {% set ns = namespace(found=false) %}
+            {% for suffix in preferred_suffixes %}
+                {% if suffix in suffixes and not ns.found %}
+                    {% set ns.found = true %}
+                    {% set found.found = true %}
+                    <script>change_all_filetypes(suffix, '{{group_root}}', '{{num_ints}}', '{{available_ints}}', '{{total_ints}}', '{{inst}}', "{{ detectors|join(',') }}", '{{base_url}}');</script>
+                    <h3>Found {{ suffix }}</h3>
+                {% endif %}
+            {% endfor %}
 
-
-
-
-        {% elif suffixes|length == 1 %}
+        {% elif suffixes|length == 1 and not found.found %}
             <script>change_all_filetypes('{{suffixes.0}}', '{{group_root}}', '{{num_ints}}', "{{available_ints}}", "{{total_ints}}", '{{inst}}', "{{ detectors|join(',') }}", '{{base_url}}');</script>
+            {% set found.found = true %}
         {% else %}
             <a>Unable to show image for: {{suffixes}}</a>
         {% endif %}

--- a/jwql/website/apps/jwql/templates/view_exposure.html
+++ b/jwql/website/apps/jwql/templates/view_exposure.html
@@ -15,7 +15,7 @@
         <!-- Specify the attributes of what is currently being shown -->
         <div class="d-flex flex-row">
             <div class="APT_parameters">Proposal: <a id="proposal" href="{{ url('jwql:archive_thumb_per_obs', args=[inst, prop_id, obsnum]) }}"></a></div>
-            <div class="APT_parameters">Observation: <a id="obs_id"></a></div>
+            <div class="APT_parameters">Observation: {{ obsnum }}</div>
             <div class="APT_parameters">Visit: <a id="visit_id"></a></div>
             <div class="APT_parameters"> <a></a></div>
             <input class="btn btn-primary" id="viewed" value=" " type="button" onclick='toggle_viewed_group("{{group_root}}", "{{base_url}}");'>

--- a/jwql/website/apps/jwql/templates/view_exposure.html
+++ b/jwql/website/apps/jwql/templates/view_exposure.html
@@ -92,7 +92,11 @@
             <div class="mx-2 my-2">for</div>
             <select name="fits_file_select" id="fits_file_select" onchange="update_view_explore_link();">
                 {% for detector in detectors %}
-                    <option id="{{ detector }}_filename" value="{{ inst }}/{{ group_root }}_{{ detector }}">{{ group_root }}_{{ detector }}</option>
+                    {% if detector == "Unknown" %}
+                        <option id="level3_filename" value="{{ inst }}/{{ group_root }}">{{ group_root }}</option>
+                    {% else %}
+                        <option id="{{ detector }}_filename" value="{{ inst }}/{{ group_root }}_{{ detector }}">{{ group_root }}_{{ detector }}</option>
+                    {% endif %}
                 {% endfor %}
             </select>
         </div>
@@ -108,7 +112,7 @@
                 </div>
             </div>
         </div>
-        {% if inst == 'NIRCam' %}
+        {% if inst == 'NIRCam' and "Unknown" not in detectors%}
         <div class="row">
             <!-- Display NIRCam short detectors in columns, 1st row -->
                 {% for detector1 in ['nrca2', 'nrca4', 'nrcb3', 'nrcb1'] %}
@@ -187,7 +191,7 @@
                     {% endif %}
                 {% endfor %}
         </div>
-        {% else %}
+        {% elif inst != 'NIRCam' and "Unknown" not in detectors %}
         <div class="row">
             <!-- Display non-NIRCam detectors in columns -->
                 {% for detector in detectors %}
@@ -211,6 +215,27 @@
                         </span>
                     </div>
                 {% endfor %}
+        </div>
+        {% else %}  <!-- Level 3 File Support here. In this case detectors will be a single element: "Unknown" -->
+        <div class="row">
+            <div class="col" id="level3_view">
+                <span class="image_preview">
+                    <a id="view_level3" href="{{ base_url }}/{{ inst }}/{{ group_root }}/">
+                        <img class="image_preview_viewer" id="image_viewer_level3"
+                             title="Preview image for {{ group_root }}"
+                             style="width:100%">
+                    </a>
+                </span>
+            </div>
+            <div class="col" id="level3_view_fallback">
+                <span class="image_preview">
+                    <a id="view_level3_fallback" href="{{ base_url }}/{{ inst }}/{{ group_root }}/">
+                        <img class="image_preview_viewer thumbnail" id="fallback_image_viewer_level3"
+                             title="Preview image for {{ group_root }}"
+                             src="/static/img/imagenotfound.png" alt="Preview image not found">
+                    </a>
+                </span>
+            </div>
         </div>
         {% endif %}
 

--- a/jwql/website/apps/jwql/templates/view_exposure.html
+++ b/jwql/website/apps/jwql/templates/view_exposure.html
@@ -14,8 +14,8 @@
 
         <!-- Specify the attributes of what is currently being shown -->
         <div class="d-flex flex-row">
-            <div class="APT_parameters">Proposal: <a id="proposal" href="{{ url('jwql:archive_thumb_per_obs', args=[inst, prop_id, obsnum]) }}"></a></div>
-            <div class="APT_parameters">Observation: <a id="obs_id"></a></div>
+            <div class="APT_parameters">Proposal: {{ prop_id }}<a id="proposal" href="{{ url('jwql:archive_thumb_per_obs', args=[inst, prop_id, obsnum]) }}"></a></div>
+            <div class="APT_parameters">Observation: {{ obsnum }}<a id="obs_id"></a></div>
             <div class="APT_parameters">Visit: <a id="visit_id"></a></div>
             <div class="APT_parameters"> <a></a></div>
             <input class="btn btn-primary" id="viewed" value=" " type="button" onclick='toggle_viewed_group("{{group_root}}", "{{base_url}}");'>
@@ -306,6 +306,7 @@
             {% if suffix in suffixes and not ns.found %}
                 {% set ns.found = true %}
                 <script>change_all_filetypes(suffix, '{{group_root}}', '{{num_ints}}', '{{available_ints}}', '{{total_ints}}', '{{inst}}', "{{ detectors|join(',') }}", '{{base_url}}');</script>
+                <h3>Found {{ suffix }}</h3>
             {% endif %}
         {% endfor %}
 

--- a/jwql/website/apps/jwql/templates/view_exposure.html
+++ b/jwql/website/apps/jwql/templates/view_exposure.html
@@ -10,7 +10,7 @@
 
     <main role="main" class="image_views">
     	<!-- Show exposure group name -->
-    	<h3>Exposure {{ group_root }}</h3>
+    	<h3>Exposure {{ group_root|lower }}</h3>
 
         <!-- Specify the attributes of what is currently being shown -->
         <div class="d-flex flex-row">

--- a/jwql/website/apps/jwql/templates/view_exposure.html
+++ b/jwql/website/apps/jwql/templates/view_exposure.html
@@ -300,22 +300,7 @@
         {% set loaded = namespace(found=false) %}
         {% if (initial_suffix|length > 0) and (initial_suffix in suffixes) %}
             <script>change_all_filetypes('{{initial_suffix}}', '{{group_root}}', '{{num_ints}}', '{{available_ints}}', '{{total_ints}}', '{{inst}}', "{{ detectors|join(',') }}", '{{base_url}}');</script>
-            {% set found.found = true %}
-
-        {% elif initial_suffix|length == 0 %}
-
-            {% set preferred_suffixes = ["rate", "dark", "uncal", "i2d", "c1d", "x1d", "s3d", "s2d", "whtlt", "phot", "psfsub", "psfstack", "ami", "aminorm", "cal"] %}
-            {% set ns = namespace(found=false) %}
-            {% for suffix in preferred_suffixes %}
-                {% if suffix in suffixes and not ns.found %}
-                    {% set ns.found = true %}
-                    {% set found.found = true %}
-                    <script>change_all_filetypes(suffix, '{{group_root}}', '{{num_ints}}', '{{available_ints}}', '{{total_ints}}', '{{inst}}', "{{ detectors|join(',') }}", '{{base_url}}');</script>
-                    <h3>Found {{ suffix }}</h3>
-                {% endif %}
-            {% endfor %}
-
-        {% elif suffixes|length == 1 and not found.found %}
+        {% elif suffixes|length == 1 %}
             <script>change_all_filetypes('{{suffixes.0}}', '{{group_root}}', '{{num_ints}}', "{{available_ints}}", "{{total_ints}}", '{{inst}}', "{{ detectors|join(',') }}", '{{base_url}}');</script>
             {% set found.found = true %}
         {% else %}

--- a/jwql/website/apps/jwql/templates/view_header.html
+++ b/jwql/website/apps/jwql/templates/view_header.html
@@ -13,7 +13,7 @@
 
     	<p>
             <a class="btn btn-primary my-2 mx-2" role="button" href="/{{inst}}/{{file_root}}?suffix={{file_type}}">View Image</a>
-            <a class="btn btn-primary my-2 mx-2" role="button" href={{ url('jwql:archive_thumb_per_obs', args=[inst, file_root[2:7], file_root[7:10]]) }}> View Proposal</a>
+            <a class="btn btn-primary my-2 mx-2" role="button" href={{ url('jwql:archive_thumb_per_obs', args=[inst, file_root[2:7], obsnum) }}> View Proposal</a>
 	    </p>
 
         <!-- Allow the user to change the header type that is being displayed -->

--- a/jwql/website/apps/jwql/templates/view_header.html
+++ b/jwql/website/apps/jwql/templates/view_header.html
@@ -13,7 +13,7 @@
 
     	<p>
             <a class="btn btn-primary my-2 mx-2" role="button" href="/{{inst}}/{{file_root}}?suffix={{file_type}}">View Image</a>
-            <a class="btn btn-primary my-2 mx-2" role="button" href={{ url('jwql:archive_thumb_per_obs', args=[inst, file_root[2:7], obsnum) }}> View Proposal</a>
+            <a class="btn btn-primary my-2 mx-2" role="button" href={{ url('jwql:archive_thumb_per_obs', args=[inst, file_root[2:7], obsnum]) }}> View Proposal</a>
 	    </p>
 
         <!-- Allow the user to change the header type that is being displayed -->

--- a/jwql/website/apps/jwql/templates/view_image.html
+++ b/jwql/website/apps/jwql/templates/view_image.html
@@ -15,7 +15,7 @@
     	<!-- Specify the attributes of what is currently being shown -->
         <div class="d-flex flex-row">
     		<div class="APT_parameters">Proposal: <a id="proposal" href="{{ url('jwql:archive_thumb_per_obs', args=[inst, prop_id, obsnum]) }}"></a></div>
-    		<div class="APT_parameters">Observation: <a id="obs_id"></a></div>
+    		<div class="APT_parameters">Observation: {{ obsnum }}</div>
     		<div class="APT_parameters">Visit: <a id="visit_id"></a></div>
     		<div class="APT_parameters">Detector: <a id="detector"></a></div>
             <input class="btn btn-primary" id="viewed" value=" " type="button" onclick='toggle_viewed("{{file_root}}", "{{base_url}}");'>
@@ -102,12 +102,14 @@
                              title="Preview image for {{ file_root }}" width=1000rem height=auto>
     		        </span>
 
-                    <div class="int_changer">
-                        <button id="int_before" class="btn btn-primary mx-2" role="button" onclick='change_integration("{{file_root}}", "{{num_ints}}", "{{available_ints}}", "button", "left");' disabled>&#9664;</button>
-                        <input type="range" min="1" max="5" value="1" class="slider" id="slider_range" onchange='change_integration("{{file_root}}", "{{num_ints}}",  "{{available_ints}}", "slider")'>
-                        <button id="int_after" class="btn btn-primary mx-2" role="button" onclick='change_integration("{{file_root}}", "{{num_ints}}",  "{{available_ints}}", "button", "right");' disabled>&#9658;</button>
-                        <p>Integration: <span id="slider_val"></span>/<span id="total_ints"></span></p>
-                    </div>
+                    { if available_ints != 'N/A' }
+                        <div class="int_changer">
+                            <button id="int_before" class="btn btn-primary mx-2" role="button" onclick='change_integration("{{file_root}}", "{{num_ints}}", "{{available_ints}}", "button", "left");' disabled>&#9664;</button>
+                            <input type="range" min="1" max="5" value="1" class="slider" id="slider_range" onchange='change_integration("{{file_root}}", "{{num_ints}}",  "{{available_ints}}", "slider")'>
+                            <button id="int_after" class="btn btn-primary mx-2" role="button" onclick='change_integration("{{file_root}}", "{{num_ints}}",  "{{available_ints}}", "button", "right");' disabled>&#9658;</button>
+                            <p>Integration: <span id="slider_val"></span>/<span id="total_ints"></span></p>
+                        </div>
+                    {% endif %}
                 </div>
 
                 <!-- Display the Previous/Next buttons -->
@@ -172,6 +174,22 @@
             <script>update_viewed_button(false)</script>
         {% endif %}
         <!-- Determine which filetype should be shown on load -->
+        {% set loaded = namespace(found=false) %}
+        {% if (initial_suffix|length > 0) and (initial_suffix in suffixes) %}
+            <script>handle_change('{{ initial_suffix }}', '{{file_root}}', '{{inst}}', {{file_paths | tojson | safe}}, {{file_root_list | tojson | safe}}, '{{num_ints}}', '{{total_ints}}', "{{index}}");</script>
+        {% elif suffixes|length == 1 %}
+            <script>handle_change('{{suffixes.0}}', '{{file_root}}', '{{inst}}', {{file_paths | tojson | safe}}, {{file_root_list | tojson | safe}}, '{{num_ints}}', '{{total_ints}}', "{{index}}");</script>
+            {% set found.found = true %}
+        {% else %}
+            <a>Unable to show image for: {{suffixes}}</a>
+        {% endif %}
+
+
+
+
+
+
+        <!--
         {% if (initial_suffix|length > 0) and (initial_suffix in file_paths) %}
             <script>handle_change('{{ initial_suffix }}', '{{file_root}}', '{{inst}}', {{file_paths | tojson | safe}}, {{file_root_list | tojson | safe}}, '{{num_ints}}', '{{total_ints}}', "{{index}}");</script>
         {% elif 'rate' in suffixes %}
@@ -185,6 +203,11 @@
         {% else %}
             <a>Unable to show image for: {{suffixes}}</a>
         {% endif %}
+        -->
+
+
+
+
         <!-- Determine which preview should be shown on load -->
         {% if (initial_preview|length > 0) %}
             <script>set_view("{{ initial_preview }}", '{{inst}}', {{file_root_list | tojson | safe}}, '{{index}}');</script>

--- a/jwql/website/apps/jwql/templates/view_image.html
+++ b/jwql/website/apps/jwql/templates/view_image.html
@@ -102,7 +102,7 @@
                              title="Preview image for {{ file_root }}" width=1000rem height=auto>
     		        </span>
 
-                    { if available_ints != 'N/A' }
+                    {% if available_ints != 'N/A' %}
                         <div class="int_changer">
                             <button id="int_before" class="btn btn-primary mx-2" role="button" onclick='change_integration("{{file_root}}", "{{num_ints}}", "{{available_ints}}", "button", "left");' disabled>&#9664;</button>
                             <input type="range" min="1" max="5" value="1" class="slider" id="slider_range" onchange='change_integration("{{file_root}}", "{{num_ints}}",  "{{available_ints}}", "slider")'>

--- a/jwql/website/apps/jwql/templates/view_image.html
+++ b/jwql/website/apps/jwql/templates/view_image.html
@@ -65,7 +65,7 @@
 	    </a><br>
 	    <form class="my-2">
 	    	{% for suffix in suffixes %}
-	    		<input type="radio" name="filetype" value="{{ suffix }}" id="{{ suffix }}" onclick='handle_change("{{suffix}}", "{{file_root}}", "{{inst}}", {{file_paths | tojson | safe}}, {{file_root_list | tojson | safe}}, "{{num_ints}}", "{{total_ints}}", "{{index}}");'> {{ suffix }} &nbsp;&nbsp;&nbsp;&nbsp;
+	    		<input type="radio" name="filetype" value="{{ suffix }}" id="{{ suffix }}" onclick='handle_change("{{suffix}}", "{{file_root}}", "{{inst}}", "{{obsnum}}", {{file_paths | tojson | safe}}, {{file_root_list | tojson | safe}}, "{{num_ints}}", "{{total_ints}}", "{{index}}");'> {{ suffix }} &nbsp;&nbsp;&nbsp;&nbsp;
 	    	{% endfor %}
 		</form>
 		<br>
@@ -176,9 +176,9 @@
         <!-- Determine which filetype should be shown on load -->
         {% set loaded = namespace(found=false) %}
         {% if (initial_suffix|length > 0) and (initial_suffix in suffixes) %}
-            <script>handle_change('{{ initial_suffix }}', '{{file_root}}', '{{inst}}', {{file_paths | tojson | safe}}, {{file_root_list | tojson | safe}}, '{{num_ints}}', '{{total_ints}}', "{{index}}");</script>
+            <script>handle_change('{{ initial_suffix }}', '{{file_root}}', '{{inst}}, "{{obsnum}}"', {{file_paths | tojson | safe}}, {{file_root_list | tojson | safe}}, '{{num_ints}}', '{{total_ints}}', "{{index}}");</script>
         {% elif suffixes|length == 1 %}
-            <script>handle_change('{{suffixes.0}}', '{{file_root}}', '{{inst}}', {{file_paths | tojson | safe}}, {{file_root_list | tojson | safe}}, '{{num_ints}}', '{{total_ints}}', "{{index}}");</script>
+            <script>handle_change('{{suffixes.0}}', '{{file_root}}', '{{inst}}', "{{obsnum}}", {{file_paths | tojson | safe}}, {{file_root_list | tojson | safe}}, '{{num_ints}}', '{{total_ints}}', "{{index}}");</script>
             {% set found.found = true %}
         {% else %}
             <a>Unable to show image for: {{suffixes}}</a>

--- a/jwql/website/apps/jwql/templates/view_image.html
+++ b/jwql/website/apps/jwql/templates/view_image.html
@@ -179,7 +179,7 @@
             <script>handle_change('{{ initial_suffix }}', '{{file_root}}', '{{inst}}', {{file_paths | tojson | safe}}, {{file_root_list | tojson | safe}}, '{{num_ints}}', '{{total_ints}}', "{{index}}");</script>
         {% elif suffixes|length == 1 %}
             <script>handle_change('{{suffixes.0}}', '{{file_root}}', '{{inst}}', {{file_paths | tojson | safe}}, {{file_root_list | tojson | safe}}, '{{num_ints}}', '{{total_ints}}', "{{index}}");</script>
-            {% set found.found = true %}
+            {% set loaded.found = true %}
         {% else %}
             <a>Unable to show image for: {{suffixes}}</a>
         {% endif %}

--- a/jwql/website/apps/jwql/templates/view_image.html
+++ b/jwql/website/apps/jwql/templates/view_image.html
@@ -176,7 +176,7 @@
         <!-- Determine which filetype should be shown on load -->
         {% if (initial_suffix|length > 0) and (initial_suffix in suffixes) %}
             <script>handle_change('{{ initial_suffix }}', '{{file_root}}', '{{inst}}', {{file_paths | tojson | safe}}, {{file_root_list | tojson | safe}}, '{{num_ints}}', '{{total_ints}}', "{{index}}");</script>
-        {% elif suffixes|length == 1 %}
+        {% elif suffixes|length >= 1 %}
             <script>handle_change('{{suffixes.0}}', '{{file_root}}', '{{inst}}', {{file_paths | tojson | safe}}, {{file_root_list | tojson | safe}}, '{{num_ints}}', '{{total_ints}}', "{{index}}");</script>
         {% else %}
             <a>Unable to show image for: {{suffixes}}</a>

--- a/jwql/website/apps/jwql/templates/view_image.html
+++ b/jwql/website/apps/jwql/templates/view_image.html
@@ -65,7 +65,7 @@
 	    </a><br>
 	    <form class="my-2">
 	    	{% for suffix in suffixes %}
-	    		<input type="radio" name="filetype" value="{{ suffix }}" id="{{ suffix }}" onclick='handle_change("{{suffix}}", "{{file_root}}", "{{inst}}", "{{obsnum}}", {{file_paths | tojson | safe}}, {{file_root_list | tojson | safe}}, "{{num_ints}}", "{{total_ints}}", "{{index}}");'> {{ suffix }} &nbsp;&nbsp;&nbsp;&nbsp;
+	    		<input type="radio" name="filetype" value="{{ suffix }}" id="{{ suffix }}" onclick='handle_change("{{suffix}}", "{{file_root}}", "{{inst}}", {{file_paths | tojson | safe}}, {{file_root_list | tojson | safe}}, "{{num_ints}}", "{{total_ints}}", "{{index}}");'> {{ suffix }} &nbsp;&nbsp;&nbsp;&nbsp;
 	    	{% endfor %}
 		</form>
 		<br>
@@ -176,37 +176,13 @@
         <!-- Determine which filetype should be shown on load -->
         {% set loaded = namespace(found=false) %}
         {% if (initial_suffix|length > 0) and (initial_suffix in suffixes) %}
-            <script>handle_change('{{ initial_suffix }}', '{{file_root}}', '{{inst}}, "{{obsnum}}"', {{file_paths | tojson | safe}}, {{file_root_list | tojson | safe}}, '{{num_ints}}', '{{total_ints}}', "{{index}}");</script>
+            <script>handle_change('{{ initial_suffix }}', '{{file_root}}', '{{inst}}', {{file_paths | tojson | safe}}, {{file_root_list | tojson | safe}}, '{{num_ints}}', '{{total_ints}}', "{{index}}");</script>
         {% elif suffixes|length == 1 %}
-            <script>handle_change('{{suffixes.0}}', '{{file_root}}', '{{inst}}', "{{obsnum}}", {{file_paths | tojson | safe}}, {{file_root_list | tojson | safe}}, '{{num_ints}}', '{{total_ints}}', "{{index}}");</script>
+            <script>handle_change('{{suffixes.0}}', '{{file_root}}', '{{inst}}', {{file_paths | tojson | safe}}, {{file_root_list | tojson | safe}}, '{{num_ints}}', '{{total_ints}}', "{{index}}");</script>
             {% set found.found = true %}
         {% else %}
             <a>Unable to show image for: {{suffixes}}</a>
         {% endif %}
-
-
-
-
-
-
-        <!--
-        {% if (initial_suffix|length > 0) and (initial_suffix in file_paths) %}
-            <script>handle_change('{{ initial_suffix }}', '{{file_root}}', '{{inst}}', {{file_paths | tojson | safe}}, {{file_root_list | tojson | safe}}, '{{num_ints}}', '{{total_ints}}', "{{index}}");</script>
-        {% elif 'rate' in suffixes %}
-            <script>handle_change('rate', '{{file_root}}', '{{inst}}', {{file_paths | tojson | safe}}, {{file_root_list | tojson | safe}}, '{{num_ints}}', '{{total_ints}}', "{{index}}");</script>
-        {% elif 'dark' in suffixes %}
-            <script>handle_change('dark', '{{file_root}}', '{{inst}}', {{file_paths | tojson | safe}}, {{file_root_list | tojson | safe}}, '{{num_ints}}', '{{total_ints}}', "{{index}}");</script>
-        {% elif 'uncal' in suffixes %}
-            <script>handle_change('uncal', '{{file_root}}', '{{inst}}', {{file_paths | tojson | safe}}, {{file_root_list | tojson | safe}}, '{{num_ints}}', '{{total_ints}}', "{{index}}");</script>
-        {% elif suffixes|length == 1 %}
-            <script>handle_change('{{suffixes.0}}', '{{file_root}}', '{{inst}}', {{file_paths | tojson | safe}}, {{file_root_list | tojson | safe}}, '{{num_ints}}', '{{total_ints}}', "{{index}}");</script>
-        {% else %}
-            <a>Unable to show image for: {{suffixes}}</a>
-        {% endif %}
-        -->
-
-
-
 
         <!-- Determine which preview should be shown on load -->
         {% if (initial_preview|length > 0) %}

--- a/jwql/website/apps/jwql/templates/view_image.html
+++ b/jwql/website/apps/jwql/templates/view_image.html
@@ -174,12 +174,10 @@
             <script>update_viewed_button(false)</script>
         {% endif %}
         <!-- Determine which filetype should be shown on load -->
-        {% set loaded = namespace(found=false) %}
         {% if (initial_suffix|length > 0) and (initial_suffix in suffixes) %}
             <script>handle_change('{{ initial_suffix }}', '{{file_root}}', '{{inst}}', {{file_paths | tojson | safe}}, {{file_root_list | tojson | safe}}, '{{num_ints}}', '{{total_ints}}', "{{index}}");</script>
         {% elif suffixes|length == 1 %}
             <script>handle_change('{{suffixes.0}}', '{{file_root}}', '{{inst}}', {{file_paths | tojson | safe}}, {{file_root_list | tojson | safe}}, '{{num_ints}}', '{{total_ints}}', "{{index}}");</script>
-            {% set loaded.found = true %}
         {% else %}
             <a>Unable to show image for: {{suffixes}}</a>
         {% endif %}

--- a/jwql/website/apps/jwql/views.py
+++ b/jwql/website/apps/jwql/views.py
@@ -62,7 +62,7 @@ import numpy as np
 from sqlalchemy import inspect
 
 from jwql.utils import monitor_utils
-from jwql.utils.constants import JWQLDB_EXCLUDED, JWST_INSTRUMENT_NAMES_MIXEDCASE, QUERY_CONFIG_TEMPLATE, URL_DICT, QueryConfigKeys
+from jwql.utils.constants import JWQLDB_EXCLUDED, JWST_INSTRUMENT_NAMES_MIXEDCASE, QUERY_CONFIG_TEMPLATE, SUFFIXES_OF_ECSV_FILES, URL_DICT, QueryConfigKeys
 from jwql.utils.interactive_preview_image import InteractivePreviewImg
 from jwql.utils.logging_functions import configure_logging
 from jwql.utils.utils import filename_parser, get_base_url, get_config, get_rootnames_for_instrument_proposal, query_unformat
@@ -1418,13 +1418,22 @@ def view_image(request, inst, file_root, initial_suffix=None):
                          'Please add them, so that they will appear in a '
                          'consistent order on the webpage.'))
 
+
+
+
+
+
+
     file_paths = {}
     for file_path in image_info['all_files']:
         logging.debug(f"Checking input file {file_path}")
         source_path = Path(file_path).parent
         for suffix in suffixes:
             logging.debug(f"\tChecking suffix {suffix}")
-            file_search = list(source_path.rglob(f"{file_root}*_{suffix}.fits"))
+            file_type = 'fits'
+            if suffix in SUFFIXES_OF_ECSV_FILES:
+                file_type = 'ecsv'
+            file_search = list(source_path.rglob(f"{file_root}*_{suffix}.{file_type}"))
             if len(file_search) > 0:
                 if suffix not in file_paths:
                     logging.debug(f"\tAdding {suffix} to file paths")

--- a/jwql/website/apps/jwql/views.py
+++ b/jwql/website/apps/jwql/views.py
@@ -1247,7 +1247,7 @@ def view_exposure(request, inst, group_root):
         for file in image_info['all_files']:
             name = Path(file).name
             obs = name.split("_")[0]
-            if obs not in group_root_list:
+            if '-' not in obs and obs not in group_root_list:
                 group_root_list.append(obs)
 
     # Get our current views RootFileInfo model and send our "viewed/new" information

--- a/jwql/website/apps/jwql/views.py
+++ b/jwql/website/apps/jwql/views.py
@@ -1499,7 +1499,7 @@ def view_image(request, inst, file_root, initial_suffix=None):
                'file_paths': file_paths,
                'inst': inst,
                'prop_id': prop_id,
-               'obsnum': file_root[7:10],
+               'obsnum': image_info['obsnum'],
                'file_root': file_root,
                'suffixes': suffixes,
                'num_ints': image_info['num_ints'],

--- a/jwql/website/apps/jwql/views.py
+++ b/jwql/website/apps/jwql/views.py
@@ -81,6 +81,7 @@ from .data_containers import (
     get_explorer_extension_names,
     get_group_anomalies,
     get_header_info,
+    get_header_info_ecsv,
     get_image_info,
     get_instrument_looks,
     get_rootnames_from_query,

--- a/jwql/website/apps/jwql/views.py
+++ b/jwql/website/apps/jwql/views.py
@@ -1196,10 +1196,6 @@ def view_exposure(request, inst, group_root):
     template = 'view_exposure.html'
     image_info = get_image_info(group_root)
 
-    # Get the proposal id and obsnum from the group root name
-    prop_id = group_root[2:7]
-    obsnum = group_root[7:10]
-
     # Get available suffixes in a consistent order.
     suffixes = get_available_suffixes(image_info['suffixes'],
                                       return_untracked=False)
@@ -1259,6 +1255,11 @@ def view_exposure(request, inst, group_root):
     if len(root_file_info) == 0:
         return generate_error_view(request, inst, f"No groups starting with {group_root} currently in JWQL database.")
     viewed = all([rf.viewed for rf in root_file_info])
+
+    # Get the program ID and the obsnum
+    prop_id = group_root[2:7]
+    #obsnum = group_root[7:10]
+    obsnum = root_file_info[0].obsnum
 
     # Convert expstart from MJD to a date
     expstart_str = Time(root_file_info[0].expstart, format='mjd').to_datetime().strftime('%d %b %Y %H:%M')

--- a/jwql/website/apps/jwql/views.py
+++ b/jwql/website/apps/jwql/views.py
@@ -1186,10 +1186,6 @@ def view_exposure(request, inst, group_root):
         Outgoing response sent to the webpage
     """
 
-    default_suffix = ''
-    if "suffix" in request.GET:
-        default_suffix = request.GET["suffix"]
-
     # Ensure the instrument is correctly capitalized
     inst = JWST_INSTRUMENT_NAMES_MIXEDCASE[inst.lower()]
 
@@ -1199,6 +1195,19 @@ def view_exposure(request, inst, group_root):
     # Get available suffixes in a consistent order.
     suffixes = get_available_suffixes(image_info['suffixes'],
                                       return_untracked=False)
+
+    # Determine which suffix to show upon page load
+    default_suffix = ''
+    if "suffix" in request.GET:
+        default_suffix = request.GET["suffix"]
+    else:
+        preferred_suffixes = ["rate", "dark", "uncal", "i2d", "c1d", "x1d", "s3d",
+                              "s2d", "whtlt", "phot", "psfsub", "psfstack", "ami",
+                              "aminorm", "cal"]
+        for suffix in preferred_suffixes:
+            if suffix in suffixes:
+                default_suffix = suffix
+                break
 
     # Get the anomaly submission form
     form = get_anomaly_form(request, inst, group_root)

--- a/jwql/website/apps/jwql/views.py
+++ b/jwql/website/apps/jwql/views.py
@@ -1489,6 +1489,7 @@ def view_image(request, inst, file_root, initial_suffix=None):
     logging.info(f"File root is {file_root}")
     logging.info(f"File root list is {file_root_list}")
     logging.info(f"File root in file_root_list: {file_root in file_root_list}")
+    logging.info(f"file_paths should be a dict: {file_paths}")
 
     # Build the context
     context = {'base_url': get_base_url(),

--- a/jwql/website/apps/jwql/views.py
+++ b/jwql/website/apps/jwql/views.py
@@ -58,7 +58,7 @@ from bokeh.layouts import layout
 from django.core.paginator import Paginator
 from django.http import HttpResponse, JsonResponse
 from django.shortcuts import redirect, render
-from numpy import where
+import numpy as np
 from sqlalchemy import inspect
 
 from jwql.utils import monitor_utils

--- a/jwql/website/apps/jwql/views.py
+++ b/jwql/website/apps/jwql/views.py
@@ -58,6 +58,7 @@ from bokeh.layouts import layout
 from django.core.paginator import Paginator
 from django.http import HttpResponse, JsonResponse
 from django.shortcuts import redirect, render
+from numpy import where
 from sqlalchemy import inspect
 
 from jwql.utils import monitor_utils
@@ -868,13 +869,44 @@ def view_header(request, inst, filename, filetype):
 
     template = 'view_header.html'
     file_root = '_'.join(filename.split('_'))
+    header_info = get_header_info(filename, filetype)
+
+    # For level 3 files, we need the obsnum, which cannot be
+    # reliably found by parsing the filename.
+    if header_info:
+        obsidx = np.where(np.array(header_info[0]['keywords']) == 'OBSERVTN')[0]
+        if len(obsidx) > 0:
+            obsnum = header_info[0]['values'][obsidx[0]]
+        else:
+            # Observation number not in the header in this case.
+            # Query for RootFileInfo instances for similar files, and try to
+            # extract the keyword from one of those.
+            file_base = '_'.join(filename.split('_')[0:-1])
+            root_file_info = RootFileInfo.objects.filter(root_name__startswith=file_base)
+            if root_file_info:
+                obsnum = root_file_info[0].obsnum.obsnum
+            else:
+                obsnum = 'N/A'
+
+    else:
+        # header_info is an empty dict here because we are looking at a non-fits file.
+        # Add an entry that will make it clear to the user that there is no header available.
+        # Try to get the obsnum from the RootFileInfo instance
+        header_info[0] = {'No header available': ''}
+        file_base = '_'.join(filename.split('_')[0:-1])
+        root_file_info = RootFileInfo.objects.filter(root_name__startswith=file_base)
+        if root_file_info:
+            obsnum = root_file_info[0].obsnum.obsnum
+        else:
+            obsnum = 'N/A'
 
     context = {'inst': inst,
                'filename': filename,
                'file_root': file_root,
                'file_type': filetype,
                'extended_root': f"{file_root}_suffix_{filetype}",
-               'header_info': get_header_info(filename, filetype)}
+               'header_info': header_info,
+               'obsnum': obsnum}
 
     return render(request, template, context)
 

--- a/jwql/website/apps/jwql/views.py
+++ b/jwql/website/apps/jwql/views.py
@@ -869,7 +869,11 @@ def view_header(request, inst, filename, filetype):
 
     template = 'view_header.html'
     file_root = '_'.join(filename.split('_'))
-    header_info = get_header_info(filename, filetype)
+
+    if filetype not in SUFFIXES_OF_ECSV_FILES:
+        header_info = get_header_info(filename, filetype)
+    else:
+        header_info = get_header_info_ecsv(filename, filetype)
 
     # For level 3 files, we need the obsnum, which cannot be
     # reliably found by parsing the filename.
@@ -889,7 +893,7 @@ def view_header(request, inst, filename, filetype):
                 obsnum = 'N/A'
 
     else:
-        # header_info is an empty dict here because we are looking at a non-fits file.
+        # header_info is an empty dict here.
         # Add an entry that will make it clear to the user that there is no header available.
         # Try to get the obsnum from the RootFileInfo instance
         header_info[0] = {'No header available': ''}

--- a/jwql/website/apps/jwql/views.py
+++ b/jwql/website/apps/jwql/views.py
@@ -1369,38 +1369,6 @@ def view_image(request, inst, file_root, initial_suffix=None):
     HttpResponse object
         Outgoing response sent to the webpage
     """
-    url_suffix = None
-    if "_suffix_" in file_root:
-        file_bits = file_root.split("_")
-        file_root = "_".join(file_bits[:-2])
-        url_suffix = file_bits[-1]
-    log_file = configure_logging("django", include_time=False)
-    logging.debug(f"Running through view_image() for {inst} {file_root}")
-
-    request_suffix = None
-    if "suffix" in request.GET:
-        request_suffix = request.GET["suffix"]
-
-    if initial_suffix is not None:
-        logging.debug(f"Setting suffix via initial suffix to {initial_suffix}")
-        default_suffix = initial_suffix
-    elif request_suffix is not None:
-        logging.debug(f"Setting suffix via request object to {request_suffix}")
-        default_suffix = request_suffix
-    elif url_suffix is not None:
-        logging.debug(f"Setting suffix via URL apped to {url_suffix}")
-        default_suffix = url_suffix
-    else:
-        default_suffix = ""
-
-    default_preview = ""
-    preview_cookie = request.COOKIES.get('preview')
-    if preview_cookie:
-        logging.debug(f"Found cookie value {preview_cookie}")
-        default_preview = preview_cookie
-    elif "preview" in request.GET:
-        default_preview = request.GET["preview"]
-
     # Ensure the instrument is correctly capitalized
     inst = JWST_INSTRUMENT_NAMES_MIXEDCASE[inst.lower()]
 
@@ -1422,6 +1390,48 @@ def view_image(request, inst, file_root, initial_suffix=None):
                          f'constants.py: {untracked_suffixes} '
                          'Please add them, so that they will appear in a '
                          'consistent order on the webpage.'))
+
+
+
+
+
+
+    url_suffix = None
+    if "_suffix_" in file_root:
+        file_bits = file_root.split("_")
+        file_root = "_".join(file_bits[:-2])
+        url_suffix = file_bits[-1]
+    log_file = configure_logging("django", include_time=False)
+    logging.debug(f"Running through view_image() for {inst} {file_root}")
+
+    request_suffix = None
+    if "suffix" in request.GET:
+        request_suffix = request.GET["suffix"]
+
+    if initial_suffix is not None:
+        logging.debug(f"Setting suffix via initial suffix to {initial_suffix}")
+        default_suffix = initial_suffix
+    elif request_suffix is not None:
+        logging.debug(f"Setting suffix via request object to {request_suffix}")
+        default_suffix = request_suffix
+    elif url_suffix is not None:
+        logging.debug(f"Setting suffix via URL apped to {url_suffix}")
+        default_suffix = url_suffix
+    elif 'rate' in suffixes:
+        default_suffix = 'rate'
+    else:
+        default_suffix = ""
+
+    default_preview = ""
+    preview_cookie = request.COOKIES.get('preview')
+    if preview_cookie:
+        logging.debug(f"Found cookie value {preview_cookie}")
+        default_preview = preview_cookie
+    elif "preview" in request.GET:
+        default_preview = request.GET["preview"]
+
+
+
 
 
 

--- a/jwql/website/apps/jwql/views.py
+++ b/jwql/website/apps/jwql/views.py
@@ -1461,7 +1461,15 @@ def view_image(request, inst, file_root, initial_suffix=None):
         else:
             file_root_list = sorted(navigation_data)
     else:
-        file_root_list = sorted(get_detectors_by_rootname(file_root))
+        if image_info['level'] == 2:
+            file_root_list = sorted(get_detectors_by_rootname(file_root))
+        elif image_info['level'] == 3:
+            # In most (all?) cases with level 3 rootnames, I think we should end up
+            # with a single element list that's essentially equal to file_root
+            #file_list = get_filenames_by_rootname(file_root)
+            #file_root_list = [filestr.rsplit('_', 1)[0] for filestr in file_list if 'jpg' not in filestr]
+            #file_root_list = sorted(set(file_root_list))
+            file_root_list = [file_root]
 
     # Get our current views RootFileInfo model and send our "viewed/new" information
     root_file_info = RootFileInfo.objects.get(root_name=file_root)

--- a/jwql/website/apps/jwql/views.py
+++ b/jwql/website/apps/jwql/views.py
@@ -1257,9 +1257,8 @@ def view_exposure(request, inst, group_root):
     viewed = all([rf.viewed for rf in root_file_info])
 
     # Get the program ID and the obsnum
-    prop_id = group_root[2:7]
-    #obsnum = group_root[7:10]
-    obsnum = root_file_info[0].obsnum
+    prop_id = root_file_info[0].proposal.zfill(5)
+    obsnum = root_file_info[0].obsnum.obsnum
 
     # Convert expstart from MJD to a date
     expstart_str = Time(root_file_info[0].expstart, format='mjd').to_datetime().strftime('%d %b %Y %H:%M')
@@ -1278,6 +1277,8 @@ def view_exposure(request, inst, group_root):
     logging.info(f"Group Root is {group_root}")
     logging.info(f"Group Root List is {group_root_list}")
     logging.info(f"Group Root in List: {group_root in group_root_list}")
+    logging.info(f"prop_id is : {prop_id}")
+    logging.info(f"obsnum is: {obsnum}")
 
     # Build the context
     context = {'base_url': get_base_url(),

--- a/jwql/website/apps/jwql/views.py
+++ b/jwql/website/apps/jwql/views.py
@@ -1391,11 +1391,6 @@ def view_image(request, inst, file_root, initial_suffix=None):
                          'Please add them, so that they will appear in a '
                          'consistent order on the webpage.'))
 
-
-
-
-
-
     url_suffix = None
     if "_suffix_" in file_root:
         file_bits = file_root.split("_")
@@ -1418,8 +1413,14 @@ def view_image(request, inst, file_root, initial_suffix=None):
         logging.debug(f"Setting suffix via URL apped to {url_suffix}")
         default_suffix = url_suffix
     elif 'rate' in suffixes:
+        # Default to rate files for level 2 rootnames
         default_suffix = 'rate'
+    elif 'x1d' in suffixes:
+        # Default to x1d files for the level 3 rootnames
+        default_suffix = 'x1d'
     else:
+        # In this case, the html template will fall back to the first suffix
+        # in the list.
         default_suffix = ""
 
     default_preview = ""
@@ -1429,15 +1430,6 @@ def view_image(request, inst, file_root, initial_suffix=None):
         default_preview = preview_cookie
     elif "preview" in request.GET:
         default_preview = request.GET["preview"]
-
-
-
-
-
-
-
-
-
 
     file_paths = {}
     for file_path in image_info['all_files']:


### PR DESCRIPTION
Tweak the code so that we can create and serve exposure-level pages that show level 3 files. For the moment these changes are intended only to create separate exposure-level pages for level 3 files, rather than adding level 3 suffixes to the exposure-level pages for level 2 files. While we may end up going that route in the future, that will take more work since we will have to map level 2 rootnames to associated level 3 rootnames.