### PR TITLE
Fix bias monitor issues related to new jwst pipeline version

### DIFF
--- a/jwql/instrument_monitors/common_monitors/bias_monitor.py
+++ b/jwql/instrument_monitors/common_monitors/bias_monitor.py
@@ -377,9 +377,8 @@ class Bias():
         logging.info("Creating calibration tasks")
 
         # Run only required pipeline steps
-        steps = {'dq_init': {'skip': False},
-                 'refpix': {'skip': False,
-                            'save_results': True},
+        steps = {'dq_init': {},
+                 'refpix': {'save_results': True},
                  'ipc': {'skip': True},
                  'group_scale': {},
                  'saturation': {'skip': True},
@@ -393,10 +392,6 @@ class Bias():
                  'ramp_fit': {'skip': True},
                  'persistence': {'skip': True}
                  }
-        #if self.read_pattern not in pipeline_tools.GROUPSCALE_READOUT_PATTERNS:
-        #    steps['group_scale']['skip'] = True
-        #else:
-        #    steps['group_scale']['skip'] = False
 
         outputs = run_parallel_pipeline(file_list, "uncal_0thgroup", "refpix", self.instrument, step_args=steps)
 
@@ -498,7 +493,7 @@ class Bias():
             self.identify_tables()
 
             # Get a list of all possible full-frame apertures for this instrument
-            possible_apertyres = FULL_FRAME_APERTURES[instrument.upper()]
+            possible_apertures = FULL_FRAME_APERTURES[instrument.upper()]
 
             for aperture in possible_apertures:
 

--- a/jwql/instrument_monitors/common_monitors/bias_monitor.py
+++ b/jwql/instrument_monitors/common_monitors/bias_monitor.py
@@ -45,12 +45,11 @@ matplotlib.use('Agg')
 import matplotlib.pyplot as plt  # noqa: E402 (module import not at top)
 from mpl_toolkits.axes_grid1 import make_axes_locatable  # noqa: E402 (module import not at top)
 import numpy as np  # noqa: E402 (module import not at top)
-from pysiaf import Siaf  # noqa: E402 (module import not at top)
 
 from jwql.instrument_monitors import pipeline_tools  # noqa: E402 (module import not at top)
 from jwql.shared_tasks.shared_tasks import only_one, run_parallel_pipeline  # noqa: E402 (module import not at top)
 from jwql.utils import instrument_properties, monitor_utils  # noqa: E402 (module import not at top)
-from jwql.utils.constants import JWST_INSTRUMENT_NAMES_MIXEDCASE, ON_GITHUB_ACTIONS, ON_READTHEDOCS  # noqa: E402 (module import not at top)
+from jwql.utils.constants import FULL_FRAME_APERTURES, JWST_INSTRUMENT_NAMES_MIXEDCASE, ON_GITHUB_ACTIONS, ON_READTHEDOCS  # noqa: E402 (module import not at top)
 from jwql.utils.logging_functions import log_info, log_fail  # noqa: E402 (module import not at top)
 from jwql.utils.permissions import set_permissions  # noqa: E402 (module import not at top)
 from jwql.utils.utils import ensure_dir_exists, filesystem_path, get_config  # noqa: E402 (module import not at top)
@@ -379,9 +378,12 @@ class Bias():
 
         # Run only required pipeline steps
         steps = {'dq_init': {'skip': False},
-                 'refpix': {'skip': False},
+                 'refpix': {'skip': False,
+                            'save_results': True},
                  'ipc': {'skip': True},
+                 'group_scale': {},
                  'saturation': {'skip': True},
+                 'superbias': {'skip': True},
                  'reset': {'skip': True},
                  'clean_flicker_noise': {'skip': True},
                  'linearity': {'skip': True},
@@ -391,6 +393,10 @@ class Bias():
                  'ramp_fit': {'skip': True},
                  'persistence': {'skip': True}
                  }
+        #if self.read_pattern not in pipeline_tools.GROUPSCALE_READOUT_PATTERNS:
+        #    steps['group_scale']['skip'] = True
+        #else:
+        #    steps['group_scale']['skip'] = False
 
         outputs = run_parallel_pipeline(file_list, "uncal_0thgroup", "refpix", self.instrument, step_args=steps)
 
@@ -492,8 +498,7 @@ class Bias():
             self.identify_tables()
 
             # Get a list of all possible full-frame apertures for this instrument
-            siaf = Siaf(self.instrument)
-            possible_apertures = [aperture for aperture in siaf.apertures if siaf[aperture].AperType == 'FULLSCA']
+            possible_apertyres = FULL_FRAME_APERTURES[instrument.upper()]
 
             for aperture in possible_apertures:
 

--- a/jwql/instrument_monitors/common_monitors/bias_monitor.py
+++ b/jwql/instrument_monitors/common_monitors/bias_monitor.py
@@ -180,11 +180,16 @@ class Bias():
         # headers from the input file, as well as the 0th group
         # data of the first integration
         hdu = fits.open(filename)
-        new_hdu = fits.HDUList([hdu['PRIMARY'], hdu['SCI']])
-        new_hdu['SCI'].data = hdu['SCI'].data[0:1, 0:1, :, :]
-        new_hdu.writeto(output_filename, overwrite=True)
+
+        hdu['SCI'].data = hdu['SCI'].data[0:1, 0:1, :, :]
+
+        try:
+            hdu['ZEROFRAME'].data = hdu['ZEROFRAME'].data[0:1, :, :]
+        except KeyError:
+            pass
+
+        hdu.writeto(output_filename, overwrite=True)
         hdu.close()
-        new_hdu.close()
         set_permissions(output_filename)
         logging.info('\t{} created'.format(output_filename))
 
@@ -371,7 +376,23 @@ class Bias():
             files.
         """
         logging.info("Creating calibration tasks")
-        outputs = run_parallel_pipeline(file_list, "uncal_0thgroup", "refpix", self.instrument)
+
+        # Run only required pipeline steps
+        steps = {'dq_init': {'skip': False},
+                 'refpix': {'skip': False},
+                 'ipc': {'skip': True},
+                 'saturation': {'skip': True},
+                 'reset': {'skip': True},
+                 'clean_flicker_noise': {'skip': True},
+                 'linearity': {'skip': True},
+                 'charge_migration': {'skip': True},
+                 'dark_current': {'skip': True},
+                 'jump': {'skip': True},
+                 'ramp_fit': {'skip': True},
+                 'persistence': {'skip': True}
+                 }
+
+        outputs = run_parallel_pipeline(file_list, "uncal_0thgroup", "refpix", self.instrument, step_args=steps)
 
         for filename in file_list:
             logging.info('\tWorking on file: {}'.format(filename))

--- a/jwql/instrument_monitors/pipeline_tools.py
+++ b/jwql/instrument_monitors/pipeline_tools.py
@@ -168,11 +168,11 @@ def get_pipeline_steps(instrument):
 
     # Order is important in 'steps' lists below!!
     if instrument == 'MIRI':
-        steps = ['group_scale', 'dq_init', 'saturation', 'ipc', 'firstframe', 'lastframe', 'reset',
-                 'linearity', 'rscd', 'dark_current', 'refpix', 'jump', 'rate', 'gain_scale']
+        steps = ['group_scale', 'dq_init', 'emicorr', 'saturation', 'ipc', 'firstframe', 'lastframe', 'reset',
+                 'linearity', 'rscd', 'dark_current', 'refpix', 'jump', 'clean_flicker_noise', 'rate', 'gain_scale']
     else:
         steps = ['group_scale', 'dq_init', 'saturation', 'ipc', 'superbias', 'refpix', 'linearity',
-                 'persistence', 'dark_current', 'jump', 'rate']
+                 'persistence', 'dark_current', 'charge_migration', 'jump', 'picture_frame', 'clean_flicker_noise', 'rate', 'gain_scale']
 
         # No persistence correction for NIRSpec
         if instrument == 'NIRSPEC':

--- a/jwql/tests/test_pipeline_tools.py
+++ b/jwql/tests/test_pipeline_tools.py
@@ -74,7 +74,8 @@ def test_get_pipeline_steps():
     for instrument in instruments:
         req_steps = pipeline_tools.get_pipeline_steps(instrument)
         steps = ['dq_init', 'saturation', 'superbias', 'refpix', 'linearity',
-                 'persistence', 'dark_current', 'jump', 'rate']
+                 'persistence', 'dark_current', 'charge_migration', 'jump', 'picture_frame',
+                 'clean_flicker_noise', 'rate', 'gain_scale']
         not_required = ['group_scale', 'ipc', 'firstframe', 'lastframe', 'rscd']
         steps_dict = OrderedDict({})
         for step in steps:
@@ -90,7 +91,8 @@ def test_get_pipeline_steps():
     # NIRSpec
     nrs_req_steps = pipeline_tools.get_pipeline_steps('nirspec')
     nrs_steps = ['group_scale', 'dq_init', 'saturation', 'superbias', 'refpix', 'linearity',
-                 'dark_current', 'jump', 'rate']
+                 'dark_current', 'charge_migration', 'jump', 'picture_frame', 'clean_flicker_noise',
+                 'rate', 'gain_scale']
     not_required = ['ipc', 'persistence', 'firstframe', 'lastframe', 'rscd']
     nrs_dict = OrderedDict({})
     for step in nrs_steps:
@@ -104,9 +106,9 @@ def test_get_pipeline_steps():
 
     # MIRI
     miri_req_steps = pipeline_tools.get_pipeline_steps('miri')
-    miri_steps = ['group_scale', 'dq_init', 'saturation', 'firstframe', 'lastframe',
-                  'reset', 'linearity', 'rscd', 'dark_current', 'refpix', 'jump', 'rate',
-                  'gain_scale']
+    miri_steps = ['group_scale', 'dq_init', 'emicorr', 'saturation', 'firstframe', 'lastframe',
+                  'reset', 'linearity', 'rscd', 'dark_current', 'refpix', 'jump', 'clean_flicker_noise',
+                  'rate', 'gain_scale']
     not_required = ['ipc', 'superbias', 'persistence']
     miri_dict = OrderedDict({})
     for step in miri_steps:


### PR DESCRIPTION
This PR fixes a couple of issues with the bias monitor first seen after switching to version >2.0 of the jwst pipeline.

1) It fixes the extraction of the 0th group into its own file (which is then sent through the pipeline). It seems that the newer pipeline versions require the presence of the asdf extension, which wasn't previously present.

2) When the bias monitor calls the pipeline, the only steps that actually need to run are dq_init and reference pixel correction. However, at the moment all the steps through ramp fitting are run. This PR uses a parameter dictionary to turn off the unnecessary steps, which will save compute time.