### PR TITLE
Fix Bias Monitor Page

### DIFF
--- a/jwql/website/apps/jwql/monitor_pages/monitor_bias_bokeh.py
+++ b/jwql/website/apps/jwql/monitor_pages/monitor_bias_bokeh.py
@@ -287,7 +287,16 @@ class BiasMonitorPlots():
         lines_to_remove = ["<!DOCTYPE html>",
                            '<html lang="en">',
                            '  </body>',
-                           '</html>']
+                           '</html>',
+                           '    <style>',
+                           '      html, body {',
+                           '        box-sizing: border-box;',
+                           '        display: flow-root;',
+                           '        height: 100%;',
+                           '        margin: 0;',
+                           '        padding: 0;',
+                           '      }',
+                           '    </style>']
 
         # Our Django-related lines that need to be at the top of the file
         hstring = """href="{{'/jwqldb/%s_bias_stats'%inst.lower()}}" name=test_link class="btn btn-primary my-2" type="submit">Go to JWQLDB page</a>"""


### PR DESCRIPTION
This adds lines to `lines_to_remove` variable that strips extra styling from our bokeh figures. @bhilbert4 found that the bad pixel monitor figures were stripping the same lines so I am adding it here to strip the lines out the bias monitor plots as well.