### PR TITLE
Patch 2.0.2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,17 @@
 ## What's Changed
 
+2.0.2 (2026-08-05)
+====================
+
+* Updated pyproject.toml to explicitly pin asdf-coordinates-schemas above 0.5.1
+
+
+2.0.1 (2026-08-05)
+====================
+
+* Updated pyproject.toml to include minimum jwst pipeline version
+
+
 2.0.0 (2026-08-04)
 ====================
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
 ]
 dependencies = [
     "asdf>=3.1.0,<6",
+    "asdf-coordinates-schemas>=0.5.1,<1",
     "astropy>=6.0,<8",
     "astroquery>=0.4.7,<1",
     "beautifulsoup4>=4.12.3,<5",


### PR DESCRIPTION
Explicitly pin asdf-coordinates-schemas to 0.5.1 or above.