### PR TITLE
Allow coron "psf" suffix files to be seen

### DIFF
--- a/jwql/utils/constants.py
+++ b/jwql/utils/constants.py
@@ -1004,7 +1004,7 @@ SUFFIXES_OF_ECSV_FILES = ['whtlt', 'phot']
 # Filename suffixes that need to include the association value in the suffix in
 # order to identify the preview image file. This should only be crf and crfints,
 # since those are essentially level 2 files that are output by the level 3 pipeline.
-SUFFIXES_TO_ADD_ASSOCIATION = ["crf", "crfints"]
+SUFFIXES_TO_ADD_ASSOCIATION = ["crf", "crfints", "psfalign", "psfsub"]
 
 # Filename suffixes where data have been averaged over integrations
 SUFFIXES_WITH_AVERAGED_INTS = ["rate", "cal", "crf", "i2d", "bsub", "x1d"]

--- a/jwql/website/apps/jwql/data_containers.py
+++ b/jwql/website/apps/jwql/data_containers.py
@@ -570,7 +570,7 @@ def get_available_suffixes(all_suffixes, return_untracked=True):
     suffixes = []
     untracked_suffixes = set(all_suffixes)
     for poss_suffix in EXPOSURE_PAGE_SUFFIX_ORDER:
-        if 'crf' not in poss_suffix:
+        if (('crf' not in poss_suffix) and ('psf' not in poss_suffix)):
             if (poss_suffix in all_suffixes and poss_suffix not in suffixes):
                 suffixes.append(poss_suffix)
                 untracked_suffixes.remove(poss_suffix)


### PR DESCRIPTION
Resolves #1726 

Coronagraphy observations create psfsub.fits and psfalign.fits files. JWQL is currently missing the preview images for these files, because like the crf files, the name of the association is included in the filename. e.g. jw09431001001_03106_00001_nrca2_c1000_psfalign.fits, where the c1000 is the name of the association.

JWQL isn't adding the association to the filename when creating/displaying preview images. This PR corrects that.