### PR TITLE
Fix links to multiple instruments to use full program number

### DIFF
--- a/jwql/website/apps/jwql/forms.py
+++ b/jwql/website/apps/jwql/forms.py
@@ -381,7 +381,7 @@ class FileSearchForm(forms.Form):
 
                 if len(set(all_instruments)) > 1:
                     # Technically all proposal have multiple instruments if you include guider data. Remove Guider Data
-                    instrument_routes = [format_html('<a href="/{}/archive/{}/obs{}">{}</a>', instrument, proposal_string[1:],
+                    instrument_routes = [format_html('<a href="/{}/archive/{}/obs{}">{}</a>', instrument, int(proposal_string),
                                                      all_observations[instrument][0], instrument) for instrument in set(all_instruments)]
                     raise forms.ValidationError(
                         mark_safe(('Proposal contains multiple instruments, please click instrument link to view data: {}.').format(', '.join(instrument_routes))))  # noqa


### PR DESCRIPTION
Currently, when you use the query box on the front page and query for a program number, if that program uses multiple instruments, you get back a text box with a list of instruments, where each instrument name is a link to the first observation for that instrument. However, these links currently only work for 4 digit program numbers. The initial number is stripped from the string. This is a relic from before we reached program numbers > 9999. This PR fixes that by converting the program string (which may contain a leading zero) to an integer before using it in the construction of the link address.